### PR TITLE
feat(admin): modernize dashboard UI and fix broken latency charts

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -104,6 +104,66 @@ function prometheusLabeled(metrics, name, label, value) {
   return match ? match.value : 0;
 }
 
+// Compute quantile from a Prometheus histogram's cumulative `_bucket{le="…"}` series.
+// Works with default `prometheus` crate histograms which only emit buckets (not quantiles).
+// q in [0,1]. Returns value in the histogram's native unit (seconds for durations).
+function histogramQuantile(metrics, baseName, q) {
+  const buckets = metrics[baseName + '_bucket'];
+  if (!buckets || !buckets.length) return 0;
+  const parsed = buckets
+    .map(b => ({
+      le: b.labels.le === '+Inf' ? Infinity : parseFloat(b.labels.le),
+      count: b.value,
+    }))
+    .filter(b => !isNaN(b.le))
+    .sort((a, b) => a.le - b.le);
+  if (!parsed.length) return 0;
+  const total = parsed[parsed.length - 1].count;
+  if (total <= 0) return 0;
+  const target = q * total;
+  let prevLe = 0, prevCount = 0;
+  for (const { le, count } of parsed) {
+    if (count >= target) {
+      if (le === Infinity) return prevLe;
+      if (count === prevCount) return le;
+      const frac = (target - prevCount) / (count - prevCount);
+      return prevLe + frac * (le - prevLe);
+    }
+    prevLe = le;
+    prevCount = count;
+  }
+  return prevLe;
+}
+
+// In-memory trend buffers for sparklines (last ~20 polls per metric).
+const _trendHistory = {};
+function pushTrend(key, value, max = 20) {
+  if (!_trendHistory[key]) _trendHistory[key] = [];
+  _trendHistory[key].push(value);
+  if (_trendHistory[key].length > max) _trendHistory[key].shift();
+  return _trendHistory[key];
+}
+function trendDelta(key) {
+  const h = _trendHistory[key];
+  if (!h || h.length < 2) return null;
+  return h[h.length - 1] - h[h.length - 2];
+}
+// Build a compact sparkline SVG path from a numeric series.
+function sparklinePath(series, w = 80, h = 24) {
+  if (!series || series.length < 2) return '';
+  const min = Math.min(...series);
+  const max = Math.max(...series);
+  const range = max - min || 1;
+  const step = w / (series.length - 1);
+  return series
+    .map((v, i) => {
+      const x = (i * step).toFixed(1);
+      const y = (h - ((v - min) / range) * h).toFixed(1);
+      return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+    })
+    .join(' ');
+}
+
 // ─── Chart helpers ────────────────────────────────────────────────────────────
 
 const _charts = {};
@@ -123,9 +183,58 @@ function createOrUpdateChart(id, config) {
 function chartDefaults() {
   const dark = document.documentElement.classList.contains('dark');
   return {
-    gridColor: dark ? 'rgba(148,163,184,0.15)' : 'rgba(148,163,184,0.3)',
+    gridColor: dark ? 'rgba(148,163,184,0.08)' : 'rgba(148,163,184,0.18)',
     textColor: dark ? '#94a3b8' : '#64748b',
-    bg: dark ? '#1e293b' : '#ffffff',
+    bg: dark ? '#0f172a' : '#ffffff',
+    tooltipBg: dark ? 'rgba(15,23,42,0.95)' : 'rgba(255,255,255,0.98)',
+    tooltipBorder: dark ? 'rgba(148,163,184,0.2)' : 'rgba(148,163,184,0.3)',
+    tooltipText: dark ? '#e2e8f0' : '#0f172a',
+  };
+}
+
+// Shared palette — modern engineering-dashboard tone.
+const PALETTE = {
+  indigo:  '#6366f1',
+  emerald: '#10b981',
+  rose:    '#f43f5e',
+  amber:   '#f59e0b',
+  cyan:    '#06b6d4',
+  violet:  '#a855f7',
+  slate:   '#64748b',
+};
+
+function baseChartOpts() {
+  const { textColor, gridColor, tooltipBg, tooltipBorder, tooltipText } = chartDefaults();
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: { duration: 400, easing: 'easeOutQuart' },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: tooltipBg,
+        borderColor: tooltipBorder,
+        borderWidth: 1,
+        titleColor: tooltipText,
+        bodyColor: tooltipText,
+        padding: 10,
+        cornerRadius: 6,
+        displayColors: true,
+        titleFont: { family: "'Manrope', system-ui, sans-serif", weight: '600', size: 12 },
+        bodyFont:  { family: "'JetBrains Mono', monospace", size: 11 },
+      },
+    },
+    scales: {
+      x: {
+        ticks: { color: textColor, font: { family: "'Manrope', system-ui, sans-serif", size: 11 } },
+        grid: { color: gridColor, drawBorder: false },
+      },
+      y: {
+        beginAtZero: true,
+        ticks: { color: textColor, font: { family: "'JetBrains Mono', monospace", size: 10 } },
+        grid: { color: gridColor, drawBorder: false },
+      },
+    },
   };
 }
 
