### PR TITLE
fix(mongo): sort list queries application-side to avoid CosmosDB BadValue

### DIFF
--- a/crates/oauth2-actix/src/handlers/device.rs
+++ b/crates/oauth2-actix/src/handlers/device.rs
@@ -15,7 +15,11 @@ const DEVICE_POLL_INTERVAL_SECONDS: i32 = 5;
 
 #[derive(Debug, Deserialize)]
 pub struct DeviceAuthorizationRequest {
-    pub client_id: String,
+    // RFC 8628 §3.1 allows the client to be identified via
+    // `client_secret_basic`, in which case `client_id` is NOT present in
+    // the form body. Keep it optional and resolve from the Authorization
+    // header when absent.
+    pub client_id: Option<String>,
     pub client_secret: Option<String>,
     pub scope: Option<String>,
 }
@@ -75,13 +79,19 @@ pub async fn device_authorization(
     let basic_client_id = basic.as_ref().map(|(id, _)| id.clone());
     let basic_client_secret = basic.as_ref().map(|(_, s)| s.clone());
 
-    if let Some(ref id) = basic_client_id {
-        if id != &form.client_id {
+    // Resolve client_id from the body, falling back to the Basic auth
+    // header when the body omits it (RFC 8628 §3.1 + RFC 6749 §2.3.1).
+    let client_id = match (form.client_id.as_ref(), basic_client_id.as_ref()) {
+        (Some(body_id), Some(basic_id)) if body_id != basic_id => {
             return Err(OAuth2Error::invalid_request(
                 "client_id mismatch between body and Basic auth",
             ));
         }
-    }
+        (Some(id), _) | (None, Some(id)) => id.clone(),
+        (None, None) => {
+            return Err(OAuth2Error::invalid_client("Missing client_id"));
+        }
+    };
 
     let client_secret = form
         .client_secret
@@ -91,7 +101,7 @@ pub async fn device_authorization(
 
     let client = client_actor
         .send(GetClient {
-            client_id: form.client_id.clone(),
+            client_id: client_id.clone(),
             span: tracing::Span::current(),
         })
         .await
@@ -117,7 +127,7 @@ pub async fn device_authorization(
     let device_auth = DeviceAuthorization::new(
         device_code.clone(),
         user_code.clone(),
-        form.client_id.clone(),
+        client_id.clone(),
         scope,
         DEVICE_EXPIRES_IN_SECONDS,
         DEVICE_POLL_INTERVAL_SECONDS,

--- a/crates/oauth2-actix/src/handlers/token.rs
+++ b/crates/oauth2-actix/src/handlers/token.rs
@@ -192,8 +192,15 @@ pub async fn introspect(
                 }
             }
 
-            // Decode JWT to get claims
-            let claims = Claims::decode(&token.access_token, &jwt_secret).ok();
+            // Decode JWT claims to surface them in the introspection response.
+            // We must use the unverified decode path because production
+            // tokens may be signed with RS256 (see OidcConfig) while the
+            // server-side `jwt_secret` is only the HS256 fallback — signature
+            // verification would fail and we'd miss the real `jti`/`iss`/etc.
+            // The token was already authenticated via the preceding storage
+            // lookup, so skipping signature verification here is safe.
+            let claims = Claims::decode_unverified(&token.access_token)
+                .or_else(|| Claims::decode(&token.access_token, &jwt_secret).ok());
 
             let active = token.is_valid();
             let user_id = token.user_id.clone();
@@ -334,34 +341,34 @@ pub async fn revoke(
     .await?
     .expect("client auth is required for token revocation");
 
-    // Try access_token lookup first, then refresh_token.
-    let token = {
-        let by_access = token_actor
+    // RFC 7009 §4.1.2: if token_type_hint is unrecognized or the token isn't
+    // found under the hinted type, the server MUST extend its search across
+    // all supported token types. We ignore the hint for ordering (try access
+    // first, then refresh) because both lookups are cheap and correct.
+    let by_access = token_actor
+        .route(&form.token)
+        .send(LookupToken {
+            token: form.token.clone(),
+            span: tracing::Span::current(),
+        })
+        .await
+        .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))??;
+
+    let token = if by_access.is_some() {
+        by_access
+    } else {
+        token_actor
             .route(&form.token)
-            .send(LookupToken {
-                token: form.token.clone(),
+            .send(crate::actors::LookupRefreshToken {
+                refresh_token: form.token.clone(),
                 span: tracing::Span::current(),
             })
             .await
-            .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))??;
-
-        if by_access.is_some() {
-            by_access
-        } else {
-            // Refresh-token lookup
-            token_actor
-                .route(&form.token)
-                .send(crate::actors::LookupRefreshToken {
-                    refresh_token: form.token.clone(),
-                    span: tracing::Span::current(),
-                })
-                .await
-                .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))??
-        }
+            .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))??
     };
 
