### PR TITLE
feat(admin): Bearer token auth for admin API + MCP server admin tools

### DIFF
--- a/crates/oauth2-actix/src/middleware/admin_guard.rs
+++ b/crates/oauth2-actix/src/middleware/admin_guard.rs
@@ -1,18 +1,24 @@
 //! Middleware that restricts access to admin-level users.
 //!
-//! Checks the session for `role == "admin"` or matches the user's email
-//! against the `OAUTH2_ADMIN_EMAILS` environment variable. Unauthenticated
-//! requests redirect to `/auth/login`; authenticated but non-admin requests
-//! receive a 302 redirect to `OAUTH2_NON_ADMIN_REDIRECT` (defaults to
-//! `https://profile.cat-herding.net`).
+//! Accepts two auth mechanisms:
+//!
+//! 1. **Bearer token** — `Authorization: Bearer <token>` with `admin` scope.
+//!    Checked first; intended for machine-to-machine callers (e.g. MCP server).
+//! 2. **Session cookie** — `role == "admin"` in the session, or the user's
+//!    email matches `OAUTH2_ADMIN_EMAILS`. Intended for browser dashboard access.
+//!
+//! Unauthenticated requests redirect to `/auth/login`; authenticated but
+//! non-admin requests receive a 302 redirect to `OAUTH2_NON_ADMIN_REDIRECT`
+//! (defaults to `/profile`).
 
 use actix_session::SessionExt;
 use actix_web::{
     body::EitherBody,
     dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
-    Error, HttpResponse,
+    web, Error, HttpResponse,
 };
 use futures::future::LocalBoxFuture;
+use oauth2_ports::DynStorage;
 use std::future::{ready, Ready};
 use std::rc::Rc;
 
