### PR TITLE
fix(admin): resolve runtime errors breaking admin dashboard UI

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -790,7 +790,7 @@ function metricsPage() {
 
 function eventsPage() {
   return {
-    ...makeGrid('/events/admin/recent', 'created_at', 'desc'),
+    ...makeGrid('/admin/api/events/recent', 'created_at', 'desc'),
     pluginHealth: null,
 
     async init() {

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -10,7 +10,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 
-  <!-- Tailwind CSS (Play CDN) -->
+  <!-- Tailwind CSS (Play CDN) — config MUST come after CDN load -->
+  <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
       darkMode: 'class',
@@ -24,7 +25,7 @@
             primary: {
               50:'#eef2ff',100:'#e0e7ff',200:'#c7d2fe',300:'#a5b4fc',
               400:'#818cf8',500:'#6366f1',600:'#4f46e5',700:'#4338ca',
-              800:'#3730a3',900:'#312e81',
+              800:'#3730a3',900:'#312e81',950:'#1e1b4b',
             },
             surface: {
               light: '#fafbfc',
@@ -43,7 +44,6 @@
       },
     };
   </script>
-  <script src="https://cdn.tailwindcss.com"></script>
 
   <!-- Alpine.js -->
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"
@@ -487,8 +487,8 @@
                 </tr>
               </thead>
               <tbody>
-                <template x-if="loading">
-                  <tr x-for="i in 5" :key="i">
+                <template x-for="i in (loading ? [1,2,3,4,5] : [])" :key="i">
+                  <tr>
                     <td colspan="6" class="table-cell">
                       <div class="h-4 bg-slate-200 dark:bg-slate-700 rounded animate-pulse"></div>
                     </td>


### PR DESCRIPTION
## Summary
Three runtime bugs kept the refreshed admin UI from rendering on production (`roauth2.cat-herding.net`):

- **Tailwind Play CDN config ordering** — `tailwind.config = {...}` ran before the CDN script loaded, so custom `primary` palette + `shadow-soft`/`shadow-ring` never registered. Moved config after CDN load per [Play CDN docs](https://tailwindcss.com/docs/installation/play-cdn#customizing-your-configuration). Also added `primary-950` (used by dark mode `nav-link-active`).
- **`<tr x-for="i in 5">`** — Alpine's `x-for` only works on `<template>` elements. Threw `Failed to execute 'importNode' on 'Document': parameter 1 is not of type 'Node'`. Rewrote loading skeleton as `<template x-for="i in (loading ? [1..5] : [])">`.
- **Events page 404** — `admin.js` called `/events/admin/recent`, but the backend route is `/admin/api/events/recent`.

## Test plan
- [x] Build passes (`cargo build --bin rust_oauth2_server`)
- [x] Local server + Playwright: 0 console errors on `/admin`, `/admin/metrics`, `/admin/events`
- [x] Latency quantiles populate from histogram buckets (p50=2.7ms, p95=7.7ms, p99=22.2ms after test traffic)
- [x] Events bus health + recent events grid render (empty state renders cleanly)
- [ ] Verify on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)