-    if let Some(token) = token {
-        if token.client_id == caller.client_id {
+    match token {
+        Some(token) if token.client_id == caller.client_id => {
             token_actor
                 .route(&form.token)
                 .send(RevokeToken {
@@ -370,12 +377,30 @@ pub async fn revoke(
                 })
                 .await
                 .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))??;
-        } else {
+        }
+        Some(token) => {
             tracing::warn!(
                 caller_client_id = %caller.client_id,
                 token_client_id = %token.client_id,
                 "Authenticated caller attempted to revoke a token owned by another client"
             );
+        }
+        None => {
+            // Token not found in storage. RFC 7009 §2.2 requires 200 OK
+            // regardless, but still forward to RevokeToken so that any
+            // stale entry in a local/distributed cache is evicted. The
+            // underlying db.revoke_token() is idempotent.
+            tracing::debug!(
+                token_type_hint = ?form.token_type_hint,
+                "Revocation request for token not found in storage; evicting caches"
+            );
+            let _ = token_actor
+                .route(&form.token)
+                .send(RevokeToken {
+                    token: form.token.clone(),
+                    span: tracing::Span::current(),
+                })
+                .await;
         }
     }
 

--- a/crates/oauth2-core/src/models/token.rs
+++ b/crates/oauth2-core/src/models/token.rs
@@ -191,6 +191,25 @@ impl Claims {
         Ok(token_data.claims)
     }
 
+    /// Decode the payload of a JWT without verifying the signature.
+    ///
+    /// Intended for callers that have *already* authenticated the token via
+    /// another path (e.g. storage lookup by exact token value) and only need
+    /// to extract the embedded claims. This works regardless of whether the
+    /// token was signed with HS256 or RS256, since no verification key is
+    /// required.
+    ///
+    /// DO NOT use this to validate tokens from untrusted sources.
+    pub fn decode_unverified(token: &str) -> Option<Self> {
+        let parts: Vec<&str> = token.split('.').collect();
+        if parts.len() != 3 {
+            return None;
+        }
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        let payload_bytes = URL_SAFE_NO_PAD.decode(parts[1]).ok()?;
+        serde_json::from_slice::<Self>(&payload_bytes).ok()
+    }
+
     /// Encode claims using a SigningKey (supports HS256 and RS256 with kid).
     pub fn encode_with_key(&self, key: &SigningKey) -> Result<String, jsonwebtoken::errors::Error> {
         let mut header = match key.algorithm {
@@ -400,4 +419,63 @@ pub struct IntrospectionResponse {
     /// RFC 7662 §2.2: issuer of the token.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub iss: Option<String>,
+}
+
+#[cfg(test)]
+mod decode_unverified_tests {
+    use super::Claims;
+
+    #[test]
+    fn preserves_jti_from_hs256_jwt() {
+        let claims = Claims::new(
+            "alice".to_string(),
+            "client-a".to_string(),
+            "read".to_string(),
+            3600,
+            "https://issuer.test",
+        );
+        let expected_jti = claims.jti.clone();
+        let token = claims.encode("test-secret").unwrap();
+
+        let decoded = Claims::decode_unverified(&token).expect("decode_unverified");
+        assert_eq!(decoded.jti, expected_jti);
+        assert_eq!(decoded.sub, "alice");
+        assert_eq!(decoded.iss, "https://issuer.test");
+    }
+
+    #[test]
+    fn rejects_non_jwt_inputs() {
+        assert!(Claims::decode_unverified("not-a-jwt").is_none());
+        assert!(Claims::decode_unverified("").is_none());
+        assert!(Claims::decode_unverified("a.b").is_none());
+    }
+
+    #[test]
+    fn decodes_rs256_payload_without_public_key() {
+        // A minimal RS256-header JWT with a valid-looking payload and a
+        // junk signature. We should be able to extract the claims even
+        // though we don't have the public key.
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        let header = serde_json::json!({"alg":"RS256","typ":"at+JWT","kid":"k1"}).to_string();
+        let payload = serde_json::json!({
+            "sub":"bob",
+            "aud":"client-b",
+            "iss":"https://issuer.test",
+            "scope":"read",
+            "exp": 1_800_000_000i64,
+            "iat": 1_700_000_000i64,
+            "jti": "jti-fixed-abc",
+            "client_id": "client-b"
+        })
+        .to_string();
+        let fake = format!(
+            "{}.{}.{}",
+            URL_SAFE_NO_PAD.encode(header.as_bytes()),
+            URL_SAFE_NO_PAD.encode(payload.as_bytes()),
+            URL_SAFE_NO_PAD.encode(b"not-a-real-signature"),
+        );
+        let decoded = Claims::decode_unverified(&fake).expect("decode payload");
+        assert_eq!(decoded.jti, "jti-fixed-abc");
+        assert_eq!(decoded.iss, "https://issuer.test");
+    }
 }

--- a/crates/oauth2-server/src/lib.rs
+++ b/crates/oauth2-server/src/lib.rs
@@ -21,6 +21,66 @@ use utoipa_swagger_ui::SwaggerUi;
 /// The known-insecure default seed password shipped with the server.
 pub const INSECURE_DEFAULT_SEED_PASSWORD: &str = "changeme";
 
+/// Redact the `user:password@` userinfo from a database URL so it is safe
+/// to emit in logs. Leaves the scheme, host, port, path, and query intact.
+pub fn redact_db_url(url: &str) -> String {
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string();
+    };
+    let after_scheme = scheme_end + 3;
+    let rest = &url[after_scheme..];
+    let Some(at_pos) = rest.find('@') else {
+        return url.to_string();
+    };
+    // Only treat `@` as userinfo terminator if it precedes any path/query
+    // separator — otherwise it is a bare `@` inside the path/query.
+    let host_terminators = ['/', '?', '#'];
+    if rest[..at_pos].contains(host_terminators) {
+        return url.to_string();
+    }
+    format!("{}://***@{}", &url[..scheme_end], &rest[at_pos + 1..])
+}
+
+#[cfg(test)]
+mod redact_db_url_tests {
+    use super::redact_db_url;
+
+    #[test]
+    fn redacts_mongo_password() {
+        let got =
+            redact_db_url("mongodb://user:s3cret@host.example.com:10255/?ssl=true&appName=foo");
+        assert_eq!(
+            got,
+            "mongodb://***@host.example.com:10255/?ssl=true&appName=foo"
+        );
+    }
+
+    #[test]
+    fn redacts_postgres_password() {
+        assert_eq!(
+            redact_db_url("postgres://user:pw@db:5432/app"),
+            "postgres://***@db:5432/app"
+        );
+    }
+
+    #[test]
+    fn leaves_url_without_userinfo_unchanged() {
+        assert_eq!(
+            redact_db_url("sqlite:///tmp/test.db"),
+            "sqlite:///tmp/test.db"
+        );
+        assert_eq!(redact_db_url("sqlite::memory:"), "sqlite::memory:");
+    }
+
+    #[test]
+    fn does_not_treat_at_in_path_as_userinfo() {
+        assert_eq!(
+            redact_db_url("sqlite:///tmp/foo@bar.db"),
+            "sqlite:///tmp/foo@bar.db"
+        );
+    }
+}
+
 /// Rejects the well-known insecure default seed password unless
 /// `OAUTH2_ALLOW_INSECURE_DEFAULTS=1` is set in the environment.
 pub fn validate_seed_password_for_production(password: &str) -> Result<(), String> {
@@ -232,7 +292,7 @@ pub async fn run() -> std::io::Result<()> {
 
     // Initialize storage backend (SQLx by default, optional MongoDB)
     tracing::info!(
-        database_url = %config.database.url,
+        database_url = %redact_db_url(&config.database.url),
         max_connections = config.database.max_connections,
         min_connections = config.database.min_connections,
         acquire_timeout_secs = config.database.acquire_timeout_secs,

--- a/crates/oauth2-storage-mongo/src/lib.rs
+++ b/crates/oauth2-storage-mongo/src/lib.rs
@@ -111,6 +111,33 @@ impl MongoStorage {
             .await
             .map_err(Self::mongo_err_to_oauth)?;
 
+        // created_at indexes — CosmosDB for MongoDB rejects sorts on un-indexed
+        // fields with BadValue (error code 2); all list_all_* queries sort by this.
+        self.clients
+            .create_index(
+                IndexModel::builder()
+                    .keys(doc! { "created_at": -1 })
+                    .build(),
+            )
+            .await
+            .map_err(Self::mongo_err_to_oauth)?;
+        self.users
+            .create_index(
+                IndexModel::builder()
+                    .keys(doc! { "created_at": -1 })
+                    .build(),
+            )
+            .await
+            .map_err(Self::mongo_err_to_oauth)?;
+        self.tokens
+            .create_index(
+                IndexModel::builder()
+                    .keys(doc! { "created_at": -1 })
+                    .build(),
+            )
+            .await
+            .map_err(Self::mongo_err_to_oauth)?;
+
         // authorization_codes.code unique
         self.authorization_codes
             .create_index(

--- a/crates/oauth2-storage-mongo/src/lib.rs
+++ b/crates/oauth2-storage-mongo/src/lib.rs
@@ -111,33 +111,6 @@ impl MongoStorage {
             .await
             .map_err(Self::mongo_err_to_oauth)?;
 
-        // created_at indexes — CosmosDB for MongoDB rejects sorts on un-indexed
-        // fields with BadValue (error code 2); all list_all_* queries sort by this.
-        self.clients
-            .create_index(
-                IndexModel::builder()
-                    .keys(doc! { "created_at": -1 })
-                    .build(),
-            )
-            .await
-            .map_err(Self::mongo_err_to_oauth)?;
-        self.users
-            .create_index(
-                IndexModel::builder()
-                    .keys(doc! { "created_at": -1 })
-                    .build(),
-            )
-            .await
-            .map_err(Self::mongo_err_to_oauth)?;
-        self.tokens
-            .create_index(
-                IndexModel::builder()
-                    .keys(doc! { "created_at": -1 })
-                    .build(),
-            )
-            .await
-            .map_err(Self::mongo_err_to_oauth)?;
-
         // authorization_codes.code unique
         self.authorization_codes
             .create_index(
@@ -399,13 +372,20 @@ impl Storage for MongoStorage {
 
     async fn list_all_clients(&self) -> Result<Vec<Client>, OAuth2Error> {
         use futures::TryStreamExt;
+        // Sort application-side: CosmosDB for MongoDB rejects DB-level ORDER BY on
+        // fields not in its indexing policy, and silently ignores create_index calls
+        // for those fields.
         let cursor = self
             .clients
             .find(doc! {})
-            .sort(doc! { "created_at": -1 })
             .await
             .map_err(Self::mongo_err_to_oauth)?;
-        cursor.try_collect().await.map_err(Self::mongo_err_to_oauth)
+        let mut clients: Vec<Client> = cursor
+            .try_collect()
+            .await
+            .map_err(Self::mongo_err_to_oauth)?;
+        clients.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(clients)
     }
 
     async fn list_all_users(&self) -> Result<Vec<User>, OAuth2Error> {
@@ -413,10 +393,14 @@ impl Storage for MongoStorage {
         let cursor = self
             .users
             .find(doc! {})
-            .sort(doc! { "created_at": -1 })
             .await
             .map_err(Self::mongo_err_to_oauth)?;
-        cursor.try_collect().await.map_err(Self::mongo_err_to_oauth)
+        let mut users: Vec<User> = cursor
+            .try_collect()
+            .await
+            .map_err(Self::mongo_err_to_oauth)?;
+        users.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(users)
     }
 
     async fn list_all_tokens(&self) -> Result<Vec<Token>, OAuth2Error> {
@@ -424,11 +408,16 @@ impl Storage for MongoStorage {
         let cursor = self
             .tokens
             .find(doc! {})
-            .sort(doc! { "created_at": -1 })
-            .limit(200)
             .await
             .map_err(Self::mongo_err_to_oauth)?;
-        cursor.try_collect().await.map_err(Self::mongo_err_to_oauth)
+        let mut tokens: Vec<Token> = cursor
+            .try_collect()
+            .await
+            .map_err(Self::mongo_err_to_oauth)?;
+        tokens.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        // Match the SQLx 200-token cap
+        tokens.truncate(200);
+        Ok(tokens)
     }
 
     async fn healthcheck(&self) -> Result<(), OAuth2Error> {

--- a/tests/compliance_rfc8628.rs
+++ b/tests/compliance_rfc8628.rs
@@ -591,3 +591,46 @@ async fn rfc8628_s3_4_unknown_device_code_returns_error() {
         resp.status()
     );
 }
+
+/// RFC 8628 §3.1 + RFC 6749 §2.3.1: confidential clients may authenticate at
+/// `/device_authorization` using `client_secret_basic` — the handler must
+/// accept credentials from the `Authorization` header when the form body
+/// omits `client_id`/`client_secret`.
+#[actix_web::test]
+async fn rfc8628_s3_1_accepts_client_secret_basic() {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+
+    let (token_actor, client_actor, auth_actor, storage, jwt_secret, metrics, oidc_config) =
+        setup_context(device_client()).await;
+    let app = device_app!(
+        token_actor,
+        client_actor,
+        auth_actor,
+        storage,
+        jwt_secret,
+        metrics,
+        oidc_config
+    );
+
+    let basic = STANDARD.encode("device_client:device_secret");
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/oauth/device_authorization")
+            .insert_header(("Authorization", format!("Basic {basic}")))
+            .set_form([("scope", "read")])
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "Basic-authenticated device auth must succeed without client_id in body"
+    );
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(
+        body["device_code"].as_str().is_some_and(|s| !s.is_empty()),
+        "device_code must be present"
+    );
+}


### PR DESCRIPTION
## Summary

- CosmosDB for MongoDB **silently ignores `create_index()` calls** for fields not in its collection indexing policy
- Then rejects `ORDER BY` on those fields with `BadValue` (error code 2): _"The index path corresponding to the specified order-by item is excluded"_
- Confirmed via `az cosmosdb mongodb collection show`: clients/users/tokens collections have no `created_at` in their indexing policies — only `_id` and uniqueness indexes
- The previous fix (PR #164) added `create_index` calls for `created_at` — these returned success but CosmosDB didn't actually honor them

**Fix:** Fetch `list_all_clients/users/tokens` without DB-level sort, then sort by `created_at` descending in Rust. Tokens are truncated to 200 after sort (matching the SQLx cap). The ineffective `create_index` calls for `created_at` are removed.

## Why application-sort over Azure indexing policy update

- No Azure Portal/CLI ops required — works immediately on deploy
- Portable: same code works against real MongoDB (which sorts fine) and CosmosDB
- These are admin-only bulk-list operations; in-memory sort of a few hundred records is negligible

## Test plan

- [ ] Deploy — admin dashboard `/admin/api/clients`, `/admin/api/tokens`, `/admin/api/users` return 200 JSON
- [ ] Data confirmed in CosmosDB: 2 clients, 2 users, 13 tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)