@@ -214,23 +323,22 @@ function dashboardPage() {
 
     async initCharts() {
       const m = await fetchPrometheus();
-      const { textColor, gridColor } = chartDefaults();
+      const opts = baseChartOpts();
 
-      const scaleOpts = {
-        x: { ticks: { color: textColor }, grid: { color: gridColor } },
-        y: { beginAtZero: true, ticks: { color: textColor }, grid: { color: gridColor } },
-      };
-
-      // Token issued/revoked bar chart from metrics counters
-      const issued = prometheusScalar(m, 'oauth2_server_oauth_token_issued_total');
+      // Token issued/revoked
+      const issued  = prometheusScalar(m, 'oauth2_server_oauth_token_issued_total');
       const revoked = prometheusScalar(m, 'oauth2_server_oauth_token_revoked_total');
       createOrUpdateChart('tokenChart', {
         type: 'bar',
         data: {
           labels: ['Issued', 'Revoked'],
-          datasets: [{ data: [issued, revoked], backgroundColor: ['#2563eb', '#ef4444'] }],
+          datasets: [{
+            data: [issued, revoked],
+            backgroundColor: [PALETTE.indigo, PALETTE.rose],
+            borderRadius: 6, borderSkipped: false, barThickness: 36,
+          }],
         },
-        options: { responsive: true, plugins: { legend: { display: false } }, scales: scaleOpts },
+        options: opts,
       });
 
       // HTTP status distribution
@@ -242,41 +350,72 @@ function dashboardPage() {
         type: 'doughnut',
         data: {
           labels: ['2xx Success', '4xx Client', '5xx Server'],
-          datasets: [{ data: [s2xx, s4xx, s5xx], backgroundColor: ['#10b981', '#f59e0b', '#ef4444'] }],
+          datasets: [{
+            data: [s2xx, s4xx, s5xx],
+            backgroundColor: [PALETTE.emerald, PALETTE.amber, PALETTE.rose],
+            borderWidth: 0, hoverOffset: 6,
+          }],
         },
-        options: { responsive: true, plugins: { legend: { position: 'bottom' } } },
+        options: {
+          ...opts,
+          cutout: '66%',
+          plugins: {
+            ...opts.plugins,
+            legend: {
+              display: true,
+              position: 'bottom',
+              labels: {
+                color: chartDefaults().textColor,
+                font: { family: "'Manrope', system-ui, sans-serif", size: 11 },
+                boxWidth: 10, boxHeight: 10, padding: 14, usePointStyle: true,
+              },
+            },
+          },
+          scales: {},
+        },
       });
 
-      // Latency p50/p95/p99 — use fake buckets if histogram quantiles not available
-      const p50 = prometheusLabeled(m, 'oauth2_server_http_request_duration_seconds', 'quantile', '0.5') * 1000;
-      const p95 = prometheusLabeled(m, 'oauth2_server_http_request_duration_seconds', 'quantile', '0.95') * 1000;
-      const p99 = prometheusLabeled(m, 'oauth2_server_http_request_duration_seconds', 'quantile', '0.99') * 1000;
+      // Latency p50/p95/p99 — computed from histogram buckets.
+      const p50 = histogramQuantile(m, 'oauth2_server_http_request_duration_seconds', 0.5)  * 1000;
+      const p95 = histogramQuantile(m, 'oauth2_server_http_request_duration_seconds', 0.95) * 1000;
+      const p99 = histogramQuantile(m, 'oauth2_server_http_request_duration_seconds', 0.99) * 1000;
+      pushTrend('p95', p95);
       createOrUpdateChart('latencyChart', {
         type: 'bar',
         data: {
           labels: ['p50', 'p95', 'p99'],
-          datasets: [{ label: 'ms', data: [p50, p95, p99], backgroundColor: '#8b5cf6' }],
+          datasets: [{
+            label: 'latency (ms)',
+            data: [p50.toFixed(1), p95.toFixed(1), p99.toFixed(1)],
+            backgroundColor: [PALETTE.cyan, PALETTE.indigo, PALETTE.violet],
+            borderRadius: 6, borderSkipped: false, barThickness: 34,
+          }],
         },
         options: {
-          responsive: true,
-          plugins: { legend: { display: false } },
+          ...opts,
+          indexAxis: 'y',
           scales: {
-            ...scaleOpts,
-            y: { ...scaleOpts.y, title: { display: true, text: 'ms', color: textColor } },
+            x: { ...opts.scales.x, title: { display: true, text: 'ms', color: chartDefaults().textColor, font: { size: 10 } } },
+            y: opts.scales.y,
           },
         },
       });
 
-      // Rate-limit rejections
+      // Resilience events
       const rl = prometheusScalar(m, 'oauth2_server_rate_limit_rejected_total');
-      const cb = prometheusLabeled(m, 'oauth2_server_circuit_breaker_state', 'state', '1'); // 1=Open
+      const cb = prometheusScalar(m, 'oauth2_server_circuit_breaker_trips_total');
+      const bp = prometheusScalar(m, 'oauth2_server_back_pressure_rejected_total');
       createOrUpdateChart('resilienceChart', {
         type: 'bar',
         data: {
-          labels: ['Rate-limit rejects', 'Circuit trips'],
-          datasets: [{ data: [rl, cb], backgroundColor: ['#f59e0b', '#ef4444'] }],
+          labels: ['Rate-limit', 'Circuit trips', 'Back-pressure'],
+          datasets: [{
+            data: [rl, cb, bp],
+            backgroundColor: [PALETTE.amber, PALETTE.rose, PALETTE.violet],
+            borderRadius: 6, borderSkipped: false, barThickness: 34,
+          }],
         },
-        options: { responsive: true, plugins: { legend: { display: false } }, scales: scaleOpts },
+        options: opts,
       });
     },
 