@@ -70,21 +76,53 @@ where
         let svc = self.service.clone();
 
         Box::pin(async move {
+            // --- Bearer token check (machine-to-machine / MCP) ---
+            if let Some(auth_header) = req.headers().get("Authorization") {
+                if let Ok(auth_str) = auth_header.to_str() {
+                    if let Some(bearer) = auth_str.strip_prefix("Bearer ") {
+                        let bearer = bearer.to_string();
+                        if let Some(storage) = req.app_data::<web::Data<DynStorage>>() {
+                            match storage.get_token_by_access_token(&bearer).await {
+                                Ok(Some(token)) if token.is_valid() => {
+                                    let scopes: Vec<&str> =
+                                        token.scope.split_whitespace().collect();
+                                    if scopes.contains(&"admin") {
+                                        let res = svc.call(req).await?;
+                                        return Ok(res.map_into_left_body());
+                                    }
+                                    // Valid token but no admin scope
+                                    let response = HttpResponse::Forbidden()
+                                        .json(serde_json::json!({
+                                            "error": "insufficient_scope",
+                                            "error_description": "Token requires 'admin' scope"
+                                        }));
+                                    return Ok(req.into_response(response).map_into_right_body());
+                                }
+                                _ => {
+                                    let response = HttpResponse::Unauthorized()
+                                        .json(serde_json::json!({
+                                            "error": "invalid_token",
+                                            "error_description": "Bearer token is invalid or expired"
+                                        }));
+                                    return Ok(req.into_response(response).map_into_right_body());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // --- Session cookie check (browser dashboard) ---
             let session = req.get_session();
 
-            // Check if user is authenticated at all
             let user_id: Option<String> = session.get("user_id").unwrap_or(None);
             if user_id.is_none() {
-                // Not logged in — redirect to login
                 let response = HttpResponse::Found()
                     .append_header(("Location", "/auth/login?error=login_required"))
                     .finish();
                 return Ok(req.into_response(response).map_into_right_body());
             }
 
-            // Check admin privileges:
-            // 1. Session role == "admin"
-            // 2. Session email matches OAUTH2_ADMIN_EMAILS
             let role: String = session
                 .get("role")
                 .unwrap_or(None)
@@ -95,7 +133,6 @@ where
             let is_admin = role == "admin" || is_admin_email(&email);
 
             if !is_admin {
-                // Authenticated but not admin — redirect to profile site
                 let redirect_url = std::env::var("OAUTH2_NON_ADMIN_REDIRECT")
                     .unwrap_or_else(|_| "/profile".to_string());
                 tracing::warn!(
@@ -109,7 +146,6 @@ where
                 return Ok(req.into_response(response).map_into_right_body());
             }
 
-            // Admin access granted
             let res = svc.call(req).await?;
             Ok(res.map_into_left_body())
         })

--- a/mcp-server/src/index.js
+++ b/mcp-server/src/index.js
@@ -20,10 +20,8 @@ dotenv.config();
 
 // Configuration
 const OAUTH2_BASE_URL = process.env.OAUTH2_BASE_URL || 'http://localhost:8080';
-// Optional: Default client credentials can be configured via environment variables
-// These are used as defaults but can be overridden per-request
-// const OAUTH2_CLIENT_ID = process.env.OAUTH2_CLIENT_ID;
-// const OAUTH2_CLIENT_SECRET = process.env.OAUTH2_CLIENT_SECRET;
+const OAUTH2_CLIENT_ID = process.env.OAUTH2_CLIENT_ID || '';
+const OAUTH2_CLIENT_SECRET = process.env.OAUTH2_CLIENT_SECRET || '';
 
 /**
  * OAuth2 API Client
@@ -40,13 +38,43 @@ class OAuth2Client {
   }
 
   /**
-   * Register a new OAuth2 client.
-   *
-   * Note: the target endpoint is admin-protected. This wrapper does not manage
-   * an admin browser session for you.
+   * Register a new OAuth2 client via RFC 7591 Dynamic Client Registration.
    */
   async registerClient(data) {
-    const response = await this.axios.post('/admin/clients/register', data);
+    const response = await this.axios.post('/connect/register', data);
+    return response.data;
+  }
+
+  /**
+   * List all registered clients (requires admin client credentials).
+   */
+  async listClients(clientId, clientSecret) {
+    const token = await this.getToken(clientId, clientSecret, 'admin');
+    const response = await this.axios.get('/admin/api/clients', {
+      headers: { Authorization: `Bearer ${token.access_token}` },
+    });
+    return response.data;
+  }
+
+  /**
+   * List all tokens (requires admin client credentials).
+   */
+  async listTokens(clientId, clientSecret) {
+    const token = await this.getToken(clientId, clientSecret, 'admin');
+    const response = await this.axios.get('/admin/api/tokens', {
+      headers: { Authorization: `Bearer ${token.access_token}` },
+    });
+    return response.data;
+  }
+
+  /**
+   * Delete a registered client (requires admin client credentials).
+   */
+  async deleteClient(clientId, clientSecret, targetClientId) {
+    const token = await this.getToken(clientId, clientSecret, 'admin');
+    const response = await this.axios.delete(`/admin/api/clients/${targetClientId}`, {
+      headers: { Authorization: `Bearer ${token.access_token}` },
+    });
     return response.data;
   }
 
@@ -361,6 +389,41 @@ class OAuth2MCPServer {
           },
         },
         {
+          name: 'list_clients',
+          description: 'List all registered OAuth2 clients (uses configured admin client credentials)',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              client_id: { type: 'string', description: 'Admin client ID (defaults to env OAUTH2_CLIENT_ID)' },
+              client_secret: { type: 'string', description: 'Admin client secret (defaults to env OAUTH2_CLIENT_SECRET)' },
+            },
+          },
+        },
+        {
+          name: 'list_tokens',
+          description: 'List recent tokens (uses configured admin client credentials)',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              client_id: { type: 'string', description: 'Admin client ID (defaults to env OAUTH2_CLIENT_ID)' },
+              client_secret: { type: 'string', description: 'Admin client secret (defaults to env OAUTH2_CLIENT_SECRET)' },
+            },
+          },
+        },
+        {
+          name: 'delete_client',
+          description: 'Delete a registered OAuth2 client by client_id (uses configured admin client credentials)',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              target_client_id: { type: 'string', description: 'The client_id of the client to delete' },
+              client_id: { type: 'string', description: 'Admin client ID (defaults to env OAUTH2_CLIENT_ID)' },
+              client_secret: { type: 'string', description: 'Admin client secret (defaults to env OAUTH2_CLIENT_SECRET)' },
+            },
+            required: ['target_client_id'],
+          },
+        },
+        {
           name: 'get_health',
           description: 'Check the health status of the OAuth2 server',
           inputSchema: {
@@ -505,6 +568,43 @@ class OAuth2MCPServer {
                     : 'Failed to revoke token',
                 },
               ],
+            };
+
+          case 'list_clients':
+            return {
+              content: [{
+                type: 'text',
+                text: JSON.stringify(
+                  await this.oauth2Client.listClients(
+                    args.client_id || OAUTH2_CLIENT_ID,
+                    args.client_secret || OAUTH2_CLIENT_SECRET
+                  ), null, 2),
+              }],
+            };
+
+          case 'list_tokens':
+            return {
+              content: [{
+                type: 'text',
+                text: JSON.stringify(
+                  await this.oauth2Client.listTokens(
+                    args.client_id || OAUTH2_CLIENT_ID,
+                    args.client_secret || OAUTH2_CLIENT_SECRET
+                  ), null, 2),
+              }],
+            };
+
+          case 'delete_client':
+            return {
+              content: [{
+                type: 'text',
+                text: JSON.stringify(
+                  await this.oauth2Client.deleteClient(
+                    args.client_id || OAUTH2_CLIENT_ID,
+                    args.client_secret || OAUTH2_CLIENT_SECRET,
+                    args.target_client_id
+                  ), null, 2),
+              }],
             };
 
           case 'get_health':


### PR DESCRIPTION
## Summary
- `AdminGuard` middleware now accepts `Authorization: Bearer <token>` with `admin` scope, enabling MCP server and script access to `/admin/api/*` without a browser session
- MCP server: fixed `registerClient` to use RFC 7591 `/connect/register` endpoint (was incorrectly hitting `/admin/clients/register`)
- MCP server: added `list_clients`, `list_tokens`, and `delete_client` tools using Bearer token auth

## Test plan
- [ ] Obtain an access token with `admin` scope via client credentials or password grant
- [ ] Call `GET /admin/api/clients` with `Authorization: Bearer <token>` → 200 with client list
- [ ] Call without token or with non-admin scoped token → 401/403 respectively
- [ ] MCP `list_clients` tool returns client list
- [ ] MCP `register_client` tool creates a new client via `/connect/register`

🤖 Generated with [Claude Code](https://claude.com/claude-code)