@@ -567,14 +706,11 @@ function metricsPage() {
     scalar(name) { return prometheusScalar(this.metrics, name); },
     labeled(name, label, value) { return prometheusLabeled(this.metrics, name, label, value); },
 
-    drawCharts() {
-      const { textColor, gridColor } = chartDefaults();
-      const scale = {
-        x: { ticks: { color: textColor }, grid: { color: gridColor } },
-        y: { beginAtZero: true, ticks: { color: textColor }, grid: { color: gridColor } },
-      };
+    hq(name, q) { return histogramQuantile(this.metrics, name, q); },
 
-      // Auth metrics
+    drawCharts() {
+      const opts = baseChartOpts();
+
       createOrUpdateChart('m-tokens', {
         type: 'bar',
         data: {
@@ -586,53 +722,53 @@ function metricsPage() {
               this.scalar('oauth2_server_oauth_authorization_codes_issued'),
               this.scalar('oauth2_server_oauth_failed_authentications'),
             ],
-            backgroundColor: ['#2563eb', '#ef4444', '#10b981', '#f59e0b'],
+            backgroundColor: [PALETTE.indigo, PALETTE.rose, PALETTE.emerald, PALETTE.amber],
+            borderRadius: 6, borderSkipped: false, barThickness: 32,
           }],
         },
-        options: { responsive: true, plugins: { legend: { display: false } }, scales: scale },
+        options: opts,
       });
 
-      // Latency
+      // HTTP latency — computed from buckets
+      const hp50 = this.hq('oauth2_server_http_request_duration_seconds', 0.5)  * 1000;
+      const hp95 = this.hq('oauth2_server_http_request_duration_seconds', 0.95) * 1000;
+      const hp99 = this.hq('oauth2_server_http_request_duration_seconds', 0.99) * 1000;
       createOrUpdateChart('m-latency', {
         type: 'bar',
         data: {
           labels: ['p50', 'p95', 'p99'],
           datasets: [{
             label: 'ms',
-            data: [
-              (this.labeled('oauth2_server_http_request_duration_seconds', 'quantile', '0.5') * 1000).toFixed(1),
-              (this.labeled('oauth2_server_http_request_duration_seconds', 'quantile', '0.95') * 1000).toFixed(1),
-              (this.labeled('oauth2_server_http_request_duration_seconds', 'quantile', '0.99') * 1000).toFixed(1),
-            ],
-            backgroundColor: '#8b5cf6',
+            data: [hp50.toFixed(1), hp95.toFixed(1), hp99.toFixed(1)],
+            backgroundColor: [PALETTE.cyan, PALETTE.indigo, PALETTE.violet],
+            borderRadius: 6, borderSkipped: false, barThickness: 32,
           }],
         },
-        options: { responsive: true, plugins: { legend: { display: false } }, scales: scale },
+        options: { ...opts, indexAxis: 'y' },
       });
 
-      // DB query latency
+      // DB query latency — computed from buckets
+      const dp50 = this.hq('oauth2_server_db_query_duration_seconds', 0.5)  * 1000;
+      const dp95 = this.hq('oauth2_server_db_query_duration_seconds', 0.95) * 1000;
+      const dp99 = this.hq('oauth2_server_db_query_duration_seconds', 0.99) * 1000;
       createOrUpdateChart('m-db', {
         type: 'bar',
         data: {
           labels: ['p50', 'p95', 'p99'],
           datasets: [{
             label: 'ms',
-            data: [
-              (this.labeled('oauth2_server_db_query_duration_seconds', 'quantile', '0.5') * 1000).toFixed(1),
-              (this.labeled('oauth2_server_db_query_duration_seconds', 'quantile', '0.95') * 1000).toFixed(1),
-              (this.labeled('oauth2_server_db_query_duration_seconds', 'quantile', '0.99') * 1000).toFixed(1),
-            ],
-            backgroundColor: '#06b6d4',
+            data: [dp50.toFixed(1), dp95.toFixed(1), dp99.toFixed(1)],
+            backgroundColor: [PALETTE.cyan, PALETTE.emerald, PALETTE.amber],
+            borderRadius: 6, borderSkipped: false, barThickness: 32,
           }],
         },
-        options: { responsive: true, plugins: { legend: { display: false } }, scales: scale },
+        options: { ...opts, indexAxis: 'y' },
       });
 
-      // Resilience gauges
       createOrUpdateChart('m-resilience', {
         type: 'bar',
         data: {
-          labels: ['Rate-limit rejects', 'CB trips', 'Backpressure rejects', 'In-flight'],
+          labels: ['Rate-limit', 'CB trips', 'Back-pressure', 'In-flight'],
           datasets: [{
             data: [
               this.scalar('oauth2_server_rate_limit_rejected_total'),
@@ -640,10 +776,11 @@ function metricsPage() {
               this.scalar('oauth2_server_back_pressure_rejected_total'),
               this.scalar('oauth2_server_concurrent_requests_in_flight'),
             ],
-            backgroundColor: ['#f59e0b', '#ef4444', '#f97316', '#6366f1'],
+            backgroundColor: [PALETTE.amber, PALETTE.rose, PALETTE.violet, PALETTE.indigo],
+            borderRadius: 6, borderSkipped: false, barThickness: 32,
           }],
         },
-        options: { responsive: true, plugins: { legend: { display: false } }, scales: scale },
+        options: opts,
       });
     },
   };

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -3,20 +3,41 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>OAuth2 Admin</title>
+  <title>OAuth2 Control Plane</title>
 
-  <!-- Tailwind CSS (Play CDN with custom theme for local dev; replace with compiled output in prod) -->
+  <!-- Fonts: Manrope (UI) + JetBrains Mono (numbers/IDs) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+  <!-- Tailwind CSS (Play CDN) -->
   <script>
     tailwind.config = {
       darkMode: 'class',
       theme: {
         extend: {
+          fontFamily: {
+            sans: ['Manrope', 'system-ui', 'sans-serif'],
+            mono: ['"JetBrains Mono"', 'ui-monospace', 'monospace'],
+          },
           colors: {
             primary: {
-              50:'#eff6ff',100:'#dbeafe',200:'#bfdbfe',300:'#93c5fd',
-              400:'#60a5fa',500:'#3b82f6',600:'#2563eb',700:'#1d4ed8',
-              800:'#1e40af',900:'#1e3a8a',
+              50:'#eef2ff',100:'#e0e7ff',200:'#c7d2fe',300:'#a5b4fc',
+              400:'#818cf8',500:'#6366f1',600:'#4f46e5',700:'#4338ca',
+              800:'#3730a3',900:'#312e81',
             },
+            surface: {
+              light: '#fafbfc',
+              dark:  '#0b0f17',
+              card:  '#ffffff',
+              cardDark: '#10151f',
+              line:  '#e2e8f0',
+              lineDark: '#1e2636',
+            },
+          },
+          boxShadow: {
+            'soft':  '0 1px 2px 0 rgb(15 23 42 / 0.04), 0 1px 3px 0 rgb(15 23 42 / 0.06)',
+            'ring':  '0 0 0 1px rgb(99 102 241 / 0.18), 0 8px 28px -8px rgb(99 102 241 / 0.3)',
           },
         },
       },
@@ -37,17 +58,100 @@
   <!-- Admin JS (defines Alpine stores + page functions) -->
   <script src="/static/js/admin.js"></script>
 
+  <!-- Component layer compiled by Tailwind Play CDN -->
+  <style type="text/tailwindcss">
+    @layer components {
+      .btn      { @apply inline-flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-offset-white dark:focus:ring-offset-slate-900; }
+      .btn-primary   { @apply btn bg-primary-600 text-white hover:bg-primary-700 focus:ring-primary-500 shadow-sm; }
+      .btn-danger    { @apply btn bg-rose-600 text-white hover:bg-rose-700 focus:ring-rose-500 shadow-sm; }
+      .btn-secondary { @apply btn bg-slate-100 text-slate-700 hover:bg-slate-200 focus:ring-slate-400 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 border border-slate-200 dark:border-slate-700; }
+      .btn-ghost     { @apply btn bg-transparent text-slate-600 hover:bg-slate-100 focus:ring-slate-400 dark:text-slate-300 dark:hover:bg-slate-800; }
+
+      .card       { @apply bg-white dark:bg-[#10151f] rounded-xl border border-slate-200/80 dark:border-slate-800 shadow-soft; }
+      .stat-card  { @apply card p-5 relative overflow-hidden; }
+
+      .badge      { @apply inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-semibold tracking-wide; }
+      .badge-green  { @apply badge bg-emerald-50 text-emerald-700 border border-emerald-200/70 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800/50; }
+      .badge-red    { @apply badge bg-rose-50 text-rose-700 border border-rose-200/70 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-800/50; }
+      .badge-yellow { @apply badge bg-amber-50 text-amber-700 border border-amber-200/70 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800/50; }
+      .badge-blue   { @apply badge bg-indigo-50 text-indigo-700 border border-indigo-200/70 dark:bg-indigo-950/40 dark:text-indigo-300 dark:border-indigo-800/50; }
+      .badge-gray   { @apply badge bg-slate-100 text-slate-600 border border-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:border-slate-700; }
+
+      .table-header { @apply px-4 py-2.5 text-left text-[11px] font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-[0.08em] bg-slate-50/60 dark:bg-slate-900/40; }
+      .table-cell   { @apply px-4 py-3 text-sm text-slate-700 dark:text-slate-300; }
+      .table-row    { @apply border-b border-slate-100 dark:border-slate-800/80 hover:bg-slate-50/70 dark:hover:bg-slate-800/40 transition-colors cursor-pointer; }
+
+      .input  { @apply block w-full rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1.5 text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30; }
+      .select { @apply block rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1.5 text-sm text-slate-900 dark:text-slate-100 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30; }
+
+      .nav-link   { @apply w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[13px] font-medium transition-colors text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-slate-100; }
+      .nav-link-active { @apply bg-primary-50 dark:bg-primary-950/40 text-primary-700 dark:text-primary-300 hover:bg-primary-50 dark:hover:bg-primary-950/40 hover:text-primary-700 dark:hover:text-primary-300; }
+      .nav-section { @apply px-2.5 mb-1 text-[10px] font-bold uppercase tracking-[0.14em] text-slate-400 dark:text-slate-500; }
+
+      .stat-label { @apply text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500 dark:text-slate-400; }
+      .stat-value { @apply text-[28px] leading-none font-bold tracking-tight font-sans; }
+      .stat-foot  { @apply text-[11px] text-slate-500 dark:text-slate-400 mt-1 font-mono; }
+
+      .chip      { @apply inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium; }
+      .chip-live { @apply chip bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300; }
+    }
+  </style>
+
   <style>
+    /* Base typography */
+    body { font-family: 'Manrope', system-ui, sans-serif; font-feature-settings: 'ss01', 'cv11'; }
+    code, pre, .font-mono { font-family: 'JetBrains Mono', ui-monospace, monospace; font-feature-settings: 'zero', 'ss02'; }
+
     /* Sidebar scrollbar */
     #sidebar::-webkit-scrollbar { width: 4px; }
-    #sidebar::-webkit-scrollbar-thumb { background: rgba(148,163,184,.3); border-radius:2px; }
+    #sidebar::-webkit-scrollbar-thumb { background: rgba(148,163,184,.25); border-radius:2px; }
+
     /* Drawer transition */
     .drawer-enter { transform: translateX(100%); }
     .drawer-open  { transform: translateX(0); transition: transform .25s ease; }
+
+    /* Subtle grid background for dashboard surface */
+    .surface-grid {
+      background-image:
+        linear-gradient(to right, rgba(148,163,184,0.06) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(148,163,184,0.06) 1px, transparent 1px);
+      background-size: 32px 32px;
+      background-position: -1px -1px;
+    }
+    .dark .surface-grid {
+      background-image:
+        linear-gradient(to right, rgba(148,163,184,0.04) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(148,163,184,0.04) 1px, transparent 1px);
+    }
+
+    /* Live-status pulse dot */
+    @keyframes pulse-dot {
+      0%,100% { box-shadow: 0 0 0 0 rgba(16,185,129,0.55); }
+      50%     { box-shadow: 0 0 0 6px rgba(16,185,129,0); }
+    }
+    .pulse-dot {
+      width: 8px; height: 8px; border-radius: 9999px; background: #10b981;
+      animation: pulse-dot 2.2s ease-out infinite;
+    }
+
+    /* Stat card accent stripe (top, gradient) */
+    .stat-accent::before {
+      content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+      background: linear-gradient(90deg, var(--accent-from, #6366f1), var(--accent-to, #a855f7));
+    }
+
+    /* Chart container sizing */
+    .chart-box { position: relative; height: 220px; }
+
+    /* Fine-tune Manrope tabular numerals for numeric stat values */
+    .tabular { font-variant-numeric: tabular-nums; }
+
+    /* Canvas crispness */
+    canvas { image-rendering: -webkit-optimize-contrast; }
   </style>
 </head>
 
-<body class="h-full bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 font-sans"
+<body class="h-full bg-slate-50 dark:bg-[#0b0f17] text-slate-900 dark:text-slate-100 antialiased"
       x-data
       x-init="$store.theme.init(); $store.router.init(); $store.caps.init()">
 
@@ -55,7 +159,7 @@
 <div class="flex h-full">
 
   <!-- Sidebar backdrop (mobile) -->
-  <div class="fixed inset-0 z-20 bg-black/50 lg:hidden"
+  <div class="fixed inset-0 z-20 bg-black/60 backdrop-blur-sm lg:hidden"
        x-show="$store.router.sidebarOpen"
        x-transition:enter="transition duration-200"
        x-transition:enter-start="opacity-0"
@@ -67,132 +171,154 @@
 
   <!-- Sidebar -->
   <aside id="sidebar"
-         class="fixed inset-y-0 left-0 z-30 w-60 overflow-y-auto bg-white dark:bg-slate-800 border-r border-slate-200 dark:border-slate-700 flex flex-col
+         class="fixed inset-y-0 left-0 z-30 w-[232px] overflow-y-auto bg-white/95 dark:bg-[#0d1220]/95 backdrop-blur-xl border-r border-slate-200/80 dark:border-slate-800/80 flex flex-col
                 -translate-x-full lg:translate-x-0 transition-transform duration-300"
          :class="$store.router.sidebarOpen ? 'translate-x-0' : ''">
 
-    <!-- Logo -->
-    <div class="flex items-center gap-2 px-5 py-4 border-b border-slate-200 dark:border-slate-700">
-      <svg class="w-7 h-7 text-primary-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
-      </svg>
-      <span class="font-semibold text-slate-900 dark:text-white text-sm tracking-tight">OAuth2 Admin</span>
+    <!-- Brand -->
+    <div class="flex items-center gap-2.5 px-5 pt-5 pb-4 border-b border-slate-100 dark:border-slate-800/80">
+      <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center shadow-ring">
+        <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+        </svg>
+      </div>
+      <div class="flex flex-col leading-tight">
+        <span class="font-bold text-slate-900 dark:text-white text-[13px] tracking-tight">OAuth2 Control</span>
+        <span class="text-[10px] font-semibold text-slate-400 dark:text-slate-500 tracking-[0.12em] uppercase">Authorization Server</span>
+      </div>
     </div>
 
     <!-- Nav -->
-    <nav class="flex-1 px-3 py-4 space-y-6">
+    <nav class="flex-1 px-2 py-3 space-y-5">
 
       <div>
-        <p class="px-2 mb-1 text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Overview</p>
+        <p class="nav-section">Overview</p>
         <button @click="$store.router.navigate('dashboard')"
-                :class="$store.router.page === 'dashboard' ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700'"
-                class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                :class="$store.router.page === 'dashboard' ? 'nav-link-active' : ''"
+                class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
           Dashboard
         </button>
         <button @click="$store.router.navigate('metrics')"
-                :class="$store.router.page === 'metrics' ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700'"
-                class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+                :class="$store.router.page === 'metrics' ? 'nav-link-active' : ''"
+                class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
           Metrics
         </button>
       </div>
 
       <div>
-        <p class="px-2 mb-1 text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Identity</p>
+        <p class="nav-section">Identity</p>
         <button @click="$store.router.navigate('clients')"
-                :class="$store.router.page === 'clients' ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700'"
-                class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2"/></svg>
+                :class="$store.router.page === 'clients' ? 'nav-link-active' : ''"
+                class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2"/></svg>
           Clients
         </button>
         <button @click="$store.router.navigate('users')"
-                :class="$store.router.page === 'users' ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700'"
-                class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+                :class="$store.router.page === 'users' ? 'nav-link-active' : ''"
+                class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
           Users
         </button>
       </div>
 
       <div>
-        <p class="px-2 mb-1 text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Tokens &amp; Sessions</p>
+        <p class="nav-section">Tokens &amp; Sessions</p>
         <button @click="$store.router.navigate('tokens')"
-                :class="$store.router.page === 'tokens' ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700'"
-                class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 11-7.778 7.778 5.5 5.5 0 017.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+                :class="$store.router.page === 'tokens' ? 'nav-link-active' : ''"
+                class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 11-7.778 7.778 5.5 5.5 0 017.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
           Tokens
         </button>
         <button @click="$store.router.navigate('device')" x-show="$store.caps.device_flow"
-                :class="$store.router.page === 'device' ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700'"
-                class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="5" y="2" width="14" height="20" rx="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg>
+                :class="$store.router.page === 'device' ? 'nav-link-active' : ''"
+                class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><rect x="5" y="2" width="14" height="20" rx="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg>
           Device Codes
         </button>
         <button @click="$store.router.navigate('keys')" x-show="$store.caps.key_rotation"
-                :class="$store.router.page === 'keys' ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700'"
-                class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+                :class="$store.router.page === 'keys' ? 'nav-link-active' : ''"
+                class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
           JWT Keys
         </button>
       </div>
 
       <div>
-        <p class="px-2 mb-1 text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider">System</p>
+        <p class="nav-section">System</p>
         <button @click="$store.router.navigate('events')" x-show="$store.caps.events"
-                :class="$store.router.page === 'events' ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700'"
-                class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+                :class="$store.router.page === 'events' ? 'nav-link-active' : ''"
+                class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
           Events
         </button>
-        <a href="/health" target="_blank"
-           class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+        <a href="/health" target="_blank" class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
           Health
+          <svg class="w-3 h-3 ml-auto opacity-40" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M7 17l9.2-9.2M17 17V7H7"/></svg>
         </a>
-        <a href="/swagger-ui" target="_blank"
-           class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+        <a href="/swagger-ui" target="_blank" class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
           API Docs
+          <svg class="w-3 h-3 ml-auto opacity-40" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M7 17l9.2-9.2M17 17V7H7"/></svg>
         </a>
       </div>
     </nav>
 
     <!-- Bottom: Profile -->
-    <div class="px-3 py-3 border-t border-slate-200 dark:border-slate-700">
-      <a href="/profile" class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+    <div class="px-2 py-3 border-t border-slate-100 dark:border-slate-800/80">
+      <a href="/profile" class="nav-link">
+        <div class="w-6 h-6 rounded-full bg-gradient-to-br from-primary-400 to-primary-600 flex items-center justify-center text-white text-[10px] font-bold">
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+        </div>
         My Profile
       </a>
     </div>
   </aside>
 
   <!-- Main column -->
-  <div class="flex-1 flex flex-col min-w-0 lg:pl-60">
+  <div class="flex-1 flex flex-col min-w-0 lg:pl-[232px]">
 
     <!-- Top bar -->
-    <header class="sticky top-0 z-10 flex items-center gap-3 px-4 py-3 bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 shadow-sm">
+    <header class="sticky top-0 z-10 flex items-center gap-3 px-5 py-3 bg-white/80 dark:bg-[#0b0f17]/80 backdrop-blur-xl border-b border-slate-200/70 dark:border-slate-800/80">
       <!-- Mobile hamburger -->
       <button @click="$store.router.sidebarOpen = !$store.router.sidebarOpen"
-              class="lg:hidden p-1.5 rounded-md text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700">
+              class="lg:hidden p-1.5 rounded-md text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800">
         <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
       </button>
 
-      <h1 class="text-base font-semibold text-slate-800 dark:text-slate-200 capitalize"
-          x-text="$store.router.page === 'dashboard' ? 'Dashboard' : $store.router.page.replace(/-/g,' ')"></h1>
+      <div class="flex items-baseline gap-3">
+        <h1 class="text-[15px] font-bold text-slate-900 dark:text-slate-100 capitalize tracking-tight"
+            x-text="$store.router.page === 'dashboard' ? 'Dashboard' : $store.router.page.replace(/-/g,' ')"></h1>
+        <span class="hidden sm:inline text-[11px] font-medium text-slate-400 dark:text-slate-500 tracking-wider uppercase">Control Plane</span>
+      </div>
 
       <div class="flex-1"></div>
 
+      <!-- Live status -->
+      <div class="hidden md:flex items-center gap-2 px-2.5 py-1 rounded-md bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-200/50 dark:border-emerald-800/40">
+        <span class="pulse-dot"></span>
+        <span class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 tracking-wide">LIVE</span>
+      </div>
+
+      <!-- External quick-links -->
+      <a href="/metrics" target="_blank" class="hidden md:inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-mono text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors" title="Prometheus scrape endpoint">
+        <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+        /metrics
+      </a>
+
       <!-- Dark mode toggle -->
       <button @click="$store.theme.toggle()"
-              class="p-2 rounded-full text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+              class="p-2 rounded-md text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
               :title="$store.theme.isDark ? 'Switch to light mode' : 'Switch to dark mode'">
-        <svg x-show="!$store.theme.isDark" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
-        <svg x-show="$store.theme.isDark" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        <svg x-show="!$store.theme.isDark" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+        <svg x-show="$store.theme.isDark" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
       </button>
     </header>
 
     <!-- Page content -->
-    <main class="flex-1 overflow-auto p-5 space-y-5">
+    <main class="flex-1 overflow-auto p-5 space-y-5 surface-grid">
 
       <!-- ══ Dashboard ══════════════════════════════════════════════════ -->
       <div x-show="$store.router.page === 'dashboard'"
@@ -200,56 +326,128 @@
            x-init="init()"
            @navigate.away="destroy()">
 
+        <!-- Header strip -->
+        <div class="flex flex-wrap items-end justify-between gap-3 mb-5">
+          <div>
+            <h2 class="text-[22px] font-bold tracking-tight text-slate-900 dark:text-white leading-tight">Authorization Server Overview</h2>
+            <p class="text-[13px] text-slate-500 dark:text-slate-400 mt-1">Real-time health, issuance activity, and request latency across the control plane.</p>
+          </div>
+          <div class="flex items-center gap-2 text-[11px] text-slate-500 dark:text-slate-400 font-mono">
+            <span class="chip-live"><span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>auto-refresh 30s</span>
+          </div>
+        </div>
+
         <!-- Stat cards -->
         <div class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4 mb-5">
           <template x-if="loading">
-            <template x-for="i in 8" :key="i">
-              <div class="card p-5 animate-pulse h-28 bg-slate-200 dark:bg-slate-700 rounded-xl"></div>
+            <template x-for="i in 4" :key="i">
+              <div class="card p-5 animate-pulse h-[108px]">
+                <div class="h-3 bg-slate-200 dark:bg-slate-800 rounded w-1/3 mb-3"></div>
+                <div class="h-7 bg-slate-200 dark:bg-slate-800 rounded w-1/2 mb-2"></div>
+                <div class="h-2.5 bg-slate-200 dark:bg-slate-800 rounded w-2/3"></div>
+              </div>
             </template>
           </template>
           <template x-if="!loading && stats">
             <div class="contents">
-              <div class="stat-card border-primary-600">
-                <p class="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">Total Clients</p>
-                <p class="text-3xl font-bold text-primary-600 dark:text-primary-400" x-text="stats.total_clients"></p>
-                <p class="text-xs text-slate-400 mt-1" x-text="`${stats.public_clients} public · ${stats.confidential_clients} confidential`"></p>
+              <div class="stat-card stat-accent" style="--accent-from:#6366f1;--accent-to:#a855f7">
+                <div class="flex items-start justify-between">
+                  <p class="stat-label">Registered Clients</p>
+                  <svg class="w-4 h-4 text-primary-500/70" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2"/></svg>
+                </div>
+                <p class="stat-value text-primary-600 dark:text-primary-400 tabular mt-3" x-text="stats.total_clients"></p>
+                <p class="stat-foot">
+                  <span class="text-indigo-600 dark:text-indigo-400" x-text="stats.public_clients"></span> public
+                  <span class="text-slate-400 mx-1">·</span>
+                  <span class="text-slate-700 dark:text-slate-300" x-text="stats.confidential_clients"></span> confidential
+                </p>
               </div>
-              <div class="stat-card border-emerald-500">
-                <p class="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">Users</p>
-                <p class="text-3xl font-bold text-emerald-600 dark:text-emerald-400" x-text="stats.total_users"></p>
-                <p class="text-xs text-slate-400 mt-1" x-text="`${stats.enabled_users} enabled`"></p>
+
+              <div class="stat-card stat-accent" style="--accent-from:#10b981;--accent-to:#06b6d4">
+                <div class="flex items-start justify-between">
+                  <p class="stat-label">End Users</p>
+                  <svg class="w-4 h-4 text-emerald-500/70" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
+                </div>
+                <p class="stat-value text-emerald-600 dark:text-emerald-400 tabular mt-3" x-text="stats.total_users"></p>
+                <p class="stat-foot">
+                  <span class="text-emerald-600 dark:text-emerald-400" x-text="stats.enabled_users"></span> enabled
+                  <span class="text-slate-400 mx-1">·</span>
+                  <span x-text="stats.total_users - stats.enabled_users"></span> disabled
+                </p>
               </div>
-              <div class="stat-card border-blue-500">
-                <p class="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">Active Tokens</p>
-                <p class="text-3xl font-bold text-blue-600 dark:text-blue-400" x-text="stats.active_tokens"></p>
-                <p class="text-xs text-slate-400 mt-1" x-text="`${stats.total_tokens} total · ${stats.revoked_tokens} revoked`"></p>
+
+              <div class="stat-card stat-accent" style="--accent-from:#06b6d4;--accent-to:#6366f1">
+                <div class="flex items-start justify-between">
+                  <p class="stat-label">Active Tokens</p>
+                  <svg class="w-4 h-4 text-cyan-500/70" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 11-7.778 7.778 5.5 5.5 0 017.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+                </div>
+                <p class="stat-value text-cyan-600 dark:text-cyan-400 tabular mt-3" x-text="stats.active_tokens"></p>
+                <p class="stat-foot">
+                  <span x-text="stats.total_tokens"></span> issued
+                  <span class="text-slate-400 mx-1">·</span>
+                  <span class="text-rose-600 dark:text-rose-400" x-text="stats.revoked_tokens"></span> revoked
+                </p>
               </div>
-              <div class="stat-card" :class="stats.pending_device_codes > 0 ? 'border-amber-500' : 'border-slate-300 dark:border-slate-600'">
-                <p class="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">Pending Devices</p>
-                <p class="text-3xl font-bold" :class="stats.pending_device_codes > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-slate-600 dark:text-slate-300'" x-text="stats.pending_device_codes"></p>
-                <p class="text-xs text-slate-400 mt-1">awaiting user verification</p>
+
+              <div class="stat-card stat-accent"
+                   :style="stats.pending_device_codes > 0 ? '--accent-from:#f59e0b;--accent-to:#f43f5e' : '--accent-from:#64748b;--accent-to:#94a3b8'">
+                <div class="flex items-start justify-between">
+                  <p class="stat-label">Device Authorizations</p>
+                  <svg class="w-4 h-4 text-amber-500/70" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><rect x="5" y="2" width="14" height="20" rx="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg>
+                </div>
+                <p class="stat-value tabular mt-3"
+                   :class="stats.pending_device_codes > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-slate-700 dark:text-slate-300'"
+                   x-text="stats.pending_device_codes"></p>
+                <p class="stat-foot">awaiting user verification</p>
               </div>
             </div>
           </template>
         </div>
 
-        <!-- Charts grid -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
-          <div class="card p-5">
-            <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">Token Activity</h3>
-            <canvas id="tokenChart" class="max-h-48"></canvas>
+        <!-- Charts grid — 2×2 with subtle hover lift -->
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div class="card p-5 hover:shadow-ring transition-shadow">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-[13px] font-bold text-slate-800 dark:text-slate-200 tracking-tight">Token Activity</h3>
+                <p class="text-[11px] text-slate-500 dark:text-slate-500 mt-0.5">Cumulative issuance vs revocation</p>
+              </div>
+              <span class="badge-blue">counter</span>
+            </div>
+            <div class="chart-box"><canvas id="tokenChart"></canvas></div>
           </div>
-          <div class="card p-5">
-            <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">HTTP Status Distribution</h3>
-            <canvas id="requestChart" class="max-h-48"></canvas>
+
+          <div class="card p-5 hover:shadow-ring transition-shadow">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-[13px] font-bold text-slate-800 dark:text-slate-200 tracking-tight">HTTP Response Classes</h3>
+                <p class="text-[11px] text-slate-500 dark:text-slate-500 mt-0.5">Success / client error / server error</p>
+              </div>
+              <span class="badge-blue">ratio</span>
+            </div>
+            <div class="chart-box"><canvas id="requestChart"></canvas></div>
           </div>
-          <div class="card p-5">
-            <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">Response Latency</h3>
-            <canvas id="latencyChart" class="max-h-48"></canvas>
+
+          <div class="card p-5 hover:shadow-ring transition-shadow">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-[13px] font-bold text-slate-800 dark:text-slate-200 tracking-tight">Request Latency Distribution</h3>
+                <p class="text-[11px] text-slate-500 dark:text-slate-500 mt-0.5">Estimated from histogram buckets · <span class="font-mono">ms</span></p>
+              </div>
+              <span class="badge-gray">histogram</span>
+            </div>
+            <div class="chart-box"><canvas id="latencyChart"></canvas></div>
           </div>
-          <div class="card p-5">
-            <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">Resilience Events</h3>
-            <canvas id="resilienceChart" class="max-h-48"></canvas>
+
+          <div class="card p-5 hover:shadow-ring transition-shadow">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-[13px] font-bold text-slate-800 dark:text-slate-200 tracking-tight">Resilience Events</h3>
+                <p class="text-[11px] text-slate-500 dark:text-slate-500 mt-0.5">Rate-limit, circuit breaker, back-pressure</p>
+              </div>
+              <span class="badge-yellow">resilience</span>
+            </div>
+            <div class="chart-box"><canvas id="resilienceChart"></canvas></div>
           </div>
         </div>
       </div>
@@ -617,46 +815,111 @@
            x-init="init()"
            @navigate.away="destroy()">
 
-        <!-- Gauge cards -->
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-5">
-          <div class="stat-card border-primary-600">
-            <p class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Active Tokens</p>
-            <p class="text-2xl font-bold text-primary-600 dark:text-primary-400" x-text="scalar('oauth2_server_oauth_active_tokens')"></p>
+        <!-- Header strip -->
+        <div class="flex flex-wrap items-end justify-between gap-3 mb-5">
+          <div>
+            <h2 class="text-[22px] font-bold tracking-tight text-slate-900 dark:text-white leading-tight">Telemetry</h2>
+            <p class="text-[13px] text-slate-500 dark:text-slate-400 mt-1">Prometheus scrape at <code class="text-[11px] text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded">/metrics</code> — live computed latency quantiles from histogram buckets.</p>
           </div>
-          <div class="stat-card border-emerald-500">
-            <p class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Tokens Issued</p>
-            <p class="text-2xl font-bold text-emerald-600 dark:text-emerald-400" x-text="scalar('oauth2_server_oauth_token_issued_total')"></p>
-          </div>
-          <div class="stat-card border-red-500">
-            <p class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Failed Auths</p>
-            <p class="text-2xl font-bold text-red-600 dark:text-red-400" x-text="scalar('oauth2_server_oauth_failed_authentications')"></p>
-          </div>
-          <div class="stat-card border-violet-500">
-            <p class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">In-flight Requests</p>
-            <p class="text-2xl font-bold text-violet-600 dark:text-violet-400" x-text="scalar('oauth2_server_concurrent_requests_in_flight')"></p>
+          <div class="flex items-center gap-2">
+            <span class="chip-live"><span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>auto-refresh 15s</span>
           </div>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
-          <div class="card p-5">
-            <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">Auth Activity</h3>
-            <canvas id="m-tokens" class="max-h-52"></canvas>
+        <!-- Gauge tiles -->
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+          <div class="stat-card stat-accent" style="--accent-from:#6366f1;--accent-to:#a855f7">
+            <p class="stat-label">Active Tokens</p>
+            <p class="stat-value text-primary-600 dark:text-primary-400 tabular mt-2" x-text="scalar('oauth2_server_oauth_active_tokens')"></p>
+            <p class="stat-foot">current gauge</p>
           </div>
-          <div class="card p-5">
-            <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">HTTP Latency</h3>
-            <canvas id="m-latency" class="max-h-52"></canvas>
+          <div class="stat-card stat-accent" style="--accent-from:#10b981;--accent-to:#06b6d4">
+            <p class="stat-label">Tokens Issued</p>
+            <p class="stat-value text-emerald-600 dark:text-emerald-400 tabular mt-2" x-text="scalar('oauth2_server_oauth_token_issued_total')"></p>
+            <p class="stat-foot">lifetime counter</p>
           </div>
-          <div class="card p-5">
-            <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">DB Query Latency</h3>
-            <canvas id="m-db" class="max-h-52"></canvas>
+          <div class="stat-card stat-accent" style="--accent-from:#f43f5e;--accent-to:#f59e0b">
+            <p class="stat-label">Failed Auths</p>
+            <p class="stat-value text-rose-600 dark:text-rose-400 tabular mt-2" x-text="scalar('oauth2_server_oauth_failed_authentications')"></p>
+            <p class="stat-foot">401 + invalid_grant</p>
           </div>
-          <div class="card p-5">
-            <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">Resilience Events</h3>
-            <canvas id="m-resilience" class="max-h-52"></canvas>
+          <div class="stat-card stat-accent" style="--accent-from:#a855f7;--accent-to:#6366f1">
+            <p class="stat-label">In-flight Requests</p>
+            <p class="stat-value text-violet-600 dark:text-violet-400 tabular mt-2" x-text="scalar('oauth2_server_concurrent_requests_in_flight')"></p>
+            <p class="stat-foot">concurrency gauge</p>
           </div>
         </div>
 
-        <p class="text-xs text-slate-400 mt-3 text-right">Live from <code>/metrics</code> · auto-refreshes every 15s</p>
+        <!-- Latency quantile strip — show p50/p95/p99 as numeric pills -->
+        <div class="card p-5 mb-4">
+          <div class="flex items-center justify-between mb-4">
+            <div>
+              <h3 class="text-[13px] font-bold text-slate-800 dark:text-slate-200 tracking-tight">Request Latency Quantiles</h3>
+              <p class="text-[11px] text-slate-500 dark:text-slate-500 mt-0.5">Linear interpolation across histogram <code class="font-mono text-[10px]">_bucket</code> series</p>
+            </div>
+            <span class="badge-blue">HTTP</span>
+          </div>
+          <div class="grid grid-cols-3 gap-3 font-mono">
+            <template x-for="(q, i) in [0.5, 0.95, 0.99]" :key="q">
+              <div class="rounded-md border border-slate-200 dark:border-slate-800 p-3 bg-slate-50/60 dark:bg-slate-900/40">
+                <div class="flex items-baseline justify-between">
+                  <span class="text-[11px] font-bold tracking-wide uppercase"
+                        :class="['text-cyan-600 dark:text-cyan-400','text-indigo-600 dark:text-indigo-400','text-violet-600 dark:text-violet-400'][i]"
+                        x-text="'p' + (q * 100)"></span>
+                  <span class="text-[10px] text-slate-400">ms</span>
+                </div>
+                <div class="text-xl font-bold text-slate-900 dark:text-slate-100 tabular mt-1"
+                     x-text="(hq('oauth2_server_http_request_duration_seconds', q) * 1000).toFixed(1)"></div>
+              </div>
+            </template>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div class="card p-5 hover:shadow-ring transition-shadow">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-[13px] font-bold text-slate-800 dark:text-slate-200 tracking-tight">Auth Activity</h3>
+                <p class="text-[11px] text-slate-500 dark:text-slate-500 mt-0.5">Token lifecycle counters</p>
+              </div>
+              <span class="badge-blue">counter</span>
+            </div>
+            <div class="chart-box"><canvas id="m-tokens"></canvas></div>
+          </div>
+
+          <div class="card p-5 hover:shadow-ring transition-shadow">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-[13px] font-bold text-slate-800 dark:text-slate-200 tracking-tight">HTTP Latency</h3>
+                <p class="text-[11px] text-slate-500 dark:text-slate-500 mt-0.5">Request-duration quantiles · <span class="font-mono">ms</span></p>
+              </div>
+              <span class="badge-gray">histogram</span>
+            </div>
+            <div class="chart-box"><canvas id="m-latency"></canvas></div>
+          </div>
+
+          <div class="card p-5 hover:shadow-ring transition-shadow">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-[13px] font-bold text-slate-800 dark:text-slate-200 tracking-tight">DB Query Latency</h3>
+                <p class="text-[11px] text-slate-500 dark:text-slate-500 mt-0.5">Storage-layer query duration · <span class="font-mono">ms</span></p>
+              </div>
+              <span class="badge-gray">histogram</span>
+            </div>
+            <div class="chart-box"><canvas id="m-db"></canvas></div>
+          </div>
+
+          <div class="card p-5 hover:shadow-ring transition-shadow">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-[13px] font-bold text-slate-800 dark:text-slate-200 tracking-tight">Resilience Events</h3>
+                <p class="text-[11px] text-slate-500 dark:text-slate-500 mt-0.5">Rate-limit, CB trips, back-pressure, in-flight</p>
+              </div>
+              <span class="badge-yellow">resilience</span>
+            </div>
+            <div class="chart-box"><canvas id="m-resilience"></canvas></div>
+          </div>
+        </div>
       </div>
 
       <!-- ══ Events ══════════════════════════════════════════════════════ -->
@@ -718,12 +981,16 @@
     </main><!-- /main -->
 
     <!-- Footer -->
-    <footer class="px-5 py-3 text-xs text-slate-400 border-t border-slate-200 dark:border-slate-700 flex items-center justify-between">
-      <span>OAuth2 Server</span>
-      <span class="flex gap-4">
-        <a href="/health" target="_blank" class="hover:text-primary-600">Health</a>
-        <a href="/ready" target="_blank" class="hover:text-primary-600">Ready</a>
-        <a href="/metrics" target="_blank" class="hover:text-primary-600">Metrics</a>
+    <footer class="px-5 py-3 text-[11px] text-slate-400 dark:text-slate-500 border-t border-slate-200/70 dark:border-slate-800/80 flex items-center justify-between bg-white/60 dark:bg-[#0b0f17]/60 backdrop-blur-sm">
+      <span class="flex items-center gap-2 font-mono">
+        <span class="pulse-dot" style="width:6px;height:6px;"></span>
+        oauth2-server
+      </span>
+      <span class="flex gap-4 font-mono">
+        <a href="/health" target="_blank" class="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">/health</a>
+        <a href="/ready" target="_blank" class="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">/ready</a>
+        <a href="/metrics" target="_blank" class="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">/metrics</a>
+        <a href="/.well-known/openid-configuration" target="_blank" class="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">/.well-known</a>
       </span>
     </footer>
   </div><!-- /main column -->


### PR DESCRIPTION
## Summary

- **Fix:** Latency charts (Dashboard + Metrics) now populate. Prior code queried histogram `quantile` labels that Prometheus `Histogram` never emits — charts rendered blank. Replaced with client-side quantile computation via linear interpolation across `_bucket{le=\"…\"}` series.
- **Design refresh:** Manrope + JetBrains Mono typography, indigo primary with accent palette, gradient-accent stat cards, chart-card headers with metric-type badges, new latency quantile pill strip on Metrics page, backdrop-blur topbar with live-status pulse, refined sidebar.
- **Component layer fix:** Moved `@apply` component rules into `<style type=\"text/tailwindcss\">` so the Play CDN actually compiles them — `.card`, `.btn`, `.badge`, etc. were previously unstyled.

## Files

- `static/js/admin.js` — `histogramQuantile()` helper, shared chart `baseChartOpts()`, refreshed styling across dashboard + metrics charts
- `templates/admin_dashboard.html` — full design refresh, Google Fonts import, new component layer

## Test plan

- [ ] Rebuild / restart server and visit `/admin` as an admin user
- [ ] Confirm stat cards show gradient accent stripe + tabular-num values
- [ ] Confirm Dashboard → Response Latency chart populates with p50/p95/p99 bars
- [ ] Confirm Metrics → HTTP Latency + DB Query Latency charts populate
- [ ] Confirm Metrics → Request Latency Quantiles tile strip shows live ms values
- [ ] Confirm dark-mode toggle still works
- [ ] Confirm nav links, drawers (Clients/Tokens), and key-rotation modal still function
- [ ] Confirm no CSP violations in the browser console (fonts.googleapis.com + fonts.gstatic.com already allow-listed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)