### PR TITLE
feat(admin): maintainer CRUD, denylist, audit log (V17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ reports/
 __pycache__/
 *.db
 .prod.env
+
+# Local screenshots + playwright traces (not committed)
+.playwright-mcp/
+admin-*.png

--- a/crates/oauth2-actix/src/handlers/admin.rs
+++ b/crates/oauth2-actix/src/handlers/admin.rs
@@ -412,13 +412,23 @@ pub struct Capabilities {
     pub events: bool,
     pub device_flow: bool,
     pub key_rotation: bool,
+    pub user_crud: bool,
+    pub client_crud: bool,
+    pub denylist: bool,
+    pub audit_log: bool,
+    pub bulk_revoke: bool,
 }
 
 pub async fn capabilities() -> Result<HttpResponse> {
     Ok(HttpResponse::Ok().json(Capabilities {
-        events: true, // events handler is always compiled in
+        events: true,
         device_flow: true,
         key_rotation: true,
+        user_crud: true,
+        client_crud: true,
+        denylist: true,
+        audit_log: true,
+        bulk_revoke: true,
     }))
 }
 

--- a/crates/oauth2-actix/src/handlers/admin_extra.rs
+++ b/crates/oauth2-actix/src/handlers/admin_extra.rs
@@ -1,0 +1,870 @@
+//! Extended admin handlers: user CRUD, client CRUD extensions,
+//! denylist management, audit log, and bulk token operations.
+
+use actix_session::SessionExt;
+use actix_web::{web, HttpRequest, HttpResponse, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use oauth2_core::{
+    AuditLogEntry, Client, ClientRegistration, DenylistEntry, ListQuery, Page, User,
+};
+use oauth2_ports::DynStorage;
+
+use super::login::hash_password;
+
+// --- Audit helper -----------------------------------------------------------
+
+/// Build an `AuditLogEntry` seeded from the request (session actor, IP, UA).
+pub fn build_audit(
+    req: &HttpRequest,
+    action: &str,
+    target_kind: &str,
+    target_id: &str,
+    metadata: serde_json::Value,
+) -> AuditLogEntry {
+    let session = req.get_session();
+    let actor_id: String = session.get("user_id").unwrap_or(None).unwrap_or_default();
+    let actor_email: String = session.get("email").unwrap_or(None).unwrap_or_default();
+    let ip = req
+        .connection_info()
+        .realip_remote_addr()
+        .unwrap_or("")
+        .to_string();
+    let user_agent = req
+        .headers()
+        .get("User-Agent")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    AuditLogEntry::new(&actor_id, &actor_email, action)
+        .with_target(target_kind, target_id)
+        .with_request_meta(&ip, &user_agent)
+        .with_metadata_json(metadata)
+}
+
+/// Write an audit log entry. Errors are logged but never surfaced to the caller —
+/// audit failures must not block the original admin action.
+async fn record_audit(db: &DynStorage, entry: AuditLogEntry) {
+    if let Err(e) = db.write_audit_log(&entry).await {
+        tracing::warn!(error = %e, action = %entry.action, "Failed to write audit log");
+    }
+}
+
+// --- User CRUD --------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct CreateUserRequest {
+    pub username: String,
+    pub email: String,
+    pub password: String,
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+#[derive(Serialize)]
+pub struct UserResponse {
+    pub id: String,
+    pub username: String,
+    pub email: String,
+    pub role: String,
+    pub enabled: bool,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<User> for UserResponse {
+    fn from(u: User) -> Self {
+        Self {
+            id: u.id,
+            username: u.username,
+            email: u.email,
+            role: u.role,
+            enabled: u.enabled,
+            created_at: u.created_at.to_rfc3339(),
+            updated_at: u.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+pub async fn create_user(
+    req: HttpRequest,
+    db: web::Data<DynStorage>,
+    body: web::Json<CreateUserRequest>,
+) -> Result<HttpResponse> {
+    let CreateUserRequest {
+        username,
+        email,
+        password,
+        role,
+        enabled,
+    } = body.into_inner();
+
+    if username.is_empty() || email.is_empty() || password.is_empty() {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "invalid_request",
+            "error_description": "username, email, password are required"
+        })));
+    }
+
+    if let Ok(Some(_)) = db.get_user_by_username(&username).await {
+        return Ok(HttpResponse::Conflict().json(serde_json::json!({
+            "error": "already_exists",
+            "error_description": "username already registered"
+        })));
+    }
+
+    let hash = hash_password(&password).map_err(|e| {
+        tracing::error!(error = %e, "hash_password failed");
+        actix_web::error::ErrorInternalServerError("failed to hash password")
+    })?;
+
+    let mut user = User::new(username, hash, email);
+    if let Some(r) = role {
+        if r == "admin" || r == "user" {
+            user.role = r;
+        }
+    }
+    if let Some(e) = enabled {
+        user.enabled = e;
+    }
+
+    db.save_user(&user)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let audit = build_audit(
+        &req,
+        "user.create",
+        "user",
+        &user.id,
+        serde_json::json!({
+            "username": user.username,
+            "email": user.email,
+            "role": user.role,
+            "enabled": user.enabled,
+        }),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Created().json(UserResponse::from(user)))
+}
+
+#[derive(Deserialize)]
+pub struct UpdateUserRequest {
+    #[serde(default)]
+    pub email: Option<String>,
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+pub async fn update_user(
+    req: HttpRequest,
+    path: web::Path<String>,
+    db: web::Data<DynStorage>,
+    body: web::Json<UpdateUserRequest>,
+) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+    let mut user = match db
+        .get_user_by_id(&user_id)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?
+    {
+        None => {
+            return Ok(
+                HttpResponse::NotFound().json(serde_json::json!({ "error": "user not found" }))
+            )
+        }
+        Some(u) => u,
+    };
+
+    if let Some(e) = &body.email {
+        user.email = e.clone();
+    }
+    if let Some(r) = &body.role {
+        if r == "admin" || r == "user" {
+            user.role = r.clone();
+        }
+    }
+    if let Some(en) = body.enabled {
+        user.enabled = en;
+    }
+    user.updated_at = Utc::now();
+
+    db.update_user(&user)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let audit = build_audit(
+        &req,
+        "user.update",
+        "user",
+        &user.id,
+        serde_json::json!({
+            "email": body.email,
+            "role": body.role,
+            "enabled": body.enabled,
+        }),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(UserResponse::from(user)))
+}
+
+pub async fn delete_user(
+    req: HttpRequest,
+    path: web::Path<String>,
+    db: web::Data<DynStorage>,
+) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+    if db
+        .get_user_by_id(&user_id)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?
+        .is_none()
+    {
+        return Ok(HttpResponse::NotFound().json(serde_json::json!({ "error": "user not found" })));
+    }
+    db.delete_user(&user_id)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+    let _ = db.revoke_tokens_by_user_id(&user_id).await;
+
+    let audit = build_audit(&req, "user.delete", "user", &user_id, serde_json::json!({}));
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "message": "User deleted" })))
+}
+
+#[derive(Deserialize)]
+pub struct SetEnabledRequest {
+    pub enabled: bool,
+}
+
+pub async fn set_user_enabled(
+    req: HttpRequest,
+    path: web::Path<String>,
+    db: web::Data<DynStorage>,
+    body: web::Json<SetEnabledRequest>,
+) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+    db.set_user_enabled(&user_id, body.enabled)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+    if !body.enabled {
+        let _ = db.revoke_tokens_by_user_id(&user_id).await;
+    }
+
+    let audit = build_audit(
+        &req,
+        if body.enabled {
+            "user.enable"
+        } else {
+            "user.disable"
+        },
+        "user",
+        &user_id,
+        serde_json::json!({ "enabled": body.enabled }),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "enabled": body.enabled })))
+}
+
+#[derive(Deserialize)]
+pub struct SetRoleRequest {
+    pub role: String,
+}
+
+pub async fn set_user_role(
+    req: HttpRequest,
+    path: web::Path<String>,
+    db: web::Data<DynStorage>,
+    body: web::Json<SetRoleRequest>,
+) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+    let role = body.role.clone();
+    if role != "admin" && role != "user" {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "invalid_request",
+            "error_description": "role must be 'admin' or 'user'"
+        })));
+    }
+    db.set_user_role(&user_id, &role)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let audit = build_audit(
+        &req,
+        "user.set_role",
+        "user",
+        &user_id,
+        serde_json::json!({ "role": role }),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "role": role })))
+}
+
+#[derive(Deserialize)]
+pub struct ResetPasswordRequest {
+    pub password: String,
+}
+
+pub async fn reset_user_password(
+    req: HttpRequest,
+    path: web::Path<String>,
+    db: web::Data<DynStorage>,
+    body: web::Json<ResetPasswordRequest>,
+) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+    if body.password.len() < 8 {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "weak_password",
+            "error_description": "password must be at least 8 characters"
+        })));
+    }
+    let hash = hash_password(&body.password).map_err(|e| {
+        tracing::error!(error = %e, "hash_password failed");
+        actix_web::error::ErrorInternalServerError("failed to hash password")
+    })?;
+    db.set_user_password_hash(&user_id, &hash)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+    let _ = db.revoke_tokens_by_user_id(&user_id).await;
+
+    let audit = build_audit(
+        &req,
+        "user.reset_password",
+        "user",
+        &user_id,
+        serde_json::json!({}),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "message": "Password reset" })))
+}
+
+// --- Client CRUD extensions -------------------------------------------------
+
+/// Full client create payload (admin). Mirrors RFC 7591 client registration
+/// but lets admins set arbitrary fields including `client_id`/`client_secret`.
+#[derive(Deserialize)]
+pub struct CreateClientRequest {
+    pub name: String,
+    #[serde(default)]
+    pub client_id: Option<String>,
+    #[serde(default)]
+    pub client_secret: Option<String>,
+    #[serde(default)]
+    pub redirect_uris: Vec<String>,
+    #[serde(default)]
+    pub grant_types: Vec<String>,
+    #[serde(default)]
+    pub scope: String,
+    #[serde(default = "default_auth_method")]
+    pub token_endpoint_auth_method: String,
+}
+
+fn default_auth_method() -> String {
+    "client_secret_basic".to_string()
+}
+
+pub async fn create_client(
+    req: HttpRequest,
+    db: web::Data<DynStorage>,
+    body: web::Json<CreateClientRequest>,
+) -> Result<HttpResponse> {
+    let body = body.into_inner();
+    if body.name.is_empty() {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "invalid_request",
+            "error_description": "name is required"
+        })));
+    }
+
+    let client_id = body
+        .client_id
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| format!("client-{}", &Uuid::new_v4().to_string()[..12]));
+    let is_public = body.token_endpoint_auth_method == "none";
+    let client_secret = if is_public {
+        String::new()
+    } else {
+        body.client_secret
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| Uuid::new_v4().to_string().replace('-', ""))
+    };
+    let grant_types = if body.grant_types.is_empty() {
+        vec![
+            "authorization_code".to_string(),
+            "refresh_token".to_string(),
+        ]
+    } else {
+        body.grant_types
+    };
+
+    let mut client = Client::new(
+        client_id.clone(),
+        client_secret,
+        body.redirect_uris,
+        grant_types,
+        body.scope,
+        body.name.clone(),
+    );
+    client.token_endpoint_auth_method = body.token_endpoint_auth_method;
+    // Preserve the ClientRegistrationResponse shape consumers rely on.
+    let _ = ClientRegistration {
+        client_name: body.name,
+        redirect_uris: client.get_redirect_uris(),
+        grant_types: client.get_grant_types(),
+        scope: client.scope.clone(),
+        token_endpoint_auth_method: client.token_endpoint_auth_method.clone(),
+        response_types: client.get_response_types(),
+        contacts: vec![],
+        logo_uri: None,
+        client_uri: None,
+        policy_uri: None,
+        tos_uri: None,
+        jwks: None,
+        jwks_uri: None,
+        backchannel_logout_uri: None,
+        backchannel_logout_session_required: None,
+        frontchannel_logout_uri: None,
+        frontchannel_logout_session_required: None,
+        post_logout_redirect_uris: None,
+    };
+
+    db.save_client(&client)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let audit = build_audit(
+        &req,
+        "client.create",
+        "client",
+        &client.client_id,
+        serde_json::json!({
+            "name": client.name,
+            "token_endpoint_auth_method": client.token_endpoint_auth_method,
+            "grant_types": client.get_grant_types(),
+        }),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    // Return secret exactly once on creation.
+    Ok(HttpResponse::Created().json(serde_json::json!({
+        "id": client.id,
+        "client_id": client.client_id,
+        "client_secret": if client.is_public() { None } else { Some(client.client_secret.clone()) },
+        "name": client.name,
+        "redirect_uris": client.get_redirect_uris(),
+        "grant_types": client.get_grant_types(),
+        "scope": client.scope,
+        "token_endpoint_auth_method": client.token_endpoint_auth_method,
+        "enabled": client.enabled,
+        "created_at": client.created_at.to_rfc3339(),
+    })))
+}
+
+#[derive(Deserialize)]
+pub struct UpdateClientRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub redirect_uris: Option<Vec<String>>,
+    #[serde(default)]
+    pub grant_types: Option<Vec<String>>,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub token_endpoint_auth_method: Option<String>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+/// PUT /admin/api/clients/{id} — id is the internal uuid.
+pub async fn update_client(
+    req: HttpRequest,
+    path: web::Path<String>,
+    db: web::Data<DynStorage>,
+    body: web::Json<UpdateClientRequest>,
+) -> Result<HttpResponse> {
+    let id = path.into_inner();
+    let all = db
+        .list_all_clients()
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+    let mut client = match all.into_iter().find(|c| c.id == id) {
+        None => {
+            return Ok(
+                HttpResponse::NotFound().json(serde_json::json!({ "error": "client not found" }))
+            )
+        }
+        Some(c) => c,
+    };
+
+    if let Some(name) = &body.name {
+        client.name = name.clone();
+    }
+    if let Some(uris) = &body.redirect_uris {
+        client.redirect_uris = serde_json::to_string(uris).unwrap_or_else(|_| "[]".to_string());
+    }
+    if let Some(gts) = &body.grant_types {
+        client.grant_types = serde_json::to_string(gts).unwrap_or_else(|_| "[]".to_string());
+    }
+    if let Some(scope) = &body.scope {
+        client.scope = scope.clone();
+    }
+    if let Some(method) = &body.token_endpoint_auth_method {
+        client.token_endpoint_auth_method = method.clone();
+    }
+    if let Some(en) = body.enabled {
+        client.enabled = en;
+    }
+    client.updated_at = Utc::now();
+
+    db.update_client(&client)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let audit = build_audit(
+        &req,
+        "client.update",
+        "client",
+        &client.client_id,
+        serde_json::json!({
+            "name": body.name,
+            "enabled": body.enabled,
+        }),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "id": client.id,
+        "client_id": client.client_id,
+        "name": client.name,
+        "enabled": client.enabled,
+        "updated_at": client.updated_at.to_rfc3339(),
+    })))
+}
+
+pub async fn set_client_enabled(
+    req: HttpRequest,
+    path: web::Path<String>,
+    db: web::Data<DynStorage>,
+    body: web::Json<SetEnabledRequest>,
+) -> Result<HttpResponse> {
+    // Resolve internal id → client_id (same pattern as delete_client).
+    let all = db
+        .list_all_clients()
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+    let target = match all.into_iter().find(|c| c.id == *path) {
+        None => {
+            return Ok(
+                HttpResponse::NotFound().json(serde_json::json!({ "error": "client not found" }))
+            )
+        }
+        Some(c) => c,
+    };
+    db.set_client_enabled(&target.client_id, body.enabled)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+    if !body.enabled {
+        let _ = db.revoke_tokens_by_client_id(&target.client_id).await;
+    }
+
+    let audit = build_audit(
+        &req,
+        if body.enabled {
+            "client.enable"
+        } else {
+            "client.disable"
+        },
+        "client",
+        &target.client_id,
+        serde_json::json!({ "enabled": body.enabled }),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "enabled": body.enabled })))
+}
+
+pub async fn regenerate_client_secret(
+    req: HttpRequest,
+    path: web::Path<String>,
+    db: web::Data<DynStorage>,
+) -> Result<HttpResponse> {
+    let all = db
+        .list_all_clients()
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+    let target = match all.into_iter().find(|c| c.id == *path) {
+        None => {
+            return Ok(
+                HttpResponse::NotFound().json(serde_json::json!({ "error": "client not found" }))
+            )
+        }
+        Some(c) => c,
+    };
+    if target.is_public() {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "invalid_request",
+            "error_description": "public clients have no secret"
+        })));
+    }
+    let new_secret = Uuid::new_v4().to_string().replace('-', "");
+    db.set_client_secret(&target.client_id, &new_secret)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let audit = build_audit(
+        &req,
+        "client.regenerate_secret",
+        "client",
+        &target.client_id,
+        serde_json::json!({}),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "client_id": target.client_id,
+        "client_secret": new_secret,
+    })))
+}
+
+// --- Bulk token operations --------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct BulkRevokeByUserRequest {
+    pub user_id: String,
+}
+
+pub async fn bulk_revoke_by_user(
+    req: HttpRequest,
+    db: web::Data<DynStorage>,
+    body: web::Json<BulkRevokeByUserRequest>,
+) -> Result<HttpResponse> {
+    let count = db
+        .revoke_tokens_by_user_id(&body.user_id)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let audit = build_audit(
+        &req,
+        "token.bulk_revoke_by_user",
+        "user",
+        &body.user_id,
+        serde_json::json!({ "revoked": count }),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "revoked": count })))
+}
+
+#[derive(Deserialize)]
+pub struct BulkRevokeByClientRequest {
+    pub client_id: String,
+}
+
+pub async fn bulk_revoke_by_client(
+    req: HttpRequest,
+    db: web::Data<DynStorage>,
+    body: web::Json<BulkRevokeByClientRequest>,
+) -> Result<HttpResponse> {
+    let count = db
+        .revoke_tokens_by_client_id(&body.client_id)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let audit = build_audit(
+        &req,
+        "token.bulk_revoke_by_client",
+        "client",
+        &body.client_id,
+        serde_json::json!({ "revoked": count }),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "revoked": count })))
+}
+
+// --- Denylist ---------------------------------------------------------------
+
+const ALLOWED_DENYLIST_KINDS: &[&str] = &["ip", "user_id", "username", "email", "client_id"];
+
+#[derive(Deserialize)]
+pub struct AddDenylistRequest {
+    pub kind: String,
+    pub value: String,
+    #[serde(default)]
+    pub reason: String,
+    #[serde(default)]
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Serialize)]
+pub struct DenylistResponse {
+    pub id: String,
+    pub kind: String,
+    pub value: String,
+    pub reason: String,
+    pub created_by: String,
+    pub created_at: String,
+    pub expires_at: Option<String>,
+    pub active: bool,
+}
+
+impl From<DenylistEntry> for DenylistResponse {
+    fn from(e: DenylistEntry) -> Self {
+        let active = e.is_active();
+        Self {
+            id: e.id,
+            kind: e.kind,
+            value: e.value,
+            reason: e.reason,
+            created_by: e.created_by,
+            created_at: e.created_at.to_rfc3339(),
+            expires_at: e.expires_at.map(|d| d.to_rfc3339()),
+            active,
+        }
+    }
+}
+
+pub async fn list_denylist(
+    db: web::Data<DynStorage>,
+    query: web::Query<ListQuery>,
+) -> Result<HttpResponse> {
+    let page = db
+        .list_denylist(&query)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let items: Vec<DenylistResponse> = page.items.into_iter().map(DenylistResponse::from).collect();
+
+    Ok(HttpResponse::Ok().json(Page::new(items, page.total, page.limit, page.offset)))
+}
+
+pub async fn add_denylist(
+    req: HttpRequest,
+    db: web::Data<DynStorage>,
+    body: web::Json<AddDenylistRequest>,
+) -> Result<HttpResponse> {
+    let kind = body.kind.to_lowercase();
+    if !ALLOWED_DENYLIST_KINDS.contains(&kind.as_str()) {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "invalid_request",
+            "error_description": format!(
+                "kind must be one of: {}",
+                ALLOWED_DENYLIST_KINDS.join(", ")
+            )
+        })));
+    }
+    if body.value.trim().is_empty() {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "invalid_request",
+            "error_description": "value is required"
+        })));
+    }
+
+    let session = req.get_session();
+    let actor_email: String = session.get("email").unwrap_or(None).unwrap_or_default();
+
+    let mut entry = DenylistEntry::new(&kind, body.value.trim(), &body.reason, &actor_email);
+    entry.expires_at = body.expires_at;
+
+    db.add_denylist_entry(&entry)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let audit = build_audit(
+        &req,
+        "denylist.add",
+        "denylist",
+        &entry.id,
+        serde_json::json!({
+            "kind": entry.kind,
+            "value": entry.value,
+            "reason": entry.reason,
+        }),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Created().json(DenylistResponse::from(entry)))
+}
+
+pub async fn remove_denylist(
+    req: HttpRequest,
+    path: web::Path<String>,
+    db: web::Data<DynStorage>,
+) -> Result<HttpResponse> {
+    let id = path.into_inner();
+    db.remove_denylist_entry(&id)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let audit = build_audit(
+        &req,
+        "denylist.remove",
+        "denylist",
+        &id,
+        serde_json::json!({}),
+    );
+    record_audit(db.as_ref(), audit).await;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "message": "Denylist entry removed" })))
+}
+
+// --- Audit log --------------------------------------------------------------
+
+#[derive(Serialize)]
+pub struct AuditLogResponse {
+    pub id: String,
+    pub actor_id: String,
+    pub actor_email: String,
+    pub action: String,
+    pub target_kind: String,
+    pub target_id: String,
+    pub ip: String,
+    pub user_agent: String,
+    pub metadata: String,
+    pub created_at: String,
+}
+
+impl From<AuditLogEntry> for AuditLogResponse {
+    fn from(e: AuditLogEntry) -> Self {
+        Self {
+            id: e.id,
+            actor_id: e.actor_id,
+            actor_email: e.actor_email,
+            action: e.action,
+            target_kind: e.target_kind,
+            target_id: e.target_id,
+            ip: e.ip,
+            user_agent: e.user_agent,
+            metadata: e.metadata,
+            created_at: e.created_at.to_rfc3339(),
+        }
+    }
+}
+
+pub async fn list_audit_log(
+    db: web::Data<DynStorage>,
+    query: web::Query<ListQuery>,
+) -> Result<HttpResponse> {
+    let page = db
+        .list_audit_log(&query)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let items: Vec<AuditLogResponse> = page.items.into_iter().map(AuditLogResponse::from).collect();
+
+    Ok(HttpResponse::Ok().json(Page::new(items, page.total, page.limit, page.offset)))
+}

--- a/crates/oauth2-actix/src/handlers/mod.rs
+++ b/crates/oauth2-actix/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod admin_extra;
 pub mod admin_keys;
 pub mod client;
 pub mod device;

--- a/crates/oauth2-actix/src/middleware/denylist.rs
+++ b/crates/oauth2-actix/src/middleware/denylist.rs
@@ -1,0 +1,105 @@
+//! Middleware that rejects requests matching a denylist entry.
+//!
+//! Checks the client IP on every request. Paths that receive a username or
+//! client_id in the form body (e.g. `/auth/login`, `/oauth/token`) are handled
+//! by per-handler checks, since bodies aren't easily inspected here without
+//! consuming them.
+
+use actix_web::{
+    body::EitherBody,
+    dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
+    web, Error, HttpResponse,
+};
+use futures::future::LocalBoxFuture;
+use oauth2_core::DENYLIST_KIND_IP;
+use oauth2_ports::DynStorage;
+use std::future::{ready, Ready};
+use std::rc::Rc;
+
+/// Factory for the `DenylistGuard` middleware.
+pub struct DenylistGuard;
+
+impl<S, B> Transform<S, ServiceRequest> for DenylistGuard
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = DenylistGuardService<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(DenylistGuardService {
+            service: Rc::new(service),
+        }))
+    }
+}
+
+pub struct DenylistGuardService<S> {
+    service: Rc<S>,
+}
+
+impl<S, B> Service<ServiceRequest> for DenylistGuardService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let svc = self.service.clone();
+
+        Box::pin(async move {
+            if let Some(storage) = req.app_data::<web::Data<DynStorage>>() {
+                let ip = req
+                    .connection_info()
+                    .realip_remote_addr()
+                    .unwrap_or("")
+                    .to_string();
+                if !ip.is_empty() {
+                    if let Ok(Some(entry)) =
+                        storage.find_denylist_entry(DENYLIST_KIND_IP, &ip).await
+                    {
+                        tracing::warn!(
+                            ip = %ip,
+                            reason = %entry.reason,
+                            "Denylist IP match — blocking request"
+                        );
+                        let resp = HttpResponse::Forbidden().json(serde_json::json!({
+                            "error": "access_denied",
+                            "error_description": "request source is denylisted"
+                        }));
+                        return Ok(req.into_response(resp).map_into_right_body());
+                    }
+                }
+            }
+
+            let res = svc.call(req).await?;
+            Ok(res.map_into_left_body())
+        })
+    }
+}
+
+/// Helper for handlers (login, token endpoint) to check denylist by
+/// `username`/`email`/`client_id`. Returns `Some(reason)` when blocked.
+pub async fn check_subject_denylisted(
+    storage: &DynStorage,
+    kind: &str,
+    value: &str,
+) -> Option<String> {
+    if value.is_empty() {
+        return None;
+    }
+    match storage.find_denylist_entry(kind, value).await {
+        Ok(Some(entry)) => Some(entry.reason),
+        _ => None,
+    }
+}

--- a/crates/oauth2-actix/src/middleware/mod.rs
+++ b/crates/oauth2-actix/src/middleware/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin_guard;
 pub mod auth_middleware;
+pub mod denylist;
 pub mod rate_limit;
 pub mod resilience;

--- a/crates/oauth2-core/src/models/audit.rs
+++ b/crates/oauth2-core/src/models/audit.rs
@@ -1,0 +1,62 @@
+#![allow(dead_code)]
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Row from the `audit_log` table. Represents a single admin-triggered
+/// mutation (user/client/token CRUD, denylist changes, key rotations, …).
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditLogEntry {
+    pub id: String,
+    /// User id of the admin that performed the action (empty for anonymous /
+    /// bearer-token callers).
+    pub actor_id: String,
+    pub actor_email: String,
+    /// Dot-separated action code, e.g. `user.create`, `client.delete`,
+    /// `denylist.add`, `token.revoke`.
+    pub action: String,
+    /// One of: `user`, `client`, `token`, `denylist`, `device`, `key`, ``.
+    pub target_kind: String,
+    pub target_id: String,
+    pub ip: String,
+    pub user_agent: String,
+    /// JSON blob with extra details (before/after, reason, etc).
+    pub metadata: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl AuditLogEntry {
+    pub fn new(actor_id: &str, actor_email: &str, action: &str) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            actor_id: actor_id.to_string(),
+            actor_email: actor_email.to_string(),
+            action: action.to_string(),
+            target_kind: String::new(),
+            target_id: String::new(),
+            ip: String::new(),
+            user_agent: String::new(),
+            metadata: String::new(),
+            created_at: Utc::now(),
+        }
+    }
+
+    pub fn with_target(mut self, kind: &str, id: &str) -> Self {
+        self.target_kind = kind.to_string();
+        self.target_id = id.to_string();
+        self
+    }
+
+    pub fn with_request_meta(mut self, ip: &str, user_agent: &str) -> Self {
+        self.ip = ip.to_string();
+        self.user_agent = user_agent.to_string();
+        self
+    }
+
+    pub fn with_metadata_json(mut self, metadata: serde_json::Value) -> Self {
+        self.metadata = metadata.to_string();
+        self
+    }
+}

--- a/crates/oauth2-core/src/models/client.rs
+++ b/crates/oauth2-core/src/models/client.rs
@@ -78,6 +78,15 @@ pub struct Client {
     /// OIDC RP-Initiated Logout §2: registered post-logout redirect URIs (JSON array).
     #[serde(default = "default_empty_string")]
     pub post_logout_redirect_uris: String,
+    /// Admin soft-disable flag. Disabled clients are rejected at authorization
+    /// and token endpoints. Defaults to `true` so existing code paths remain
+    /// unaffected.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Client {
@@ -116,6 +125,7 @@ impl Client {
             frontchannel_logout_uri: String::new(),
             frontchannel_logout_session_required: false,
             post_logout_redirect_uris: String::new(),
+            enabled: true,
         }
     }
 

--- a/crates/oauth2-core/src/models/denylist.rs
+++ b/crates/oauth2-core/src/models/denylist.rs
@@ -1,0 +1,49 @@
+#![allow(dead_code)]
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Kinds of subject that may be denylisted.
+///
+/// Serialized as a lowercase string (`"ip"`, `"user_id"`, …) to match the
+/// `denylist.kind` column.
+pub const DENYLIST_KIND_IP: &str = "ip";
+pub const DENYLIST_KIND_USER_ID: &str = "user_id";
+pub const DENYLIST_KIND_USERNAME: &str = "username";
+pub const DENYLIST_KIND_EMAIL: &str = "email";
+pub const DENYLIST_KIND_CLIENT_ID: &str = "client_id";
+
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DenylistEntry {
+    pub id: String,
+    /// One of: `ip`, `user_id`, `username`, `email`, `client_id`.
+    pub kind: String,
+    pub value: String,
+    pub reason: String,
+    pub created_by: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+impl DenylistEntry {
+    pub fn new(kind: &str, value: &str, reason: &str, created_by: &str) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            kind: kind.to_string(),
+            value: value.to_string(),
+            reason: reason.to_string(),
+            created_by: created_by.to_string(),
+            created_at: Utc::now(),
+            expires_at: None,
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        match self.expires_at {
+            Some(exp) => exp > Utc::now(),
+            None => true,
+        }
+    }
+}

--- a/crates/oauth2-core/src/models/mod.rs
+++ b/crates/oauth2-core/src/models/mod.rs
@@ -1,5 +1,7 @@
+pub mod audit;
 pub mod authorization;
 pub mod client;
+pub mod denylist;
 pub mod device;
 pub mod error;
 pub mod key_set;
@@ -8,8 +10,10 @@ pub mod scope;
 pub mod token;
 pub mod user;
 
+pub use audit::*;
 pub use authorization::*;
 pub use client::*;
+pub use denylist::*;
 pub use device::*;
 pub use error::*;
 pub use pagination::*;

--- a/crates/oauth2-observability/src/storage.rs
+++ b/crates/oauth2-observability/src/storage.rs
@@ -2,7 +2,8 @@ use async_trait::async_trait;
 use tracing::{field, Instrument};
 
 use oauth2_core::{
-    AuthorizationCode, Client, DeviceAuthorization, ListQuery, OAuth2Error, Page, Token, User,
+    AuditLogEntry, AuthorizationCode, Client, DenylistEntry, DeviceAuthorization, ListQuery,
+    OAuth2Error, Page, Token, User,
 };
 use oauth2_ports::{DynStorage, Storage};
 
@@ -531,6 +532,139 @@ impl Storage for ObservedStorage {
         let span = self.span("expire_device_authorization");
         let dc = device_code.to_string();
         async move { self.inner.expire_device_authorization(&dc).await }
+            .instrument(span)
+            .await
+    }
+
+    // --- Admin: user management ---
+
+    async fn update_user(&self, user: &User) -> Result<(), OAuth2Error> {
+        let span = self.span("update_user");
+        async move { self.inner.update_user(user).await }
+            .instrument(span)
+            .await
+    }
+
+    async fn delete_user(&self, user_id: &str) -> Result<(), OAuth2Error> {
+        let span = self.span("delete_user");
+        let id = user_id.to_string();
+        async move { self.inner.delete_user(&id).await }
+            .instrument(span)
+            .await
+    }
+
+    async fn set_user_enabled(&self, user_id: &str, enabled: bool) -> Result<(), OAuth2Error> {
+        let span = self.span("set_user_enabled");
+        let id = user_id.to_string();
+        async move { self.inner.set_user_enabled(&id, enabled).await }
+            .instrument(span)
+            .await
+    }
+
+    async fn set_user_role(&self, user_id: &str, role: &str) -> Result<(), OAuth2Error> {
+        let span = self.span("set_user_role");
+        let id = user_id.to_string();
+        let role = role.to_string();
+        async move { self.inner.set_user_role(&id, &role).await }
+            .instrument(span)
+            .await
+    }
+
+    async fn set_user_password_hash(
+        &self,
+        user_id: &str,
+        password_hash: &str,
+    ) -> Result<(), OAuth2Error> {
+        let span = self.span("set_user_password_hash");
+        let id = user_id.to_string();
+        let hash = password_hash.to_string();
+        async move { self.inner.set_user_password_hash(&id, &hash).await }
+            .instrument(span)
+            .await
+    }
+
+    // --- Admin: client management extensions ---
+
+    async fn set_client_enabled(&self, client_id: &str, enabled: bool) -> Result<(), OAuth2Error> {
+        let span = self.span("set_client_enabled");
+        let id = client_id.to_string();
+        async move { self.inner.set_client_enabled(&id, enabled).await }
+            .instrument(span)
+            .await
+    }
+
+    async fn set_client_secret(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+    ) -> Result<(), OAuth2Error> {
+        let span = self.span("set_client_secret");
+        let id = client_id.to_string();
+        let secret = client_secret.to_string();
+        async move { self.inner.set_client_secret(&id, &secret).await }
+            .instrument(span)
+            .await
+    }
+
+    // --- Admin: denylist ---
+
+    async fn add_denylist_entry(&self, entry: &DenylistEntry) -> Result<(), OAuth2Error> {
+        let span = self.span("add_denylist_entry");
+        async move { self.inner.add_denylist_entry(entry).await }
+            .instrument(span)
+            .await
+    }
+
+    async fn remove_denylist_entry(&self, id: &str) -> Result<(), OAuth2Error> {
+        let span = self.span("remove_denylist_entry");
+        let id = id.to_string();
+        async move { self.inner.remove_denylist_entry(&id).await }
+            .instrument(span)
+            .await
+    }
+
+    async fn list_denylist(&self, q: &ListQuery) -> Result<Page<DenylistEntry>, OAuth2Error> {
+        let span = self.span("list_denylist");
+        async move { self.inner.list_denylist(q).await }
+            .instrument(span)
+            .await
+    }
+
+    async fn find_denylist_entry(
+        &self,
+        kind: &str,
+        value: &str,
+    ) -> Result<Option<DenylistEntry>, OAuth2Error> {
+        let span = self.span("find_denylist_entry");
+        let kind = kind.to_string();
+        let value = value.to_string();
+        async move { self.inner.find_denylist_entry(&kind, &value).await }
+            .instrument(span)
+            .await
+    }
+
+    // --- Admin: audit log ---
+
+    async fn write_audit_log(&self, entry: &AuditLogEntry) -> Result<(), OAuth2Error> {
+        let span = self.span("write_audit_log");
+        async move { self.inner.write_audit_log(entry).await }
+            .instrument(span)
+            .await
+    }
+
+    async fn list_audit_log(&self, q: &ListQuery) -> Result<Page<AuditLogEntry>, OAuth2Error> {
+        let span = self.span("list_audit_log");
+        async move { self.inner.list_audit_log(q).await }
+            .instrument(span)
+            .await
+    }
+
+    // --- Admin: bulk token revocation ---
+
+    async fn revoke_tokens_by_client_id(&self, client_id: &str) -> Result<u64, OAuth2Error> {
+        let span = self.span("revoke_tokens_by_client_id");
+        let id = client_id.to_string();
+        async move { self.inner.revoke_tokens_by_client_id(&id).await }
             .instrument(span)
             .await
     }

--- a/crates/oauth2-ports/src/storage.rs
+++ b/crates/oauth2-ports/src/storage.rs
@@ -2,7 +2,8 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use oauth2_core::{
-    AuthorizationCode, Client, DeviceAuthorization, ListQuery, OAuth2Error, Page, Token, User,
+    AuditLogEntry, AuthorizationCode, Client, DenylistEntry, DeviceAuthorization, ListQuery,
+    OAuth2Error, Page, Token, User,
 };
 
 /// Trait implemented by all persistence backends.
@@ -194,6 +195,110 @@ pub trait Storage: Send + Sync {
     /// Implementations may override to do something cheaper than `init()`.
     async fn healthcheck(&self) -> Result<(), OAuth2Error> {
         self.init().await
+    }
+
+    // --- Admin: user management ---
+
+    /// Update an existing user's mutable fields (email, role, enabled,
+    /// password_hash). Default no-op.
+    async fn update_user(&self, user: &User) -> Result<(), OAuth2Error> {
+        let _ = user;
+        Ok(())
+    }
+
+    /// Delete a user by id. Default no-op.
+    async fn delete_user(&self, user_id: &str) -> Result<(), OAuth2Error> {
+        let _ = user_id;
+        Ok(())
+    }
+
+    /// Soft-enable or disable a user. Default no-op.
+    async fn set_user_enabled(&self, user_id: &str, enabled: bool) -> Result<(), OAuth2Error> {
+        let (_, _) = (user_id, enabled);
+        Ok(())
+    }
+
+    /// Change a user's role (e.g. "admin" / "user"). Default no-op.
+    async fn set_user_role(&self, user_id: &str, role: &str) -> Result<(), OAuth2Error> {
+        let (_, _) = (user_id, role);
+        Ok(())
+    }
+
+    /// Replace a user's password hash. Default no-op.
+    async fn set_user_password_hash(
+        &self,
+        user_id: &str,
+        password_hash: &str,
+    ) -> Result<(), OAuth2Error> {
+        let (_, _) = (user_id, password_hash);
+        Ok(())
+    }
+
+    // --- Admin: client management extensions ---
+
+    /// Soft-enable or disable a client. Default no-op.
+    async fn set_client_enabled(&self, client_id: &str, enabled: bool) -> Result<(), OAuth2Error> {
+        let (_, _) = (client_id, enabled);
+        Ok(())
+    }
+
+    /// Replace a client's secret (hashed or plaintext per impl convention).
+    /// Default no-op.
+    async fn set_client_secret(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+    ) -> Result<(), OAuth2Error> {
+        let (_, _) = (client_id, client_secret);
+        Ok(())
+    }
+
+    // --- Admin: denylist ---
+
+    async fn add_denylist_entry(&self, entry: &DenylistEntry) -> Result<(), OAuth2Error> {
+        let _ = entry;
+        Ok(())
+    }
+
+    async fn remove_denylist_entry(&self, id: &str) -> Result<(), OAuth2Error> {
+        let _ = id;
+        Ok(())
+    }
+
+    async fn list_denylist(&self, q: &ListQuery) -> Result<Page<DenylistEntry>, OAuth2Error> {
+        let _ = q;
+        Ok(Page::from_vec(vec![], q))
+    }
+
+    /// Returns the matching active denylist entry (not expired) if any.
+    async fn find_denylist_entry(
+        &self,
+        kind: &str,
+        value: &str,
+    ) -> Result<Option<DenylistEntry>, OAuth2Error> {
+        let (_, _) = (kind, value);
+        Ok(None)
+    }
+
+    // --- Admin: audit log ---
+
+    async fn write_audit_log(&self, entry: &AuditLogEntry) -> Result<(), OAuth2Error> {
+        let _ = entry;
+        Ok(())
+    }
+
+    async fn list_audit_log(&self, q: &ListQuery) -> Result<Page<AuditLogEntry>, OAuth2Error> {
+        let _ = q;
+        Ok(Page::from_vec(vec![], q))
+    }
+
+    // --- Admin: bulk token revocation ---
+
+    /// Revoke every non-expired token issued to a given client.
+    /// Returns number of rows affected. Default no-op.
+    async fn revoke_tokens_by_client_id(&self, client_id: &str) -> Result<u64, OAuth2Error> {
+        let _ = client_id;
+        Ok(0)
     }
 }
 

--- a/crates/oauth2-server/src/lib.rs
+++ b/crates/oauth2-server/src/lib.rs
@@ -1015,6 +1015,9 @@ pub async fn run() -> std::io::Result<()> {
                 .build(),
             )
             .wrap(rl_middleware)
+            // IP denylist check runs before rate limiting so that
+            // denylisted IPs don't consume rate-limit quota.
+            .wrap(oauth2_actix::middleware::denylist::DenylistGuard)
             // Resilience is the outermost layer (last .wrap() call).
             // Tripped circuit / full concurrency pool → 503 on the cheapest
             // path, before rate-limiting, session, or logging run.
@@ -1245,6 +1248,8 @@ pub async fn run() -> std::io::Result<()> {
                     .route("/keys", web::get().to(admin_dashboard))
                     .route("/metrics", web::get().to(admin_dashboard))
                     .route("/events", web::get().to(admin_dashboard))
+                    .route("/denylist", web::get().to(admin_dashboard))
+                    .route("/audit", web::get().to(admin_dashboard))
                     .route(
                         "/clients/register",
                         web::post().to(oauth2_actix::handlers::client::register_client),
@@ -1265,12 +1270,30 @@ pub async fn run() -> std::io::Result<()> {
                                 web::get().to(oauth2_actix::handlers::admin::list_clients),
                             )
                             .route(
+                                "/clients",
+                                web::post().to(oauth2_actix::handlers::admin_extra::create_client),
+                            )
+                            .route(
                                 "/clients/{id}",
                                 web::get().to(oauth2_actix::handlers::admin::get_client),
                             )
                             .route(
                                 "/clients/{id}",
+                                web::put().to(oauth2_actix::handlers::admin_extra::update_client),
+                            )
+                            .route(
+                                "/clients/{id}",
                                 web::delete().to(oauth2_actix::handlers::admin::delete_client),
+                            )
+                            .route(
+                                "/clients/{id}/enabled",
+                                web::post()
+                                    .to(oauth2_actix::handlers::admin_extra::set_client_enabled),
+                            )
+                            .route(
+                                "/clients/{id}/regenerate-secret",
+                                web::post()
+                                    .to(oauth2_actix::handlers::admin_extra::regenerate_client_secret),
                             )
                             // Tokens
                             .route(
@@ -1285,14 +1308,70 @@ pub async fn run() -> std::io::Result<()> {
                                 "/tokens/{id}/revoke",
                                 web::post().to(oauth2_actix::handlers::admin::admin_revoke_token),
                             )
+                            .route(
+                                "/tokens/revoke-by-user",
+                                web::post()
+                                    .to(oauth2_actix::handlers::admin_extra::bulk_revoke_by_user),
+                            )
+                            .route(
+                                "/tokens/revoke-by-client",
+                                web::post()
+                                    .to(oauth2_actix::handlers::admin_extra::bulk_revoke_by_client),
+                            )
                             // Users
                             .route(
                                 "/users",
                                 web::get().to(oauth2_actix::handlers::admin::list_users),
                             )
                             .route(
+                                "/users",
+                                web::post().to(oauth2_actix::handlers::admin_extra::create_user),
+                            )
+                            .route(
                                 "/users/{id}",
                                 web::get().to(oauth2_actix::handlers::admin::get_user),
+                            )
+                            .route(
+                                "/users/{id}",
+                                web::put().to(oauth2_actix::handlers::admin_extra::update_user),
+                            )
+                            .route(
+                                "/users/{id}",
+                                web::delete().to(oauth2_actix::handlers::admin_extra::delete_user),
+                            )
+                            .route(
+                                "/users/{id}/enabled",
+                                web::post()
+                                    .to(oauth2_actix::handlers::admin_extra::set_user_enabled),
+                            )
+                            .route(
+                                "/users/{id}/role",
+                                web::post()
+                                    .to(oauth2_actix::handlers::admin_extra::set_user_role),
+                            )
+                            .route(
+                                "/users/{id}/password",
+                                web::post()
+                                    .to(oauth2_actix::handlers::admin_extra::reset_user_password),
+                            )
+                            // Denylist
+                            .route(
+                                "/denylist",
+                                web::get().to(oauth2_actix::handlers::admin_extra::list_denylist),
+                            )
+                            .route(
+                                "/denylist",
+                                web::post().to(oauth2_actix::handlers::admin_extra::add_denylist),
+                            )
+                            .route(
+                                "/denylist/{id}",
+                                web::delete()
+                                    .to(oauth2_actix::handlers::admin_extra::remove_denylist),
+                            )
+                            // Audit log
+                            .route(
+                                "/audit",
+                                web::get().to(oauth2_actix::handlers::admin_extra::list_audit_log),
                             )
                             // Device authorizations
                             .route(

--- a/crates/oauth2-storage-mongo/src/lib.rs
+++ b/crates/oauth2-storage-mongo/src/lib.rs
@@ -599,6 +599,119 @@ impl Storage for MongoStorage {
             .map(|_| ())
             .map_err(Self::mongo_err_to_oauth)
     }
+
+    // --- Admin: user management ---
+
+    async fn update_user(&self, user: &User) -> Result<(), OAuth2Error> {
+        let updated_at = mongodb::bson::DateTime::from_millis(user.updated_at.timestamp_millis());
+        self.users
+            .update_one(
+                doc! { "id": &user.id },
+                doc! {
+                    "$set": {
+                        "username": &user.username,
+                        "email": &user.email,
+                        "enabled": user.enabled,
+                        "role": &user.role,
+                        "password_hash": &user.password_hash,
+                        "updated_at": updated_at,
+                    }
+                },
+            )
+            .await
+            .map(|_| ())
+            .map_err(Self::mongo_err_to_oauth)
+    }
+
+    async fn delete_user(&self, user_id: &str) -> Result<(), OAuth2Error> {
+        self.users
+            .delete_one(doc! { "id": user_id })
+            .await
+            .map(|_| ())
+            .map_err(Self::mongo_err_to_oauth)
+    }
+
+    async fn set_user_enabled(&self, user_id: &str, enabled: bool) -> Result<(), OAuth2Error> {
+        let now = mongodb::bson::DateTime::now();
+        self.users
+            .update_one(
+                doc! { "id": user_id },
+                doc! { "$set": { "enabled": enabled, "updated_at": now } },
+            )
+            .await
+            .map(|_| ())
+            .map_err(Self::mongo_err_to_oauth)
+    }
+
+    async fn set_user_role(&self, user_id: &str, role: &str) -> Result<(), OAuth2Error> {
+        let now = mongodb::bson::DateTime::now();
+        self.users
+            .update_one(
+                doc! { "id": user_id },
+                doc! { "$set": { "role": role, "updated_at": now } },
+            )
+            .await
+            .map(|_| ())
+            .map_err(Self::mongo_err_to_oauth)
+    }
+
+    async fn set_user_password_hash(
+        &self,
+        user_id: &str,
+        password_hash: &str,
+    ) -> Result<(), OAuth2Error> {
+        let now = mongodb::bson::DateTime::now();
+        self.users
+            .update_one(
+                doc! { "id": user_id },
+                doc! { "$set": { "password_hash": password_hash, "updated_at": now } },
+            )
+            .await
+            .map(|_| ())
+            .map_err(Self::mongo_err_to_oauth)
+    }
+
+    // --- Admin: client management extensions ---
+
+    async fn set_client_enabled(&self, client_id: &str, enabled: bool) -> Result<(), OAuth2Error> {
+        let now = mongodb::bson::DateTime::now();
+        self.clients
+            .update_one(
+                doc! { "client_id": client_id },
+                doc! { "$set": { "enabled": enabled, "updated_at": now } },
+            )
+            .await
+            .map(|_| ())
+            .map_err(Self::mongo_err_to_oauth)
+    }
+
+    async fn set_client_secret(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+    ) -> Result<(), OAuth2Error> {
+        let now = mongodb::bson::DateTime::now();
+        self.clients
+            .update_one(
+                doc! { "client_id": client_id },
+                doc! { "$set": { "client_secret": client_secret, "updated_at": now } },
+            )
+            .await
+            .map(|_| ())
+            .map_err(Self::mongo_err_to_oauth)
+    }
+
+    async fn revoke_tokens_by_client_id(&self, client_id: &str) -> Result<u64, OAuth2Error> {
+        let result = self
+            .tokens
+            .update_many(
+                doc! { "client_id": client_id, "revoked": false },
+                doc! { "$set": { "revoked": true } },
+            )
+            .await
+            .map_err(Self::mongo_err_to_oauth)?;
+        Ok(result.modified_count)
+    }
 }
 
 #[cfg(test)]

--- a/crates/oauth2-storage-sqlx/src/sqlx.rs
+++ b/crates/oauth2-storage-sqlx/src/sqlx.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use oauth2_core::{
-    AuthorizationCode, Client, DeviceAuthorization, ListQuery, OAuth2Error, Page, Token, User,
+    AuditLogEntry, AuthorizationCode, Client, DenylistEntry, DeviceAuthorization, ListQuery,
+    OAuth2Error, Page, Token, User,
 };
 use oauth2_ports::Storage;
 use sqlx::pool::PoolOptions;
@@ -190,16 +191,84 @@ impl SqlxStorage {
                 backchannel_logout_session_required INTEGER NOT NULL DEFAULT 0,
                 frontchannel_logout_uri TEXT NOT NULL DEFAULT '',
                 frontchannel_logout_session_required INTEGER NOT NULL DEFAULT 0,
-                post_logout_redirect_uris TEXT NOT NULL DEFAULT '[]'
+                post_logout_redirect_uris TEXT NOT NULL DEFAULT '[]',
+                enabled INTEGER NOT NULL DEFAULT 1
             );
             "#,
         )
         .execute(pool)
         .await?;
 
+        // Idempotent upgrade for existing databases bootstrapped before the
+        // `enabled` column was added.
+        let _ = sqlx::query("ALTER TABLE clients ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1")
+            .execute(pool)
+            .await;
+
         sqlx::query(r#"CREATE INDEX IF NOT EXISTS idx_clients_client_id ON clients(client_id);"#)
             .execute(pool)
             .await?;
+
+        // Denylist table (admin denies for users/clients/IPs/emails).
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS denylist (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                value TEXT NOT NULL,
+                reason TEXT NOT NULL DEFAULT '',
+                created_by TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                expires_at TEXT
+            );
+            "#,
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_denylist_kind_value ON denylist(kind, value);",
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_denylist_kind ON denylist(kind);")
+            .execute(pool)
+            .await?;
+
+        // Audit log table.
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS audit_log (
+                id TEXT PRIMARY KEY,
+                actor_id TEXT NOT NULL DEFAULT '',
+                actor_email TEXT NOT NULL DEFAULT '',
+                action TEXT NOT NULL,
+                target_kind TEXT NOT NULL DEFAULT '',
+                target_id TEXT NOT NULL DEFAULT '',
+                ip TEXT NOT NULL DEFAULT '',
+                user_agent TEXT NOT NULL DEFAULT '',
+                metadata TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL
+            );
+            "#,
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_audit_log_actor_id ON audit_log(actor_id);")
+            .execute(pool)
+            .await?;
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action);")
+            .execute(pool)
+            .await?;
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_audit_log_target ON audit_log(target_kind, target_id);",
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_audit_log_created_at ON audit_log(created_at);",
+        )
+        .execute(pool)
+        .await?;
 
         // Users
         sqlx::query(
@@ -384,8 +453,8 @@ impl Storage for SqlxStorage {
             DatabasePool::Sqlite(pool) => {
                 sqlx::query(
                     r#"
-                    INSERT INTO clients (id, client_id, client_secret, redirect_uris, grant_types, scope, name, created_at, updated_at, token_endpoint_auth_method, registration_access_token, response_types, contacts, logo_uri, client_uri, policy_uri, tos_uri, jwks, jwks_uri, backchannel_logout_uri, backchannel_logout_session_required, frontchannel_logout_uri, frontchannel_logout_session_required, post_logout_redirect_uris)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    INSERT INTO clients (id, client_id, client_secret, redirect_uris, grant_types, scope, name, created_at, updated_at, token_endpoint_auth_method, registration_access_token, response_types, contacts, logo_uri, client_uri, policy_uri, tos_uri, jwks, jwks_uri, backchannel_logout_uri, backchannel_logout_session_required, frontchannel_logout_uri, frontchannel_logout_session_required, post_logout_redirect_uris, enabled)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     "#,
                 )
                 .bind(&client.id)
@@ -412,14 +481,15 @@ impl Storage for SqlxStorage {
                 .bind(&client.frontchannel_logout_uri)
                 .bind(client.frontchannel_logout_session_required)
                 .bind(&client.post_logout_redirect_uris)
+                .bind(client.enabled)
                 .execute(pool)
                 .await?;
             }
             DatabasePool::Postgres(pool) => {
                 sqlx::query(
                     r#"
-                    INSERT INTO clients (id, client_id, client_secret, redirect_uris, grant_types, scope, name, created_at, updated_at, token_endpoint_auth_method, registration_access_token, response_types, contacts, logo_uri, client_uri, policy_uri, tos_uri, jwks, jwks_uri, backchannel_logout_uri, backchannel_logout_session_required, frontchannel_logout_uri, frontchannel_logout_session_required, post_logout_redirect_uris)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
+                    INSERT INTO clients (id, client_id, client_secret, redirect_uris, grant_types, scope, name, created_at, updated_at, token_endpoint_auth_method, registration_access_token, response_types, contacts, logo_uri, client_uri, policy_uri, tos_uri, jwks, jwks_uri, backchannel_logout_uri, backchannel_logout_session_required, frontchannel_logout_uri, frontchannel_logout_session_required, post_logout_redirect_uris, enabled)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)
                     "#,
                 )
                 .bind(&client.id)
@@ -446,6 +516,7 @@ impl Storage for SqlxStorage {
                 .bind(&client.frontchannel_logout_uri)
                 .bind(client.frontchannel_logout_session_required)
                 .bind(&client.post_logout_redirect_uris)
+                .bind(client.enabled)
                 .execute(pool)
                 .await?;
             }
@@ -491,7 +562,8 @@ impl Storage for SqlxStorage {
                         backchannel_logout_session_required = ?,
                         frontchannel_logout_uri = ?,
                         frontchannel_logout_session_required = ?,
-                        post_logout_redirect_uris = ?
+                        post_logout_redirect_uris = ?,
+                        enabled = ?
                     WHERE client_id = ?
                     "#,
                 )
@@ -516,6 +588,7 @@ impl Storage for SqlxStorage {
                 .bind(&client.frontchannel_logout_uri)
                 .bind(client.frontchannel_logout_session_required)
                 .bind(&client.post_logout_redirect_uris)
+                .bind(client.enabled)
                 .bind(&client.client_id)
                 .execute(pool)
                 .await?;
@@ -536,8 +609,9 @@ impl Storage for SqlxStorage {
                         backchannel_logout_session_required = $18,
                         frontchannel_logout_uri = $19,
                         frontchannel_logout_session_required = $20,
-                        post_logout_redirect_uris = $21
-                    WHERE client_id = $22
+                        post_logout_redirect_uris = $21,
+                        enabled = $22
+                    WHERE client_id = $23
                     "#,
                 )
                 .bind(&client.client_secret)
@@ -561,6 +635,7 @@ impl Storage for SqlxStorage {
                 .bind(&client.frontchannel_logout_uri)
                 .bind(client.frontchannel_logout_session_required)
                 .bind(&client.post_logout_redirect_uris)
+                .bind(client.enabled)
                 .bind(&client.client_id)
                 .execute(pool)
                 .await?;
@@ -1441,6 +1516,475 @@ impl Storage for SqlxStorage {
             }
         }
         Ok(())
+    }
+
+    // --- Admin: user management ---
+
+    async fn update_user(&self, user: &User) -> Result<(), OAuth2Error> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query(
+                    r#"
+                    UPDATE users SET
+                        username = ?, email = ?, enabled = ?, role = ?,
+                        password_hash = ?, updated_at = ?
+                    WHERE id = ?
+                    "#,
+                )
+                .bind(&user.username)
+                .bind(&user.email)
+                .bind(user.enabled)
+                .bind(&user.role)
+                .bind(&user.password_hash)
+                .bind(user.updated_at)
+                .bind(&user.id)
+                .execute(pool)
+                .await?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query(
+                    r#"
+                    UPDATE users SET
+                        username = $1, email = $2, enabled = $3, role = $4,
+                        password_hash = $5, updated_at = $6
+                    WHERE id = $7
+                    "#,
+                )
+                .bind(&user.username)
+                .bind(&user.email)
+                .bind(user.enabled)
+                .bind(&user.role)
+                .bind(&user.password_hash)
+                .bind(user.updated_at)
+                .bind(&user.id)
+                .execute(pool)
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn delete_user(&self, user_id: &str) -> Result<(), OAuth2Error> {
+        // Clear foreign-key references (tokens, auth codes, device auths) before
+        // removing the user row so FK constraints don't reject the delete.
+        // Tokens are revoked so existing observers see the "no longer valid"
+        // state even after the user id is unlinked.
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query("UPDATE tokens SET revoked = 1, user_id = NULL WHERE user_id = ?")
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+                sqlx::query("DELETE FROM authorization_codes WHERE user_id = ?")
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+                sqlx::query("UPDATE device_authorizations SET user_id = NULL WHERE user_id = ?")
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+                sqlx::query("DELETE FROM users WHERE id = ?")
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query("UPDATE tokens SET revoked = true, user_id = NULL WHERE user_id = $1")
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+                sqlx::query("DELETE FROM authorization_codes WHERE user_id = $1")
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+                sqlx::query("UPDATE device_authorizations SET user_id = NULL WHERE user_id = $1")
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+                sqlx::query("DELETE FROM users WHERE id = $1")
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn set_user_enabled(&self, user_id: &str, enabled: bool) -> Result<(), OAuth2Error> {
+        let now = chrono::Utc::now();
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query("UPDATE users SET enabled = ?, updated_at = ? WHERE id = ?")
+                    .bind(enabled)
+                    .bind(now)
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query("UPDATE users SET enabled = $1, updated_at = $2 WHERE id = $3")
+                    .bind(enabled)
+                    .bind(now)
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn set_user_role(&self, user_id: &str, role: &str) -> Result<(), OAuth2Error> {
+        let now = chrono::Utc::now();
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query("UPDATE users SET role = ?, updated_at = ? WHERE id = ?")
+                    .bind(role)
+                    .bind(now)
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query("UPDATE users SET role = $1, updated_at = $2 WHERE id = $3")
+                    .bind(role)
+                    .bind(now)
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn set_user_password_hash(
+        &self,
+        user_id: &str,
+        password_hash: &str,
+    ) -> Result<(), OAuth2Error> {
+        let now = chrono::Utc::now();
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query("UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?")
+                    .bind(password_hash)
+                    .bind(now)
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query("UPDATE users SET password_hash = $1, updated_at = $2 WHERE id = $3")
+                    .bind(password_hash)
+                    .bind(now)
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    // --- Admin: client management extensions ---
+
+    async fn set_client_enabled(&self, client_id: &str, enabled: bool) -> Result<(), OAuth2Error> {
+        let now = chrono::Utc::now();
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query("UPDATE clients SET enabled = ?, updated_at = ? WHERE client_id = ?")
+                    .bind(enabled)
+                    .bind(now)
+                    .bind(client_id)
+                    .execute(pool)
+                    .await?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query(
+                    "UPDATE clients SET enabled = $1, updated_at = $2 WHERE client_id = $3",
+                )
+                .bind(enabled)
+                .bind(now)
+                .bind(client_id)
+                .execute(pool)
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn set_client_secret(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+    ) -> Result<(), OAuth2Error> {
+        let now = chrono::Utc::now();
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query(
+                    "UPDATE clients SET client_secret = ?, updated_at = ? WHERE client_id = ?",
+                )
+                .bind(client_secret)
+                .bind(now)
+                .bind(client_id)
+                .execute(pool)
+                .await?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query(
+                    "UPDATE clients SET client_secret = $1, updated_at = $2 WHERE client_id = $3",
+                )
+                .bind(client_secret)
+                .bind(now)
+                .bind(client_id)
+                .execute(pool)
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    // --- Admin: denylist ---
+
+    async fn add_denylist_entry(&self, entry: &DenylistEntry) -> Result<(), OAuth2Error> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query(
+                    r#"
+                    INSERT INTO denylist (id, kind, value, reason, created_by, created_at, expires_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(kind, value) DO UPDATE SET
+                        reason = excluded.reason,
+                        created_by = excluded.created_by,
+                        expires_at = excluded.expires_at
+                    "#,
+                )
+                .bind(&entry.id)
+                .bind(&entry.kind)
+                .bind(&entry.value)
+                .bind(&entry.reason)
+                .bind(&entry.created_by)
+                .bind(entry.created_at)
+                .bind(entry.expires_at)
+                .execute(pool)
+                .await?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query(
+                    r#"
+                    INSERT INTO denylist (id, kind, value, reason, created_by, created_at, expires_at)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7)
+                    ON CONFLICT (kind, value) DO UPDATE SET
+                        reason = EXCLUDED.reason,
+                        created_by = EXCLUDED.created_by,
+                        expires_at = EXCLUDED.expires_at
+                    "#,
+                )
+                .bind(&entry.id)
+                .bind(&entry.kind)
+                .bind(&entry.value)
+                .bind(&entry.reason)
+                .bind(&entry.created_by)
+                .bind(entry.created_at)
+                .bind(entry.expires_at)
+                .execute(pool)
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn remove_denylist_entry(&self, id: &str) -> Result<(), OAuth2Error> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query("DELETE FROM denylist WHERE id = ?")
+                    .bind(id)
+                    .execute(pool)
+                    .await?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query("DELETE FROM denylist WHERE id = $1")
+                    .bind(id)
+                    .execute(pool)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn list_denylist(&self, q: &ListQuery) -> Result<Page<DenylistEntry>, OAuth2Error> {
+        let limit = q.effective_limit();
+        let offset = q.effective_offset();
+        let sort_col = whitelist_col(q.sort_by.as_deref(), &["kind", "value", "created_at"]);
+        let order = q.sort_dir_sql();
+
+        let (items, total) = match self.read_pool() {
+            DatabasePool::Sqlite(pool) => {
+                let query =
+                    format!("SELECT * FROM denylist ORDER BY {sort_col} {order} LIMIT ? OFFSET ?");
+                let items = sqlx::query_as::<_, DenylistEntry>(&query)
+                    .bind(limit as i64)
+                    .bind(offset as i64)
+                    .fetch_all(pool)
+                    .await?;
+                let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM denylist")
+                    .fetch_one(pool)
+                    .await?;
+                (items, total)
+            }
+            DatabasePool::Postgres(pool) => {
+                let query = format!(
+                    "SELECT * FROM denylist ORDER BY {sort_col} {order} LIMIT $1 OFFSET $2"
+                );
+                let items = sqlx::query_as::<_, DenylistEntry>(&query)
+                    .bind(limit as i64)
+                    .bind(offset as i64)
+                    .fetch_all(pool)
+                    .await?;
+                let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM denylist")
+                    .fetch_one(pool)
+                    .await?;
+                (items, total)
+            }
+        };
+
+        Ok(Page::new(items, total as u64, limit, offset))
+    }
+
+    async fn find_denylist_entry(
+        &self,
+        kind: &str,
+        value: &str,
+    ) -> Result<Option<DenylistEntry>, OAuth2Error> {
+        let entry = match self.read_pool() {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query_as::<_, DenylistEntry>(
+                    "SELECT * FROM denylist WHERE kind = ? AND value = ?",
+                )
+                .bind(kind)
+                .bind(value)
+                .fetch_optional(pool)
+                .await?
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query_as::<_, DenylistEntry>(
+                    "SELECT * FROM denylist WHERE kind = $1 AND value = $2",
+                )
+                .bind(kind)
+                .bind(value)
+                .fetch_optional(pool)
+                .await?
+            }
+        };
+
+        Ok(entry.filter(|e| e.is_active()))
+    }
+
+    // --- Admin: audit log ---
+
+    async fn write_audit_log(&self, entry: &AuditLogEntry) -> Result<(), OAuth2Error> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query(
+                    r#"
+                    INSERT INTO audit_log (id, actor_id, actor_email, action, target_kind, target_id, ip, user_agent, metadata, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    "#,
+                )
+                .bind(&entry.id)
+                .bind(&entry.actor_id)
+                .bind(&entry.actor_email)
+                .bind(&entry.action)
+                .bind(&entry.target_kind)
+                .bind(&entry.target_id)
+                .bind(&entry.ip)
+                .bind(&entry.user_agent)
+                .bind(&entry.metadata)
+                .bind(entry.created_at)
+                .execute(pool)
+                .await?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query(
+                    r#"
+                    INSERT INTO audit_log (id, actor_id, actor_email, action, target_kind, target_id, ip, user_agent, metadata, created_at)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                    "#,
+                )
+                .bind(&entry.id)
+                .bind(&entry.actor_id)
+                .bind(&entry.actor_email)
+                .bind(&entry.action)
+                .bind(&entry.target_kind)
+                .bind(&entry.target_id)
+                .bind(&entry.ip)
+                .bind(&entry.user_agent)
+                .bind(&entry.metadata)
+                .bind(entry.created_at)
+                .execute(pool)
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn list_audit_log(&self, q: &ListQuery) -> Result<Page<AuditLogEntry>, OAuth2Error> {
+        let limit = q.effective_limit();
+        let offset = q.effective_offset();
+        let sort_col = whitelist_col(
+            q.sort_by.as_deref(),
+            &["actor_id", "action", "target_kind", "created_at"],
+        );
+        let order = q.sort_dir_sql();
+
+        let (items, total) = match self.read_pool() {
+            DatabasePool::Sqlite(pool) => {
+                let query =
+                    format!("SELECT * FROM audit_log ORDER BY {sort_col} {order} LIMIT ? OFFSET ?");
+                let items = sqlx::query_as::<_, AuditLogEntry>(&query)
+                    .bind(limit as i64)
+                    .bind(offset as i64)
+                    .fetch_all(pool)
+                    .await?;
+                let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_log")
+                    .fetch_one(pool)
+                    .await?;
+                (items, total)
+            }
+            DatabasePool::Postgres(pool) => {
+                let query = format!(
+                    "SELECT * FROM audit_log ORDER BY {sort_col} {order} LIMIT $1 OFFSET $2"
+                );
+                let items = sqlx::query_as::<_, AuditLogEntry>(&query)
+                    .bind(limit as i64)
+                    .bind(offset as i64)
+                    .fetch_all(pool)
+                    .await?;
+                let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_log")
+                    .fetch_one(pool)
+                    .await?;
+                (items, total)
+            }
+        };
+
+        Ok(Page::new(items, total as u64, limit, offset))
+    }
+
+    async fn revoke_tokens_by_client_id(&self, client_id: &str) -> Result<u64, OAuth2Error> {
+        let rows = match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query("UPDATE tokens SET revoked = 1 WHERE client_id = ? AND revoked = 0")
+                    .bind(client_id)
+                    .execute(pool)
+                    .await?
+                    .rows_affected()
+            }
+            DatabasePool::Postgres(pool) => sqlx::query(
+                "UPDATE tokens SET revoked = true WHERE client_id = $1 AND revoked = false",
+            )
+            .bind(client_id)
+            .execute(pool)
+            .await?
+            .rows_affected(),
+        };
+        Ok(rows)
     }
 }
 

--- a/k8s/base/configmap-migrations.yaml
+++ b/k8s/base/configmap-migrations.yaml
@@ -230,3 +230,41 @@ data:
     ALTER TABLE clients ADD COLUMN frontchannel_logout_uri TEXT NOT NULL DEFAULT '';
     ALTER TABLE clients ADD COLUMN frontchannel_logout_session_required BOOLEAN NOT NULL DEFAULT FALSE;
     ALTER TABLE clients ADD COLUMN post_logout_redirect_uris TEXT NOT NULL DEFAULT '';
+
+  V17__admin_extensions.sql: |
+    -- Admin maintainer extensions: client enabled flag, denylist, audit log.
+
+    -- Soft-disable flag for clients (mirrors users.enabled).
+    ALTER TABLE clients ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+    -- Denylist for blocking users, clients, IPs, or email addresses from
+    -- authenticating or obtaining tokens.
+    CREATE TABLE IF NOT EXISTS denylist (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        value TEXT NOT NULL,
+        reason TEXT NOT NULL DEFAULT '',
+        created_by TEXT NOT NULL DEFAULT '',
+        created_at TIMESTAMPTZ NOT NULL,
+        expires_at TIMESTAMPTZ
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_denylist_kind_value ON denylist(kind, value);
+    CREATE INDEX IF NOT EXISTS idx_denylist_kind ON denylist(kind);
+
+    -- Audit log for admin mutations.
+    CREATE TABLE IF NOT EXISTS audit_log (
+        id TEXT PRIMARY KEY,
+        actor_id TEXT NOT NULL DEFAULT '',
+        actor_email TEXT NOT NULL DEFAULT '',
+        action TEXT NOT NULL,
+        target_kind TEXT NOT NULL DEFAULT '',
+        target_id TEXT NOT NULL DEFAULT '',
+        ip TEXT NOT NULL DEFAULT '',
+        user_agent TEXT NOT NULL DEFAULT '',
+        metadata TEXT NOT NULL DEFAULT '',
+        created_at TIMESTAMPTZ NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_audit_log_actor_id ON audit_log(actor_id);
+    CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action);
+    CREATE INDEX IF NOT EXISTS idx_audit_log_target ON audit_log(target_kind, target_id);
+    CREATE INDEX IF NOT EXISTS idx_audit_log_created_at ON audit_log(created_at);

--- a/migrations/sql/V17__admin_extensions.sql
+++ b/migrations/sql/V17__admin_extensions.sql
@@ -1,0 +1,36 @@
+-- Admin maintainer extensions: client enabled flag, denylist, audit log.
+
+-- Soft-disable flag for clients (mirrors users.enabled).
+ALTER TABLE clients ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Denylist for blocking users, clients, IPs, or email addresses from
+-- authenticating or obtaining tokens.
+CREATE TABLE IF NOT EXISTS denylist (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,               -- 'ip' | 'user_id' | 'username' | 'email' | 'client_id'
+    value TEXT NOT NULL,
+    reason TEXT NOT NULL DEFAULT '',
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_denylist_kind_value ON denylist(kind, value);
+CREATE INDEX IF NOT EXISTS idx_denylist_kind ON denylist(kind);
+
+-- Audit log for admin mutations.
+CREATE TABLE IF NOT EXISTS audit_log (
+    id TEXT PRIMARY KEY,
+    actor_id TEXT NOT NULL DEFAULT '',
+    actor_email TEXT NOT NULL DEFAULT '',
+    action TEXT NOT NULL,             -- e.g. 'user.create', 'client.delete'
+    target_kind TEXT NOT NULL DEFAULT '', -- 'user' | 'client' | 'token' | 'denylist' | ...
+    target_id TEXT NOT NULL DEFAULT '',
+    ip TEXT NOT NULL DEFAULT '',
+    user_agent TEXT NOT NULL DEFAULT '',
+    metadata TEXT NOT NULL DEFAULT '', -- JSON blob with details
+    created_at TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_audit_log_actor_id ON audit_log(actor_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action);
+CREATE INDEX IF NOT EXISTS idx_audit_log_target ON audit_log(target_kind, target_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_created_at ON audit_log(created_at);

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -4,15 +4,17 @@
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const PAGE_ROUTES = {
-  '':         'dashboard',
-  'dashboard':'dashboard',
-  'clients':  'clients',
-  'tokens':   'tokens',
-  'users':    'users',
-  'device':   'device',
-  'keys':     'keys',
-  'metrics':  'metrics',
-  'events':   'events',
+  '':          'dashboard',
+  'dashboard': 'dashboard',
+  'clients':   'clients',
+  'tokens':    'tokens',
+  'users':     'users',
+  'device':    'device',
+  'keys':      'keys',
+  'metrics':   'metrics',
+  'events':    'events',
+  'denylist':  'denylist',
+  'audit':     'audit',
 };
 
 // ─── Utility helpers ──────────────────────────────────────────────────────────
@@ -285,12 +287,26 @@ document.addEventListener('alpine:init', () => {
     events: true,
     device_flow: true,
     key_rotation: true,
+    user_crud: true,
+    client_crud: true,
+    denylist: true,
+    audit_log: true,
+    bulk_revoke: true,
     async init() {
       try {
         const res = await fetch('/admin/api/capabilities');
         if (res.ok) Object.assign(this, await res.json());
       } catch (_) {}
     },
+  });
+
+  // Modal coordination store — each page opens a specific modal by
+  // flipping `$store.modals.<name>.open = true` with seed context.
+  Alpine.store('modals', {
+    client: { open: false, mode: 'create', initial: null, onDone: null },
+    user:   { open: false, mode: 'create', initial: null, onDone: null },
+    password: { open: false, userId: '', username: '' },
+    denylist: { open: false, onDone: null },
   });
 });
 
@@ -537,6 +553,56 @@ function clientsPage() {
       if (res.ok) this.load();
       else alert('Failed to delete client');
     },
+
+    async toggleEnabled(item, event) {
+      event.stopPropagation();
+      const enabled = !(item.enabled !== false);
+      const res = await fetch(`/admin/api/clients/${item.id}/enabled`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      });
+      if (res.ok) this.load();
+      else alert('Failed to update client');
+    },
+
+    async rotateSecret(item, event) {
+      event.stopPropagation();
+      if (!confirm(`Rotate secret for "${item.name}"? Existing integrations will break until updated.`)) return;
+      const res = await fetch(`/admin/api/clients/${item.id}/regenerate-secret`, { method: 'POST' });
+      if (res.ok) {
+        const data = await res.json();
+        prompt('New client secret (copy now — will not be shown again):', data.client_secret || '');
+        this.load();
+      } else {
+        alert('Failed to rotate secret');
+      }
+    },
+
+    async revokeAllTokens(item, event) {
+      event.stopPropagation();
+      if (!confirm(`Revoke ALL active tokens for client "${item.name}"?`)) return;
+      const res = await fetch('/admin/api/tokens/revoke-by-client', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ client_id: item.client_id }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        alert(`Revoked ${data.revoked || 0} tokens`);
+      } else {
+        alert('Failed to revoke tokens');
+      }
+    },
+
+    openCreateModal() {
+      Alpine.store('modals').client = {
+        open: true,
+        mode: 'create',
+        initial: null,
+        onDone: () => this.load(),
+      };
+    },
   };
 }
 
@@ -567,6 +633,55 @@ function tokensPage() {
 function usersPage() {
   return {
     ...makeGrid('/admin/api/users', 'created_at', 'desc'),
+
+    openCreateModal() {
+      Alpine.store('modals').user = {
+        open: true,
+        mode: 'create',
+        initial: null,
+        onDone: () => this.load(),
+      };
+    },
+
+    async toggleEnabled(item, event) {
+      event.stopPropagation();
+      const res = await fetch(`/admin/api/users/${item.id}/enabled`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: !item.enabled }),
+      });
+      if (res.ok) this.load();
+      else alert('Failed to update user');
+    },
+
+    async toggleRole(item, event) {
+      event.stopPropagation();
+      const nextRole = item.role === 'admin' ? 'user' : 'admin';
+      if (!confirm(`Change ${item.username}'s role to "${nextRole}"?`)) return;
+      const res = await fetch(`/admin/api/users/${item.id}/role`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role: nextRole }),
+      });
+      if (res.ok) this.load();
+      else alert('Failed to update role');
+    },
+
+    openPasswordModal(item) {
+      Alpine.store('modals').password = {
+        open: true,
+        userId: item.id,
+        username: item.username,
+      };
+    },
+
+    async deleteUser(item, event) {
+      event.stopPropagation();
+      if (!confirm(`Delete user "${item.username}"? All their tokens will be revoked. This cannot be undone.`)) return;
+      const res = await fetch(`/admin/api/users/${item.id}`, { method: 'DELETE' });
+      if (res.ok) this.load();
+      else alert('Failed to delete user');
+    },
   };
 }
 
@@ -803,6 +918,337 @@ function eventsPage() {
         const res = await fetch('/events/health');
         if (res.ok) this.pluginHealth = await res.json();
       } catch (_) {}
+    },
+  };
+}
+
+// ─── Page: Denylist ──────────────────────────────────────────────────────────
+
+function denylistPage() {
+  return {
+    ...makeGrid('/admin/api/denylist', 'created_at', 'desc'),
+
+    openAddModal() {
+      Alpine.store('modals').denylist = {
+        open: true,
+        onDone: () => this.load(),
+      };
+    },
+
+    async remove(item, event) {
+      event.stopPropagation();
+      if (!confirm(`Remove denylist entry for ${item.kind}=${item.value}?`)) return;
+      const res = await fetch(`/admin/api/denylist/${item.id}`, { method: 'DELETE' });
+      if (res.ok) this.load();
+      else alert('Failed to remove denylist entry');
+    },
+  };
+}
+
+// ─── Page: Audit Log ─────────────────────────────────────────────────────────
+
+function auditPage() {
+  return {
+    ...makeGrid('/admin/api/audit', 'created_at', 'desc'),
+  };
+}
+
+// ─── Modal: Create/Edit Client ───────────────────────────────────────────────
+
+function clientFormModal() {
+  return {
+    saving: false,
+    error: null,
+    createdSecret: null,
+    form: {
+      name: '',
+      client_id: '',
+      token_endpoint_auth_method: 'client_secret_basic',
+      redirect_uris_text: '',
+      grant_types_text: 'authorization_code refresh_token',
+      scope: 'openid profile email',
+      enabled: true,
+    },
+
+    init() {
+      this.$watch('$store.modals.client.open', (open) => {
+        if (open) this._reset();
+      });
+    },
+
+    _reset() {
+      const init = Alpine.store('modals').client.initial;
+      this.saving = false;
+      this.error = null;
+      this.createdSecret = null;
+      if (init) {
+        this.form = {
+          name: init.name || '',
+          client_id: init.client_id || '',
+          token_endpoint_auth_method: init.token_endpoint_auth_method || 'client_secret_basic',
+          redirect_uris_text: Array.isArray(init.redirect_uris) ? init.redirect_uris.join('\n') : (init.redirect_uris || ''),
+          grant_types_text: Array.isArray(init.grant_types) ? init.grant_types.join(' ') : (init.grant_types || ''),
+          scope: init.scope || '',
+          enabled: init.enabled !== false,
+        };
+      } else {
+        this.form = {
+          name: '',
+          client_id: '',
+          token_endpoint_auth_method: 'client_secret_basic',
+          redirect_uris_text: '',
+          grant_types_text: 'authorization_code refresh_token',
+          scope: 'openid profile email',
+          enabled: true,
+        };
+      }
+    },
+
+    async submit() {
+      this.saving = true;
+      this.error = null;
+      const redirect_uris = this.form.redirect_uris_text
+        .split(/\n|,/)
+        .map(s => s.trim())
+        .filter(Boolean);
+      const grant_types = this.form.grant_types_text
+        .split(/\s+|,/)
+        .map(s => s.trim())
+        .filter(Boolean);
+      const body = {
+        name: this.form.name,
+        redirect_uris,
+        grant_types,
+        scope: this.form.scope,
+        token_endpoint_auth_method: this.form.token_endpoint_auth_method,
+        enabled: this.form.enabled,
+      };
+      const mode = Alpine.store('modals').client.mode;
+      let res;
+      if (mode === 'edit') {
+        const id = Alpine.store('modals').client.initial.id;
+        res = await fetch(`/admin/api/clients/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      } else {
+        if (this.form.client_id) body.client_id = this.form.client_id;
+        res = await fetch('/admin/api/clients', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      }
+      this.saving = false;
+      if (!res.ok) {
+        try {
+          const err = await res.json();
+          this.error = err.error_description || err.error || `HTTP ${res.status}`;
+        } catch (_) {
+          this.error = `HTTP ${res.status}`;
+        }
+        return;
+      }
+      const data = await res.json().catch(() => ({}));
+      const onDone = Alpine.store('modals').client.onDone;
+      if (onDone) onDone();
+      if (data.client_secret) {
+        this.createdSecret = data.client_secret;
+      } else {
+        Alpine.store('modals').client.open = false;
+      }
+    },
+  };
+}
+
+// ─── Modal: Create/Edit User ─────────────────────────────────────────────────
+
+function userFormModal() {
+  return {
+    saving: false,
+    error: null,
+    form: {
+      username: '',
+      email: '',
+      password: '',
+      role: 'user',
+      enabled: true,
+    },
+
+    init() {
+      this.$watch('$store.modals.user.open', (open) => {
+        if (open) this._reset();
+      });
+    },
+
+    _reset() {
+      const init = Alpine.store('modals').user.initial;
+      this.saving = false;
+      this.error = null;
+      if (init) {
+        this.form = {
+          username: init.username || '',
+          email: init.email || '',
+          password: '',
+          role: init.role || 'user',
+          enabled: init.enabled !== false,
+        };
+      } else {
+        this.form = {
+          username: '',
+          email: '',
+          password: '',
+          role: 'user',
+          enabled: true,
+        };
+      }
+    },
+
+    async submit() {
+      this.saving = true;
+      this.error = null;
+      const mode = Alpine.store('modals').user.mode;
+      let res;
+      if (mode === 'edit') {
+        const id = Alpine.store('modals').user.initial.id;
+        res = await fetch(`/admin/api/users/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: this.form.email,
+            role: this.form.role,
+            enabled: this.form.enabled,
+          }),
+        });
+      } else {
+        res = await fetch('/admin/api/users', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            username: this.form.username,
+            email: this.form.email,
+            password: this.form.password,
+            role: this.form.role,
+            enabled: this.form.enabled,
+          }),
+        });
+      }
+      this.saving = false;
+      if (!res.ok) {
+        try {
+          const err = await res.json();
+          this.error = err.error_description || err.error || `HTTP ${res.status}`;
+        } catch (_) {
+          this.error = `HTTP ${res.status}`;
+        }
+        return;
+      }
+      const onDone = Alpine.store('modals').user.onDone;
+      if (onDone) onDone();
+      Alpine.store('modals').user.open = false;
+    },
+  };
+}
+
+// ─── Modal: Reset Password ───────────────────────────────────────────────────
+
+function passwordModal() {
+  return {
+    password: '',
+    saving: false,
+    error: null,
+    init() {
+      this.$watch('$store.modals.password.open', (open) => {
+        if (open) {
+          this.password = '';
+          this.error = null;
+          this.saving = false;
+        }
+      });
+    },
+    async submit() {
+      if (this.password.length < 8) {
+        this.error = 'Password must be at least 8 characters';
+        return;
+      }
+      this.saving = true;
+      const userId = Alpine.store('modals').password.userId;
+      const res = await fetch(`/admin/api/users/${userId}/password`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: this.password }),
+      });
+      this.saving = false;
+      if (!res.ok) {
+        try {
+          const err = await res.json();
+          this.error = err.error_description || err.error || `HTTP ${res.status}`;
+        } catch (_) {
+          this.error = `HTTP ${res.status}`;
+        }
+        return;
+      }
+      Alpine.store('modals').password.open = false;
+    },
+  };
+}
+
+// ─── Modal: Add Denylist Entry ───────────────────────────────────────────────
+
+function denylistModal() {
+  return {
+    saving: false,
+    error: null,
+    form: {
+      kind: 'ip',
+      value: '',
+      reason: '',
+      expires_at_local: '',
+    },
+    init() {
+      this.$watch('$store.modals.denylist.open', (open) => {
+        if (open) {
+          this.form = { kind: 'ip', value: '', reason: '', expires_at_local: '' };
+          this.saving = false;
+          this.error = null;
+        }
+      });
+    },
+    async submit() {
+      if (!this.form.value.trim()) {
+        this.error = 'value is required';
+        return;
+      }
+      this.saving = true;
+      const body = {
+        kind: this.form.kind,
+        value: this.form.value.trim(),
+        reason: this.form.reason,
+      };
+      if (this.form.expires_at_local) {
+        try {
+          body.expires_at = new Date(this.form.expires_at_local).toISOString();
+        } catch (_) {}
+      }
+      const res = await fetch('/admin/api/denylist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      this.saving = false;
+      if (!res.ok) {
+        try {
+          const err = await res.json();
+          this.error = err.error_description || err.error || `HTTP ${res.status}`;
+        } catch (_) {
+          this.error = `HTTP ${res.status}`;
+        }
+        return;
+      }
+      const onDone = Alpine.store('modals').denylist.onDone;
+      if (onDone) onDone();
+      Alpine.store('modals').denylist.open = false;
     },
   };
 }

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -253,6 +253,18 @@
           <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
           Events
         </button>
+        <button @click="$store.router.navigate('denylist')" x-show="$store.caps.denylist"
+                :class="$store.router.page === 'denylist' ? 'nav-link-active' : ''"
+                class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg>
+          Denylist
+        </button>
+        <button @click="$store.router.navigate('audit')" x-show="$store.caps.audit_log"
+                :class="$store.router.page === 'audit' ? 'nav-link-active' : ''"
+                class="nav-link">
+          <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="8" y1="13" x2="16" y2="13"/><line x1="8" y1="17" x2="12" y2="17"/></svg>
+          Audit Log
+        </button>
         <a href="/health" target="_blank" class="nav-link">
           <svg class="w-4 h-4 opacity-80" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
           Health
@@ -466,6 +478,7 @@
             <select x-model="limit" @change="setPageSize($event.target.value)" class="select text-sm py-1.5">
               <option>10</option><option selected>25</option><option>50</option><option>100</option>
             </select>
+            <button @click="openCreateModal()" class="btn btn-primary text-xs">+ New Client</button>
           </div>
           <!-- Table -->
           <div class="overflow-x-auto">
@@ -509,9 +522,18 @@
                     </td>
                     <td class="table-cell text-slate-500 max-w-xs truncate" x-text="item.scope"></td>
                     <td class="table-cell text-slate-500 whitespace-nowrap" x-text="relativeTime(item.created_at)"></td>
-                    <td class="table-cell">
-                      <button @click.stop="deleteClient(item, $event)"
-                              class="btn btn-danger text-xs py-1 px-2">Delete</button>
+                    <td class="table-cell whitespace-nowrap">
+                      <div class="flex gap-1 flex-wrap">
+                        <button @click.stop="toggleEnabled(item, $event)"
+                                class="btn btn-secondary text-xs py-1 px-2"
+                                x-text="item.enabled === false ? 'Enable' : 'Disable'"></button>
+                        <button @click.stop="rotateSecret(item, $event)" x-show="item.token_endpoint_auth_method !== 'none'"
+                                class="btn btn-secondary text-xs py-1 px-2">Rotate Secret</button>
+                        <button @click.stop="revokeAllTokens(item, $event)"
+                                class="btn btn-secondary text-xs py-1 px-2">Revoke Tokens</button>
+                        <button @click.stop="deleteClient(item, $event)"
+                                class="btn btn-danger text-xs py-1 px-2">Delete</button>
+                      </div>
                     </td>
                   </tr>
                 </template>
@@ -662,6 +684,7 @@
             <select x-model="limit" @change="setPageSize($event.target.value)" class="select text-sm py-1.5">
               <option>10</option><option selected>25</option><option>50</option><option>100</option>
             </select>
+            <button @click="openCreateModal()" class="btn btn-primary text-xs">+ New User</button>
           </div>
           <div class="overflow-x-auto">
             <table class="w-full text-sm">
@@ -672,11 +695,12 @@
                   <th class="table-header">Role</th>
                   <th class="table-header">Status</th>
                   <th class="table-header cursor-pointer" @click="sort('created_at')">Created <span class="text-xs opacity-60" x-text="sortIcon('created_at')"></span></th>
+                  <th class="table-header">Actions</th>
                 </tr>
               </thead>
               <tbody>
-                <template x-if="loading"><tr><td colspan="5" class="table-cell py-10 text-center"><div class="animate-spin inline-block w-5 h-5 border-2 border-primary-600 border-t-transparent rounded-full"></div></td></tr></template>
-                <template x-if="!loading && items.length === 0"><tr><td colspan="5" class="table-cell text-slate-400 py-10 text-center">No users found</td></tr></template>
+                <template x-if="loading"><tr><td colspan="6" class="table-cell py-10 text-center"><div class="animate-spin inline-block w-5 h-5 border-2 border-primary-600 border-t-transparent rounded-full"></div></td></tr></template>
+                <template x-if="!loading && items.length === 0"><tr><td colspan="6" class="table-cell text-slate-400 py-10 text-center">No users found</td></tr></template>
                 <template x-for="item in items" :key="item.id">
                   <tr class="table-row" @click="openDrawer(item)">
                     <td class="table-cell font-medium" x-text="item.username"></td>
@@ -684,6 +708,128 @@
                     <td class="table-cell"><span :class="item.role === 'admin' ? 'badge-blue' : 'badge-gray'" class="badge" x-text="item.role"></span></td>
                     <td class="table-cell"><span :class="item.enabled ? 'badge-green' : 'badge-red'" class="badge" x-text="item.enabled ? 'Enabled' : 'Disabled'"></span></td>
                     <td class="table-cell text-slate-500 whitespace-nowrap" x-text="relativeTime(item.created_at)"></td>
+                    <td class="table-cell whitespace-nowrap">
+                      <div class="flex gap-1 flex-wrap">
+                        <button @click.stop="toggleEnabled(item, $event)"
+                                class="btn btn-secondary text-xs py-1 px-2"
+                                x-text="item.enabled ? 'Disable' : 'Enable'"></button>
+                        <button @click.stop="toggleRole(item, $event)"
+                                class="btn btn-secondary text-xs py-1 px-2"
+                                x-text="item.role === 'admin' ? 'Make User' : 'Make Admin'"></button>
+                        <button @click.stop="openPasswordModal(item)"
+                                class="btn btn-secondary text-xs py-1 px-2">Reset Pw</button>
+                        <button @click.stop="deleteUser(item, $event)"
+                                class="btn btn-danger text-xs py-1 px-2">Delete</button>
+                      </div>
+                    </td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+          <div class="flex items-center justify-between px-4 py-3 border-t border-slate-200 dark:border-slate-700 text-sm text-slate-500">
+            <span x-text="total === 0 ? 'No results' : `${pageStart}–${pageEnd} of ${total}`"></span>
+            <div class="flex gap-2">
+              <button @click="prevPage()" :disabled="!hasPrev" class="btn btn-secondary disabled:opacity-40">← Prev</button>
+              <button @click="nextPage()" :disabled="!hasNext" class="btn btn-secondary disabled:opacity-40">Next →</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ══ Denylist ════════════════════════════════════════════════════ -->
+      <div x-show="$store.router.page === 'denylist'"
+           x-data="denylistPage()"
+           x-init="init()"
+           @navigate.away="destroy && destroy()">
+        <div class="card overflow-hidden">
+          <div class="flex flex-wrap items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-700">
+            <h2 class="text-sm font-semibold text-slate-700 dark:text-slate-300 mr-auto">Denylist</h2>
+            <select x-model="limit" @change="setPageSize($event.target.value)" class="select text-sm py-1.5">
+              <option>10</option><option selected>25</option><option>50</option><option>100</option>
+            </select>
+            <button @click="openAddModal()" class="btn btn-primary text-xs">+ Add Entry</button>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead class="bg-slate-50 dark:bg-slate-900/50">
+                <tr>
+                  <th class="table-header">Kind</th>
+                  <th class="table-header">Value</th>
+                  <th class="table-header">Reason</th>
+                  <th class="table-header">By</th>
+                  <th class="table-header">Active</th>
+                  <th class="table-header cursor-pointer" @click="sort('created_at')">Created <span class="text-xs opacity-60" x-text="sortIcon('created_at')"></span></th>
+                  <th class="table-header">Expires</th>
+                  <th class="table-header">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <template x-if="loading"><tr><td colspan="8" class="table-cell py-10 text-center"><div class="animate-spin inline-block w-5 h-5 border-2 border-primary-600 border-t-transparent rounded-full"></div></td></tr></template>
+                <template x-if="!loading && items.length === 0"><tr><td colspan="8" class="table-cell text-slate-400 py-10 text-center">No denylist entries</td></tr></template>
+                <template x-for="item in items" :key="item.id">
+                  <tr class="table-row">
+                    <td class="table-cell"><span class="badge badge-gray" x-text="item.kind"></span></td>
+                    <td class="table-cell font-mono text-xs break-all" x-text="item.value"></td>
+                    <td class="table-cell text-slate-500" x-text="item.reason || '—'"></td>
+                    <td class="table-cell text-slate-500" x-text="item.created_by || '—'"></td>
+                    <td class="table-cell"><span :class="item.active ? 'badge-red' : 'badge-gray'" class="badge" x-text="item.active ? 'active' : 'expired'"></span></td>
+                    <td class="table-cell text-slate-500 whitespace-nowrap" x-text="relativeTime(item.created_at)"></td>
+                    <td class="table-cell text-slate-500 whitespace-nowrap" x-text="item.expires_at ? relativeTime(item.expires_at) : '—'"></td>
+                    <td class="table-cell">
+                      <button @click.stop="remove(item, $event)" class="btn btn-danger text-xs py-1 px-2">Remove</button>
+                    </td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+          <div class="flex items-center justify-between px-4 py-3 border-t border-slate-200 dark:border-slate-700 text-sm text-slate-500">
+            <span x-text="total === 0 ? 'No results' : `${pageStart}–${pageEnd} of ${total}`"></span>
+            <div class="flex gap-2">
+              <button @click="prevPage()" :disabled="!hasPrev" class="btn btn-secondary disabled:opacity-40">← Prev</button>
+              <button @click="nextPage()" :disabled="!hasNext" class="btn btn-secondary disabled:opacity-40">Next →</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ══ Audit Log ═══════════════════════════════════════════════════ -->
+      <div x-show="$store.router.page === 'audit'"
+           x-data="auditPage()"
+           x-init="init()"
+           @navigate.away="destroy && destroy()">
+        <div class="card overflow-hidden">
+          <div class="flex flex-wrap items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-700">
+            <h2 class="text-sm font-semibold text-slate-700 dark:text-slate-300 mr-auto">Audit Log</h2>
+            <select x-model="limit" @change="setPageSize($event.target.value)" class="select text-sm py-1.5">
+              <option>25</option><option selected>50</option><option>100</option><option>200</option>
+            </select>
+            <button @click="load()" class="btn btn-secondary text-xs">Refresh</button>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead class="bg-slate-50 dark:bg-slate-900/50">
+                <tr>
+                  <th class="table-header cursor-pointer" @click="sort('created_at')">When <span class="text-xs opacity-60" x-text="sortIcon('created_at')"></span></th>
+                  <th class="table-header">Actor</th>
+                  <th class="table-header">Action</th>
+                  <th class="table-header">Target</th>
+                  <th class="table-header">IP</th>
+                  <th class="table-header">Details</th>
+                </tr>
+              </thead>
+              <tbody>
+                <template x-if="loading"><tr><td colspan="6" class="table-cell py-10 text-center"><div class="animate-spin inline-block w-5 h-5 border-2 border-primary-600 border-t-transparent rounded-full"></div></td></tr></template>
+                <template x-if="!loading && items.length === 0"><tr><td colspan="6" class="table-cell text-slate-400 py-10 text-center">No audit events yet</td></tr></template>
+                <template x-for="item in items" :key="item.id">
+                  <tr class="table-row">
+                    <td class="table-cell whitespace-nowrap text-slate-500" x-text="relativeTime(item.created_at)"></td>
+                    <td class="table-cell text-slate-700 dark:text-slate-300" x-text="item.actor_email || item.actor_id || '—'"></td>
+                    <td class="table-cell"><span class="badge badge-blue font-mono" x-text="item.action"></span></td>
+                    <td class="table-cell text-slate-500"><span x-text="item.target_kind"></span><span x-show="item.target_id">: <code class="text-xs" x-text="item.target_id.slice(0,12)"></code></span></td>
+                    <td class="table-cell text-slate-500 font-mono text-xs" x-text="item.ip || '—'"></td>
+                    <td class="table-cell text-slate-500 text-xs max-w-md truncate" x-text="item.metadata || '—'"></td>
                   </tr>
                 </template>
               </tbody>
@@ -1018,6 +1164,169 @@
     <div class="flex justify-end gap-2">
       <button @click="$store.router.showRotateModal = false" class="btn btn-secondary">Cancel</button>
       <button @click="rotate()" :disabled="rotating" class="btn btn-primary" x-text="rotating ? 'Rotating…' : 'Rotate'"></button>
+    </div>
+  </div>
+</div>
+
+<!-- ══ Create / Edit Client modal ════════════════════════════════════════ -->
+<div style="display:none"
+     x-data="clientFormModal()"
+     x-show="$store.modals.client.open"
+     @click.self="$store.modals.client.open = false"
+     @keydown.escape.window="$store.modals.client.open = false"
+     class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+  <div class="bg-white dark:bg-slate-800 rounded-xl shadow-xl w-full max-w-lg p-6 space-y-4">
+    <h3 class="font-semibold text-slate-800 dark:text-slate-200" x-text="$store.modals.client.mode === 'edit' ? 'Edit Client' : 'New Client'"></h3>
+    <div class="space-y-3 text-sm max-h-[60vh] overflow-y-auto">
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Name <span class="text-red-500">*</span></label>
+        <input type="text" x-model="form.name" class="input w-full" placeholder="Acme SSO">
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Client ID <span class="text-slate-400">(optional, auto-generated)</span></label>
+        <input type="text" x-model="form.client_id" class="input w-full" :disabled="$store.modals.client.mode === 'edit'" placeholder="leave blank to auto-generate">
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Auth Method</label>
+        <select x-model="form.token_endpoint_auth_method" class="select w-full">
+          <option value="client_secret_basic">client_secret_basic</option>
+          <option value="client_secret_post">client_secret_post</option>
+          <option value="client_secret_jwt">client_secret_jwt</option>
+          <option value="private_key_jwt">private_key_jwt</option>
+          <option value="none">none (public)</option>
+        </select>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Redirect URIs (one per line)</label>
+        <textarea x-model="form.redirect_uris_text" rows="3" class="input w-full font-mono text-xs" placeholder="https://app.example.com/callback"></textarea>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Grant Types (space-separated)</label>
+        <input type="text" x-model="form.grant_types_text" class="input w-full" placeholder="authorization_code refresh_token">
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Scope</label>
+        <input type="text" x-model="form.scope" class="input w-full" placeholder="openid profile email">
+      </div>
+      <div x-show="$store.modals.client.mode === 'edit'">
+        <label class="inline-flex items-center gap-2 text-xs text-slate-600 dark:text-slate-400">
+          <input type="checkbox" x-model="form.enabled"> Enabled
+        </label>
+      </div>
+      <p x-show="error" class="text-xs text-red-500" x-text="error"></p>
+      <div x-show="createdSecret" class="p-3 rounded bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 text-xs">
+        <p class="font-semibold text-amber-800 dark:text-amber-300 mb-1">Copy this secret now — it will not be shown again.</p>
+        <code class="block font-mono break-all text-amber-900 dark:text-amber-200" x-text="createdSecret"></code>
+      </div>
+    </div>
+    <div class="flex justify-end gap-2">
+      <button @click="$store.modals.client.open = false" class="btn btn-secondary" x-text="createdSecret ? 'Close' : 'Cancel'"></button>
+      <button x-show="!createdSecret" @click="submit()" :disabled="saving" class="btn btn-primary" x-text="saving ? 'Saving…' : 'Save'"></button>
+    </div>
+  </div>
+</div>
+
+<!-- ══ Create / Edit User modal ════════════════════════════════════════ -->
+<div style="display:none"
+     x-data="userFormModal()"
+     x-show="$store.modals.user.open"
+     @click.self="$store.modals.user.open = false"
+     @keydown.escape.window="$store.modals.user.open = false"
+     class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+  <div class="bg-white dark:bg-slate-800 rounded-xl shadow-xl w-full max-w-md p-6 space-y-4">
+    <h3 class="font-semibold text-slate-800 dark:text-slate-200" x-text="$store.modals.user.mode === 'edit' ? 'Edit User' : 'New User'"></h3>
+    <div class="space-y-3 text-sm">
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Username <span class="text-red-500">*</span></label>
+        <input type="text" x-model="form.username" class="input w-full" :disabled="$store.modals.user.mode === 'edit'">
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Email <span class="text-red-500">*</span></label>
+        <input type="email" x-model="form.email" class="input w-full">
+      </div>
+      <div x-show="$store.modals.user.mode !== 'edit'">
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Password <span class="text-red-500">*</span></label>
+        <input type="password" x-model="form.password" class="input w-full" placeholder="min 8 characters">
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Role</label>
+        <select x-model="form.role" class="select w-full">
+          <option value="user">user</option>
+          <option value="admin">admin</option>
+        </select>
+      </div>
+      <div>
+        <label class="inline-flex items-center gap-2 text-xs text-slate-600 dark:text-slate-400">
+          <input type="checkbox" x-model="form.enabled"> Enabled
+        </label>
+      </div>
+      <p x-show="error" class="text-xs text-red-500" x-text="error"></p>
+    </div>
+    <div class="flex justify-end gap-2">
+      <button @click="$store.modals.user.open = false" class="btn btn-secondary">Cancel</button>
+      <button @click="submit()" :disabled="saving" class="btn btn-primary" x-text="saving ? 'Saving…' : 'Save'"></button>
+    </div>
+  </div>
+</div>
+
+<!-- ══ Reset Password modal ══════════════════════════════════════════════ -->
+<div style="display:none"
+     x-data="passwordModal()"
+     x-show="$store.modals.password.open"
+     @click.self="$store.modals.password.open = false"
+     @keydown.escape.window="$store.modals.password.open = false"
+     class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+  <div class="bg-white dark:bg-slate-800 rounded-xl shadow-xl w-full max-w-sm p-6 space-y-4">
+    <h3 class="font-semibold text-slate-800 dark:text-slate-200">Reset Password</h3>
+    <p class="text-xs text-slate-500">Resetting password for <span class="font-mono" x-text="$store.modals.password.username"></span>. All active tokens will be revoked.</p>
+    <div class="space-y-3 text-sm">
+      <input type="password" x-model="password" class="input w-full" placeholder="New password (min 8 chars)">
+      <p x-show="error" class="text-xs text-red-500" x-text="error"></p>
+    </div>
+    <div class="flex justify-end gap-2">
+      <button @click="$store.modals.password.open = false" class="btn btn-secondary">Cancel</button>
+      <button @click="submit()" :disabled="saving" class="btn btn-danger" x-text="saving ? 'Resetting…' : 'Reset'"></button>
+    </div>
+  </div>
+</div>
+
+<!-- ══ Add Denylist Entry modal ══════════════════════════════════════════ -->
+<div style="display:none"
+     x-data="denylistModal()"
+     x-show="$store.modals.denylist.open"
+     @click.self="$store.modals.denylist.open = false"
+     @keydown.escape.window="$store.modals.denylist.open = false"
+     class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+  <div class="bg-white dark:bg-slate-800 rounded-xl shadow-xl w-full max-w-md p-6 space-y-4">
+    <h3 class="font-semibold text-slate-800 dark:text-slate-200">Add Denylist Entry</h3>
+    <div class="space-y-3 text-sm">
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Kind</label>
+        <select x-model="form.kind" class="select w-full">
+          <option value="ip">IP address</option>
+          <option value="username">Username</option>
+          <option value="email">Email</option>
+          <option value="user_id">User ID</option>
+          <option value="client_id">Client ID</option>
+        </select>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Value <span class="text-red-500">*</span></label>
+        <input type="text" x-model="form.value" class="input w-full">
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Reason</label>
+        <input type="text" x-model="form.reason" class="input w-full" placeholder="e.g. brute-force attempt">
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Expires at (optional ISO-8601)</label>
+        <input type="datetime-local" x-model="form.expires_at_local" class="input w-full">
+      </div>
+      <p x-show="error" class="text-xs text-red-500" x-text="error"></p>
+    </div>
+    <div class="flex justify-end gap-2">
+      <button @click="$store.modals.denylist.open = false" class="btn btn-secondary">Cancel</button>
+      <button @click="submit()" :disabled="saving" class="btn btn-primary" x-text="saving ? 'Adding…' : 'Add'"></button>
     </div>
   </div>
 </div>

--- a/tests/admin_denylist_middleware.rs
+++ b/tests/admin_denylist_middleware.rs
@@ -1,0 +1,129 @@
+//! Integration test for the DenylistGuard middleware — requests from
+//! denylisted IPs must be rejected with 403 before reaching the handler.
+
+use actix_web::{test, web, App, HttpResponse};
+use oauth2_core::{DenylistEntry, DENYLIST_KIND_IP};
+use oauth2_ports::DynStorage;
+
+async fn setup_storage() -> DynStorage {
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    let url = format!("sqlite://{}", tmp.path().display());
+    std::mem::forget(tmp);
+    let storage = oauth2_storage_factory::create_storage(&url)
+        .await
+        .expect("create storage");
+    storage.init().await.expect("init");
+    storage
+}
+
+async fn echo_ok() -> HttpResponse {
+    HttpResponse::Ok().body("ok")
+}
+
+#[actix_web::test]
+async fn middleware_allows_requests_from_non_denylisted_ip() {
+    let storage = setup_storage().await;
+
+    let app = test::init_service(
+        App::new()
+            .wrap(oauth2_actix::middleware::denylist::DenylistGuard)
+            .app_data(web::Data::new(storage))
+            .route("/echo", web::get().to(echo_ok)),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/echo")
+        .peer_addr("203.0.113.99:40000".parse().unwrap())
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+}
+
+#[actix_web::test]
+async fn middleware_blocks_denylisted_ip() {
+    let storage = setup_storage().await;
+    let entry = DenylistEntry::new(
+        DENYLIST_KIND_IP,
+        "198.51.100.5",
+        "brute force",
+        "admin@test.example",
+    );
+    storage.add_denylist_entry(&entry).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(oauth2_actix::middleware::denylist::DenylistGuard)
+            .app_data(web::Data::new(storage))
+            .route("/echo", web::get().to(echo_ok)),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/echo")
+        .peer_addr("198.51.100.5:40000".parse().unwrap())
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 403);
+
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body["error"], "access_denied");
+}
+
+#[actix_web::test]
+async fn middleware_honors_expired_denylist_entries() {
+    let storage = setup_storage().await;
+    let mut entry = DenylistEntry::new(
+        DENYLIST_KIND_IP,
+        "192.0.2.77",
+        "temporary",
+        "admin@test.example",
+    );
+    entry.expires_at = Some(chrono::Utc::now() - chrono::Duration::minutes(10));
+    storage.add_denylist_entry(&entry).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(oauth2_actix::middleware::denylist::DenylistGuard)
+            .app_data(web::Data::new(storage))
+            .route("/echo", web::get().to(echo_ok)),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/echo")
+        .peer_addr("192.0.2.77:40000".parse().unwrap())
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        200,
+        "expired denylist entries no longer block"
+    );
+}
+
+#[actix_web::test]
+async fn check_subject_denylisted_returns_reason() {
+    let storage = setup_storage().await;
+    let entry = DenylistEntry::new("username", "mallory", "abuse", "admin@test.example");
+    storage.add_denylist_entry(&entry).await.unwrap();
+
+    let hit = oauth2_actix::middleware::denylist::check_subject_denylisted(
+        &storage, "username", "mallory",
+    )
+    .await;
+    assert_eq!(hit.as_deref(), Some("abuse"));
+
+    let miss =
+        oauth2_actix::middleware::denylist::check_subject_denylisted(&storage, "username", "alice")
+            .await;
+    assert!(miss.is_none());
+}
+
+#[actix_web::test]
+async fn check_subject_denylisted_ignores_empty_value() {
+    let storage = setup_storage().await;
+    let hit =
+        oauth2_actix::middleware::denylist::check_subject_denylisted(&storage, "email", "").await;
+    assert!(hit.is_none());
+}

--- a/tests/admin_extra.rs
+++ b/tests/admin_extra.rs
@@ -1,0 +1,1218 @@
+//! Integration tests for admin-maintainer endpoints added in V17:
+//! user CRUD, client CRUD extensions, denylist, audit log, bulk revoke.
+//!
+//! Every test stands up an isolated `sqlite::memory:` backend and mounts just
+//! the handler(s) under test behind a minimal SessionMiddleware so
+//! `build_audit` can read the session.
+
+use actix_session::{storage::CookieSessionStore, Session, SessionMiddleware};
+use actix_web::{cookie::Key, test, web, App, HttpResponse};
+use serde_json::{json, Value};
+
+use oauth2_actix::handlers::{admin, admin_extra};
+use oauth2_core::{Client, DenylistEntry, ListQuery, Token, User};
+use oauth2_ports::DynStorage;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn setup_storage() -> DynStorage {
+    // Use a unique file-backed SQLite per test. `sqlite::memory:` creates a
+    // fresh database per connection, so a pool with >1 connection loses
+    // writes when reads hit a different connection. We also can't use a
+    // shared in-process memory DB because tests run concurrently.
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    let url = format!("sqlite://{}", tmp.path().display());
+    // Leak the guard so the file outlives the test — Drop removes it.
+    std::mem::forget(tmp);
+    let storage = oauth2_storage_factory::create_storage(&url)
+        .await
+        .expect("create storage");
+    storage.init().await.expect("init");
+    storage
+}
+
+/// Seed a persistent admin session so `build_audit` can record the actor.
+async fn seed_session(session: Session) -> HttpResponse {
+    let _ = session.insert("user_id", "admin-uid".to_string());
+    let _ = session.insert("email", "admin@test.example".to_string());
+    let _ = session.insert("role", "admin".to_string());
+    HttpResponse::Ok().finish()
+}
+
+/// Cookie-store key for session middleware. Stable so session cookies
+/// produced by `/test/login` can be reused across subsequent requests.
+fn session_key() -> Key {
+    Key::from(&[42u8; 64])
+}
+
+/// Produce a signed session cookie header value for the seeded admin
+/// session by invoking `/test/login`. Done as a macro so the caller's
+/// concrete service type stays opaque.
+macro_rules! admin_cookie {
+    ($app:expr) => {{
+        let req = test::TestRequest::get().uri("/test/login").to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 200);
+        resp.headers()
+            .get("set-cookie")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.split(';').next().unwrap_or("").to_string())
+            .expect("set-cookie header")
+    }};
+}
+
+fn make_user(username: &str) -> User {
+    User::new(
+        username.to_string(),
+        "$argon2id$unused".to_string(),
+        format!("{username}@test.example"),
+    )
+}
+
+fn make_client_row(suffix: &str) -> Client {
+    Client::new(
+        format!("client-{suffix}"),
+        "secret".to_string(),
+        vec!["https://example.com/cb".to_string()],
+        vec!["authorization_code".to_string()],
+        "read".to_string(),
+        format!("Client {suffix}"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// User CRUD
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn create_user_succeeds_and_hashes_password() {
+    let storage = setup_storage().await;
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route("/admin/api/users", web::post().to(admin_extra::create_user)),
+    )
+    .await;
+
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/users")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({
+            "username": "alice",
+            "email": "alice@test.example",
+            "password": "correcthorsebatterystaple",
+            "role": "user"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201);
+
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["username"], "alice");
+    assert_eq!(body["role"], "user");
+    assert_eq!(body["enabled"], true);
+
+    // Verify storage round-trip + password hashed (not plain).
+    let stored = storage
+        .get_user_by_username("alice")
+        .await
+        .unwrap()
+        .expect("user persisted");
+    assert!(stored.password_hash.starts_with("$argon2"));
+    assert_ne!(stored.password_hash, "correcthorsebatterystaple");
+}
+
+#[actix_web::test]
+async fn create_user_rejects_missing_fields() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .route("/test/login", web::get().to(seed_session))
+            .route("/admin/api/users", web::post().to(admin_extra::create_user)),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/users")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "username": "", "email": "", "password": "" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 400);
+}
+
+#[actix_web::test]
+async fn create_user_rejects_duplicate_username() {
+    let storage = setup_storage().await;
+    storage.save_user(&make_user("dup")).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .route("/test/login", web::get().to(seed_session))
+            .route("/admin/api/users", web::post().to(admin_extra::create_user)),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/users")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({
+            "username": "dup",
+            "email": "dup2@test.example",
+            "password": "whatever123"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 409);
+}
+
+#[actix_web::test]
+async fn update_user_patches_email_and_role() {
+    let storage = setup_storage().await;
+    let user = make_user("patchme");
+    storage.save_user(&user).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/users/{id}",
+                web::put().to(admin_extra::update_user),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::put()
+        .uri(&format!("/admin/api/users/{}", user.id))
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "email": "new@test.example", "role": "admin" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let reloaded = storage.get_user_by_id(&user.id).await.unwrap().unwrap();
+    assert_eq!(reloaded.email, "new@test.example");
+    assert_eq!(reloaded.role, "admin");
+}
+
+#[actix_web::test]
+async fn update_user_ignores_invalid_role() {
+    let storage = setup_storage().await;
+    let user = make_user("rolechk");
+    storage.save_user(&user).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/users/{id}",
+                web::put().to(admin_extra::update_user),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::put()
+        .uri(&format!("/admin/api/users/{}", user.id))
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "role": "superhacker" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let reloaded = storage.get_user_by_id(&user.id).await.unwrap().unwrap();
+    assert_eq!(reloaded.role, "user", "invalid role kept as 'user'");
+}
+
+#[actix_web::test]
+async fn update_user_404_for_missing() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/users/{id}",
+                web::put().to(admin_extra::update_user),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::put()
+        .uri("/admin/api/users/ghost-id")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "email": "x@y.z" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 404);
+}
+
+#[actix_web::test]
+async fn delete_user_removes_row_and_revokes_tokens() {
+    let storage = setup_storage().await;
+    let user = make_user("bye");
+    storage.save_user(&user).await.unwrap();
+    let client = make_client_row("del");
+    storage.save_client(&client).await.unwrap();
+
+    // Seed a live token for the user.
+    let token = Token::new(
+        "access-delete".to_string(),
+        Some("refresh-delete".to_string()),
+        client.client_id.clone(),
+        Some(user.id.clone()),
+        "read".to_string(),
+        3600,
+        None,
+    );
+    storage.save_token(&token).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/users/{id}",
+                web::delete().to(admin_extra::delete_user),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::delete()
+        .uri(&format!("/admin/api/users/{}", user.id))
+        .insert_header(("Cookie", cookie))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    assert!(storage.get_user_by_id(&user.id).await.unwrap().is_none());
+    let revoked = storage
+        .get_token_by_access_token("access-delete")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(revoked.revoked, "user deletion cascades token revocation");
+}
+
+#[actix_web::test]
+async fn set_user_enabled_toggles_flag_and_revokes_on_disable() {
+    let storage = setup_storage().await;
+    let user = make_user("onoff");
+    storage.save_user(&user).await.unwrap();
+    let client = make_client_row("enabled");
+    storage.save_client(&client).await.unwrap();
+
+    let token = Token::new(
+        "access-disable".to_string(),
+        None,
+        client.client_id.clone(),
+        Some(user.id.clone()),
+        "read".to_string(),
+        3600,
+        None,
+    );
+    storage.save_token(&token).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/users/{id}/enabled",
+                web::post().to(admin_extra::set_user_enabled),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    // Disable
+    let req = test::TestRequest::post()
+        .uri(&format!("/admin/api/users/{}/enabled", user.id))
+        .insert_header(("Cookie", cookie.clone()))
+        .set_json(json!({ "enabled": false }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let reloaded = storage.get_user_by_id(&user.id).await.unwrap().unwrap();
+    assert!(!reloaded.enabled);
+    let revoked = storage
+        .get_token_by_access_token("access-disable")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(revoked.revoked, "disable revokes active tokens");
+
+    // Re-enable
+    let req = test::TestRequest::post()
+        .uri(&format!("/admin/api/users/{}/enabled", user.id))
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "enabled": true }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let reloaded = storage.get_user_by_id(&user.id).await.unwrap().unwrap();
+    assert!(reloaded.enabled);
+}
+
+#[actix_web::test]
+async fn set_user_role_rejects_invalid_role() {
+    let storage = setup_storage().await;
+    let user = make_user("rolerej");
+    storage.save_user(&user).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/users/{id}/role",
+                web::post().to(admin_extra::set_user_role),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/admin/api/users/{}/role", user.id))
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "role": "root" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 400);
+}
+
+#[actix_web::test]
+async fn reset_user_password_rejects_weak_password() {
+    let storage = setup_storage().await;
+    let user = make_user("pwrej");
+    storage.save_user(&user).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/users/{id}/password",
+                web::post().to(admin_extra::reset_user_password),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/admin/api/users/{}/password", user.id))
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "password": "short" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 400);
+}
+
+#[actix_web::test]
+async fn reset_user_password_updates_hash_and_revokes_tokens() {
+    let storage = setup_storage().await;
+    let user = make_user("pwok");
+    storage.save_user(&user).await.unwrap();
+    let client = make_client_row("pw");
+    storage.save_client(&client).await.unwrap();
+    let token = Token::new(
+        "access-pwreset".to_string(),
+        None,
+        client.client_id.clone(),
+        Some(user.id.clone()),
+        "read".to_string(),
+        3600,
+        None,
+    );
+    storage.save_token(&token).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/users/{id}/password",
+                web::post().to(admin_extra::reset_user_password),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/admin/api/users/{}/password", user.id))
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "password": "a-very-solid-password" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let reloaded = storage.get_user_by_id(&user.id).await.unwrap().unwrap();
+    assert_ne!(reloaded.password_hash, user.password_hash);
+    assert!(reloaded.password_hash.starts_with("$argon2"));
+
+    let revoked = storage
+        .get_token_by_access_token("access-pwreset")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(revoked.revoked, "password reset revokes all active tokens");
+}
+
+// ---------------------------------------------------------------------------
+// Client CRUD extensions
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn create_client_confidential_returns_secret_once() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/clients",
+                web::post().to(admin_extra::create_client),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/clients")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({
+            "name": "Acme",
+            "redirect_uris": ["https://acme.test/cb"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "scope": "openid profile"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201);
+
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["name"], "Acme");
+    assert!(body["client_id"].as_str().unwrap().starts_with("client-"));
+    let secret = body["client_secret"]
+        .as_str()
+        .expect("confidential client gets a secret");
+    assert!(secret.len() > 16);
+}
+
+#[actix_web::test]
+async fn create_public_client_has_no_secret() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/clients",
+                web::post().to(admin_extra::create_client),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/clients")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({
+            "name": "Public",
+            "redirect_uris": ["https://public.test/cb"],
+            "token_endpoint_auth_method": "none"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201);
+
+    let body: Value = test::read_body_json(resp).await;
+    assert!(body["client_secret"].is_null());
+    assert_eq!(body["token_endpoint_auth_method"], "none");
+}
+
+#[actix_web::test]
+async fn create_client_rejects_empty_name() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/clients",
+                web::post().to(admin_extra::create_client),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/clients")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "name": "" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 400);
+}
+
+#[actix_web::test]
+async fn update_client_mutates_metadata() {
+    let storage = setup_storage().await;
+    let client = make_client_row("upd");
+    storage.save_client(&client).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/clients/{id}",
+                web::put().to(admin_extra::update_client),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::put()
+        .uri(&format!("/admin/api/clients/{}", client.id))
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({
+            "name": "Updated Acme",
+            "scope": "openid profile email",
+            "enabled": false
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let reloaded = storage
+        .get_client(&client.client_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reloaded.name, "Updated Acme");
+    assert_eq!(reloaded.scope, "openid profile email");
+    assert!(!reloaded.enabled);
+}
+
+#[actix_web::test]
+async fn set_client_enabled_toggles_and_revokes_tokens_on_disable() {
+    let storage = setup_storage().await;
+    let client = make_client_row("togl");
+    storage.save_client(&client).await.unwrap();
+    let token = Token::new(
+        "access-client-disable".to_string(),
+        None,
+        client.client_id.clone(),
+        None,
+        "read".to_string(),
+        3600,
+        None,
+    );
+    storage.save_token(&token).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/clients/{id}/enabled",
+                web::post().to(admin_extra::set_client_enabled),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/admin/api/clients/{}/enabled", client.id))
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "enabled": false }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let reloaded = storage
+        .get_client(&client.client_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!reloaded.enabled);
+    let rev = storage
+        .get_token_by_access_token("access-client-disable")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(rev.revoked);
+}
+
+#[actix_web::test]
+async fn regenerate_client_secret_rejects_public_clients() {
+    let storage = setup_storage().await;
+    let mut client = make_client_row("pub");
+    client.token_endpoint_auth_method = "none".to_string();
+    client.client_secret = String::new();
+    storage.save_client(&client).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/clients/{id}/regenerate-secret",
+                web::post().to(admin_extra::regenerate_client_secret),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri(&format!(
+            "/admin/api/clients/{}/regenerate-secret",
+            client.id
+        ))
+        .insert_header(("Cookie", cookie))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 400);
+}
+
+#[actix_web::test]
+async fn regenerate_client_secret_replaces_secret() {
+    let storage = setup_storage().await;
+    let client = make_client_row("regen");
+    let original_secret = client.client_secret.clone();
+    storage.save_client(&client).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/clients/{id}/regenerate-secret",
+                web::post().to(admin_extra::regenerate_client_secret),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri(&format!(
+            "/admin/api/clients/{}/regenerate-secret",
+            client.id
+        ))
+        .insert_header(("Cookie", cookie))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    let new_secret = body["client_secret"].as_str().unwrap();
+    assert_ne!(new_secret, original_secret);
+
+    let reloaded = storage
+        .get_client(&client.client_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reloaded.client_secret, new_secret);
+}
+
+// ---------------------------------------------------------------------------
+// Denylist
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn add_denylist_entry_round_trips() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/denylist",
+                web::post().to(admin_extra::add_denylist),
+            )
+            .route(
+                "/admin/api/denylist",
+                web::get().to(admin_extra::list_denylist),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/denylist")
+        .insert_header(("Cookie", cookie.clone()))
+        .set_json(json!({
+            "kind": "ip",
+            "value": "198.51.100.10",
+            "reason": "brute force"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201);
+
+    let req = test::TestRequest::get()
+        .uri("/admin/api/denylist")
+        .insert_header(("Cookie", cookie))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["total"].as_u64().unwrap(), 1);
+    assert_eq!(body["items"][0]["kind"], "ip");
+    assert_eq!(body["items"][0]["value"], "198.51.100.10");
+    assert_eq!(body["items"][0]["active"], true);
+}
+
+#[actix_web::test]
+async fn add_denylist_rejects_unknown_kind() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/denylist",
+                web::post().to(admin_extra::add_denylist),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/denylist")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "kind": "country", "value": "ZZ" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 400);
+}
+
+#[actix_web::test]
+async fn add_denylist_upserts_on_duplicate() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/denylist",
+                web::post().to(admin_extra::add_denylist),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    for reason in ["initial", "updated"] {
+        let req = test::TestRequest::post()
+            .uri("/admin/api/denylist")
+            .insert_header(("Cookie", cookie.clone()))
+            .set_json(json!({
+                "kind": "username",
+                "value": "mallory",
+                "reason": reason
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success(), "status: {}", resp.status());
+    }
+
+    let entry = storage
+        .find_denylist_entry("username", "mallory")
+        .await
+        .unwrap()
+        .expect("entry present");
+    assert_eq!(entry.reason, "updated", "latest reason overrides");
+}
+
+#[actix_web::test]
+async fn remove_denylist_clears_entry() {
+    let storage = setup_storage().await;
+    let entry = DenylistEntry::new("ip", "203.0.113.5", "noisy", "admin@test.example");
+    storage.add_denylist_entry(&entry).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/denylist/{id}",
+                web::delete().to(admin_extra::remove_denylist),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::delete()
+        .uri(&format!("/admin/api/denylist/{}", entry.id))
+        .insert_header(("Cookie", cookie))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let page = storage.list_denylist(&ListQuery::default()).await.unwrap();
+    assert_eq!(page.total, 0);
+}
+
+#[actix_web::test]
+async fn denylist_expired_entries_not_returned_by_find() {
+    let storage = setup_storage().await;
+    let mut entry = DenylistEntry::new("ip", "192.0.2.99", "tmp", "admin@test.example");
+    entry.expires_at = Some(chrono::Utc::now() - chrono::Duration::minutes(5));
+    storage.add_denylist_entry(&entry).await.unwrap();
+
+    let hit = storage
+        .find_denylist_entry("ip", "192.0.2.99")
+        .await
+        .unwrap();
+    assert!(hit.is_none(), "expired entries are not returned");
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn admin_mutation_writes_audit_entry() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route("/admin/api/users", web::post().to(admin_extra::create_user)),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/users")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({
+            "username": "audit-target",
+            "email": "audit@test.example",
+            "password": "passphrase-12345"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201);
+
+    let entries = storage.list_audit_log(&ListQuery::default()).await.unwrap();
+    assert!(entries.total >= 1);
+    let entry = entries
+        .items
+        .iter()
+        .find(|e| e.action == "user.create")
+        .expect("user.create audit entry");
+    assert_eq!(entry.actor_email, "admin@test.example");
+    assert_eq!(entry.target_kind, "user");
+    assert!(entry.metadata.contains("audit-target"));
+}
+
+#[actix_web::test]
+async fn list_audit_log_is_paginated_newest_first() {
+    let storage = setup_storage().await;
+
+    for i in 0..5 {
+        let mut entry = oauth2_core::AuditLogEntry::new(
+            "actor",
+            "actor@test.example",
+            &format!("test.action.{i}"),
+        );
+        entry.created_at = chrono::Utc::now() + chrono::Duration::seconds(i as i64);
+        storage.write_audit_log(&entry).await.unwrap();
+    }
+
+    let app = test::init_service(App::new().app_data(web::Data::new(storage)).route(
+        "/admin/api/audit",
+        web::get().to(admin_extra::list_audit_log),
+    ))
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/admin/api/audit?limit=3")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["items"].as_array().unwrap().len(), 3);
+    assert_eq!(body["total"].as_u64().unwrap(), 5);
+    assert_eq!(body["items"][0]["action"], "test.action.4");
+}
+
+// ---------------------------------------------------------------------------
+// Bulk revoke
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn bulk_revoke_by_user_revokes_all_their_tokens() {
+    let storage = setup_storage().await;
+    let user = make_user("bulk");
+    storage.save_user(&user).await.unwrap();
+    let client = make_client_row("bulk");
+    storage.save_client(&client).await.unwrap();
+
+    for i in 0..3 {
+        let t = Token::new(
+            format!("access-bulk-{i}"),
+            None,
+            client.client_id.clone(),
+            Some(user.id.clone()),
+            "read".to_string(),
+            3600,
+            None,
+        );
+        storage.save_token(&t).await.unwrap();
+    }
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/tokens/revoke-by-user",
+                web::post().to(admin_extra::bulk_revoke_by_user),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/tokens/revoke-by-user")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "user_id": user.id }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["revoked"].as_u64().unwrap(), 3);
+
+    for i in 0..3 {
+        let t = storage
+            .get_token_by_access_token(&format!("access-bulk-{i}"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(t.revoked);
+    }
+}
+
+#[actix_web::test]
+async fn bulk_revoke_by_client_revokes_only_that_client() {
+    let storage = setup_storage().await;
+    let c1 = make_client_row("one");
+    let c2 = make_client_row("two");
+    storage.save_client(&c1).await.unwrap();
+    storage.save_client(&c2).await.unwrap();
+
+    storage
+        .save_token(&Token::new(
+            "t1".to_string(),
+            None,
+            c1.client_id.clone(),
+            None,
+            "read".to_string(),
+            3600,
+            None,
+        ))
+        .await
+        .unwrap();
+    storage
+        .save_token(&Token::new(
+            "t2".to_string(),
+            None,
+            c2.client_id.clone(),
+            None,
+            "read".to_string(),
+            3600,
+            None,
+        ))
+        .await
+        .unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/login", web::get().to(seed_session))
+            .route(
+                "/admin/api/tokens/revoke-by-client",
+                web::post().to(admin_extra::bulk_revoke_by_client),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/tokens/revoke-by-client")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({ "client_id": c1.client_id }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let t1 = storage
+        .get_token_by_access_token("t1")
+        .await
+        .unwrap()
+        .unwrap();
+    let t2 = storage
+        .get_token_by_access_token("t2")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(t1.revoked);
+    assert!(!t2.revoked, "tokens for other clients are untouched");
+}
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn capabilities_exposes_new_feature_flags() {
+    let app = test::init_service(App::new().route(
+        "/admin/api/capabilities",
+        web::get().to(admin::capabilities),
+    ))
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/admin/api/capabilities")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    for flag in [
+        "events",
+        "device_flow",
+        "key_rotation",
+        "user_crud",
+        "client_crud",
+        "denylist",
+        "audit_log",
+        "bulk_revoke",
+    ] {
+        assert_eq!(body[flag], true, "cap flag {flag} should be true");
+    }
+}

--- a/tests/admin_rbac.rs
+++ b/tests/admin_rbac.rs
@@ -1,0 +1,348 @@
+//! Role-based access control for admin_extra endpoints.
+//!
+//! Verifies the `AdminGuard` middleware correctly gates:
+//! - Unauthenticated requests → 302 redirect (or 403 JSON on `/admin/api/*`)
+//! - Authenticated non-admin session → 403 JSON on API paths
+//! - Bearer tokens without `admin` scope → 403 `insufficient_scope`
+//! - Valid admin session → 2xx passthrough
+
+use actix_session::{storage::CookieSessionStore, Session, SessionMiddleware};
+use actix_web::{cookie::Key, test, web, App, HttpResponse};
+use serde_json::json;
+
+use oauth2_actix::handlers::admin_extra;
+use oauth2_actix::middleware::admin_guard::AdminGuard;
+use oauth2_core::{Client, Token};
+use oauth2_ports::DynStorage;
+
+async fn setup_storage() -> DynStorage {
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    let url = format!("sqlite://{}", tmp.path().display());
+    std::mem::forget(tmp);
+    let storage = oauth2_storage_factory::create_storage(&url)
+        .await
+        .expect("create storage");
+    storage.init().await.expect("init");
+    storage
+}
+
+fn session_key() -> Key {
+    Key::from(&[13u8; 64])
+}
+
+async fn as_admin(session: Session) -> HttpResponse {
+    let _ = session.insert("user_id", "admin-uid".to_string());
+    let _ = session.insert("email", "admin@example.test".to_string());
+    let _ = session.insert("role", "admin".to_string());
+    HttpResponse::Ok().finish()
+}
+
+async fn as_plain_user(session: Session) -> HttpResponse {
+    let _ = session.insert("user_id", "user-uid".to_string());
+    let _ = session.insert("email", "user@example.test".to_string());
+    let _ = session.insert("role", "user".to_string());
+    HttpResponse::Ok().finish()
+}
+
+macro_rules! session_cookie {
+    ($app:expr, $path:expr) => {{
+        let req = test::TestRequest::get().uri($path).to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 200);
+        resp.headers()
+            .get("set-cookie")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.split(';').next().unwrap_or("").to_string())
+            .expect("set-cookie header")
+    }};
+}
+
+// ---------------------------------------------------------------------------
+// No session → redirect / 403
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn admin_api_without_session_returns_redirect_for_html_paths() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .service(
+                web::scope("/admin")
+                    .wrap(AdminGuard)
+                    .route("/users/{id}", web::put().to(admin_extra::update_user)),
+            ),
+    )
+    .await;
+
+    // PUT /admin/users/{id} is not under /admin/api/ — triggers the HTML
+    // branch (302 redirect to /auth/login). We still exercise the 401-ish
+    // path because the guard must not fall through to the handler.
+    let req = test::TestRequest::put()
+        .uri("/admin/users/someone")
+        .set_json(json!({ "email": "x@y.z" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 302);
+    let location = resp
+        .headers()
+        .get("Location")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(location.contains("/auth/login"));
+}
+
+#[actix_web::test]
+async fn admin_api_without_session_returns_302_on_api_paths() {
+    // Under current AdminGuard impl, unauthenticated requests redirect
+    // regardless of `/admin/api/` prefix. This test pins that behavior so
+    // future relaxations are intentional.
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .service(web::scope("/admin").wrap(AdminGuard).service(
+                web::scope("/api").route("/users", web::post().to(admin_extra::create_user)),
+            )),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/users")
+        .set_json(json!({
+            "username": "x",
+            "email": "x@x",
+            "password": "password123"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 302);
+}
+
+// ---------------------------------------------------------------------------
+// Plain user session → 403 on API paths
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn plain_user_session_gets_403_on_admin_api() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .route("/test/user-login", web::get().to(as_plain_user))
+            .service(
+                web::scope("/admin").wrap(AdminGuard).service(
+                    web::scope("/api")
+                        .route("/users", web::post().to(admin_extra::create_user))
+                        .route("/denylist", web::post().to(admin_extra::add_denylist)),
+                ),
+            ),
+    )
+    .await;
+    let cookie = session_cookie!(app, "/test/user-login");
+
+    for (uri, body) in [
+        (
+            "/admin/api/users",
+            json!({ "username": "x", "email": "x@x", "password": "password123" }),
+        ),
+        (
+            "/admin/api/denylist",
+            json!({ "kind": "ip", "value": "203.0.113.2" }),
+        ),
+    ] {
+        let req = test::TestRequest::post()
+            .uri(uri)
+            .insert_header(("Cookie", cookie.clone()))
+            .set_json(body)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 403, "plain user must be 403 on {uri}");
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"], "insufficient_permissions");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Admin session → passes through
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn admin_session_can_invoke_admin_api() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .route("/test/admin-login", web::get().to(as_admin))
+            .service(web::scope("/admin").wrap(AdminGuard).service(
+                web::scope("/api").route("/users", web::post().to(admin_extra::create_user)),
+            )),
+    )
+    .await;
+    let cookie = session_cookie!(app, "/test/admin-login");
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/users")
+        .insert_header(("Cookie", cookie))
+        .set_json(json!({
+            "username": "fresh",
+            "email": "fresh@example.test",
+            "password": "passphrase-secure"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201);
+}
+
+// ---------------------------------------------------------------------------
+// Bearer token RBAC
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn bearer_token_without_admin_scope_is_403() {
+    let storage = setup_storage().await;
+    let client = Client::new(
+        "machine-client".to_string(),
+        "secret".to_string(),
+        vec![],
+        vec!["client_credentials".to_string()],
+        "read".to_string(),
+        "Machine".to_string(),
+    );
+    storage.save_client(&client).await.unwrap();
+
+    let token = Token::new(
+        "no-admin-scope-token".to_string(),
+        None,
+        client.client_id.clone(),
+        None,
+        "read".to_string(),
+        3600,
+        None,
+    );
+    storage.save_token(&token).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .service(web::scope("/admin").wrap(AdminGuard).service(
+                web::scope("/api").route("/users", web::post().to(admin_extra::create_user)),
+            )),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/users")
+        .insert_header(("Authorization", "Bearer no-admin-scope-token"))
+        .set_json(json!({
+            "username": "x",
+            "email": "x@x",
+            "password": "password123"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 403);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body["error"], "insufficient_scope");
+}
+
+#[actix_web::test]
+async fn bearer_token_with_admin_scope_passes() {
+    let storage = setup_storage().await;
+    let client = Client::new(
+        "machine-admin".to_string(),
+        "secret".to_string(),
+        vec![],
+        vec!["client_credentials".to_string()],
+        "admin".to_string(),
+        "Machine".to_string(),
+    );
+    storage.save_client(&client).await.unwrap();
+
+    let token = Token::new(
+        "admin-scope-token".to_string(),
+        None,
+        client.client_id.clone(),
+        None,
+        "admin read".to_string(),
+        3600,
+        None,
+    );
+    storage.save_token(&token).await.unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .service(web::scope("/admin").wrap(AdminGuard).service(
+                web::scope("/api").route("/denylist", web::post().to(admin_extra::add_denylist)),
+            )),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/denylist")
+        .insert_header(("Authorization", "Bearer admin-scope-token"))
+        .set_json(json!({
+            "kind": "ip",
+            "value": "198.51.100.200",
+            "reason": "test"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201);
+}
+
+#[actix_web::test]
+async fn invalid_bearer_token_is_401() {
+    let storage = setup_storage().await;
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .service(web::scope("/admin").wrap(AdminGuard).service(
+                web::scope("/api").route("/users", web::post().to(admin_extra::create_user)),
+            )),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/users")
+        .insert_header(("Authorization", "Bearer garbage-token"))
+        .set_json(json!({
+            "username": "x",
+            "email": "x@x",
+            "password": "password123"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 401);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body["error"], "invalid_token");
+}

--- a/tests/admin_storage_contract.rs
+++ b/tests/admin_storage_contract.rs
@@ -1,0 +1,428 @@
+//! Storage-backend contract tests for the admin-maintainer trait methods
+//! added in V17 (user/client management, denylist, audit log, bulk revoke).
+//!
+//! Mirrors `tests/common/run_storage_contract` in spirit but scoped to the
+//! admin-specific surface. Currently runs only against the SQLx backend —
+//! MongoDB admin methods are partial (denylist/audit fall back to trait
+//! no-ops).
+
+use oauth2_core::{
+    AuditLogEntry, Client, DenylistEntry, ListQuery, Token, User, DENYLIST_KIND_IP,
+    DENYLIST_KIND_USERNAME,
+};
+use oauth2_ports::DynStorage;
+
+async fn setup_storage() -> DynStorage {
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    let url = format!("sqlite://{}", tmp.path().display());
+    std::mem::forget(tmp);
+    let storage = oauth2_storage_factory::create_storage(&url)
+        .await
+        .expect("create storage");
+    storage.init().await.expect("init");
+    storage
+}
+
+fn seed_user(name: &str) -> User {
+    User::new(
+        name.to_string(),
+        "$argon2id$seed".to_string(),
+        format!("{name}@test.example"),
+    )
+}
+
+fn seed_client(suffix: &str) -> Client {
+    Client::new(
+        format!("client-{suffix}"),
+        "secret".to_string(),
+        vec!["https://example.com/cb".to_string()],
+        vec!["authorization_code".to_string()],
+        "read".to_string(),
+        format!("Client {suffix}"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// User management
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn update_user_persists_changes() {
+    let storage = setup_storage().await;
+    let mut user = seed_user("u_update");
+    storage.save_user(&user).await.unwrap();
+
+    user.email = "changed@test.example".to_string();
+    user.role = "admin".to_string();
+    user.enabled = false;
+    user.password_hash = "$argon2id$new".to_string();
+    user.updated_at = chrono::Utc::now();
+
+    storage.update_user(&user).await.unwrap();
+    let reloaded = storage.get_user_by_id(&user.id).await.unwrap().unwrap();
+    assert_eq!(reloaded.email, "changed@test.example");
+    assert_eq!(reloaded.role, "admin");
+    assert!(!reloaded.enabled);
+    assert_eq!(reloaded.password_hash, "$argon2id$new");
+}
+
+#[actix_web::test]
+async fn set_user_enabled_flips_flag() {
+    let storage = setup_storage().await;
+    let user = seed_user("u_enable");
+    storage.save_user(&user).await.unwrap();
+
+    storage.set_user_enabled(&user.id, false).await.unwrap();
+    assert!(
+        !storage
+            .get_user_by_id(&user.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .enabled
+    );
+
+    storage.set_user_enabled(&user.id, true).await.unwrap();
+    assert!(
+        storage
+            .get_user_by_id(&user.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .enabled
+    );
+}
+
+#[actix_web::test]
+async fn set_user_role_updates_row() {
+    let storage = setup_storage().await;
+    let user = seed_user("u_role");
+    storage.save_user(&user).await.unwrap();
+    storage.set_user_role(&user.id, "admin").await.unwrap();
+
+    assert_eq!(
+        storage
+            .get_user_by_id(&user.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .role,
+        "admin"
+    );
+}
+
+#[actix_web::test]
+async fn set_user_password_hash_replaces_hash() {
+    let storage = setup_storage().await;
+    let user = seed_user("u_pw");
+    storage.save_user(&user).await.unwrap();
+    storage
+        .set_user_password_hash(&user.id, "$argon2id$fresh")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        storage
+            .get_user_by_id(&user.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .password_hash,
+        "$argon2id$fresh"
+    );
+}
+
+#[actix_web::test]
+async fn delete_user_removes_row_and_nulls_token_references() {
+    let storage = setup_storage().await;
+    let user = seed_user("u_del");
+    storage.save_user(&user).await.unwrap();
+    let client = seed_client("del");
+    storage.save_client(&client).await.unwrap();
+
+    let token = Token::new(
+        "t_del".to_string(),
+        None,
+        client.client_id.clone(),
+        Some(user.id.clone()),
+        "read".to_string(),
+        3600,
+        None,
+    );
+    storage.save_token(&token).await.unwrap();
+
+    storage.delete_user(&user.id).await.unwrap();
+    assert!(storage.get_user_by_id(&user.id).await.unwrap().is_none());
+
+    let t = storage
+        .get_token_by_access_token("t_del")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(t.revoked, "associated token is revoked");
+    assert!(t.user_id.is_none(), "user_id is unlinked to satisfy FK");
+}
+
+// ---------------------------------------------------------------------------
+// Client management extensions
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn set_client_enabled_persists() {
+    let storage = setup_storage().await;
+    let client = seed_client("enable");
+    storage.save_client(&client).await.unwrap();
+
+    storage
+        .set_client_enabled(&client.client_id, false)
+        .await
+        .unwrap();
+    assert!(
+        !storage
+            .get_client(&client.client_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .enabled
+    );
+
+    storage
+        .set_client_enabled(&client.client_id, true)
+        .await
+        .unwrap();
+    assert!(
+        storage
+            .get_client(&client.client_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .enabled
+    );
+}
+
+#[actix_web::test]
+async fn set_client_secret_replaces_secret() {
+    let storage = setup_storage().await;
+    let client = seed_client("secret");
+    storage.save_client(&client).await.unwrap();
+
+    storage
+        .set_client_secret(&client.client_id, "brand-new-secret")
+        .await
+        .unwrap();
+    let reloaded = storage
+        .get_client(&client.client_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reloaded.client_secret, "brand-new-secret");
+}
+
+// ---------------------------------------------------------------------------
+// Denylist
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn denylist_add_find_remove_round_trip() {
+    let storage = setup_storage().await;
+    let entry = DenylistEntry::new(DENYLIST_KIND_IP, "198.51.100.1", "test", "admin");
+    storage.add_denylist_entry(&entry).await.unwrap();
+
+    let found = storage
+        .find_denylist_entry(DENYLIST_KIND_IP, "198.51.100.1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found.reason, "test");
+
+    storage.remove_denylist_entry(&entry.id).await.unwrap();
+    assert!(storage
+        .find_denylist_entry(DENYLIST_KIND_IP, "198.51.100.1")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[actix_web::test]
+async fn denylist_upsert_on_duplicate_kind_value() {
+    let storage = setup_storage().await;
+    let first = DenylistEntry::new(DENYLIST_KIND_USERNAME, "mallory", "first", "admin");
+    storage.add_denylist_entry(&first).await.unwrap();
+
+    let second = DenylistEntry::new(DENYLIST_KIND_USERNAME, "mallory", "updated", "admin");
+    storage.add_denylist_entry(&second).await.unwrap();
+
+    let page = storage.list_denylist(&ListQuery::default()).await.unwrap();
+    assert_eq!(page.total, 1);
+    let found = storage
+        .find_denylist_entry(DENYLIST_KIND_USERNAME, "mallory")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found.reason, "updated");
+}
+
+#[actix_web::test]
+async fn denylist_list_is_paginated() {
+    let storage = setup_storage().await;
+    for i in 0..12 {
+        let entry = DenylistEntry::new(DENYLIST_KIND_IP, &format!("10.0.0.{i}"), "bulk", "admin");
+        storage.add_denylist_entry(&entry).await.unwrap();
+    }
+
+    let q = ListQuery {
+        limit: Some(5),
+        offset: Some(0),
+        ..Default::default()
+    };
+    let page = storage.list_denylist(&q).await.unwrap();
+    assert_eq!(page.items.len(), 5);
+    assert_eq!(page.total, 12);
+
+    let q = ListQuery {
+        limit: Some(5),
+        offset: Some(10),
+        ..Default::default()
+    };
+    let page = storage.list_denylist(&q).await.unwrap();
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.total, 12);
+}
+
+#[actix_web::test]
+async fn denylist_find_skips_expired_entries() {
+    let storage = setup_storage().await;
+    let mut entry = DenylistEntry::new(DENYLIST_KIND_IP, "192.0.2.50", "stale", "admin");
+    entry.expires_at = Some(chrono::Utc::now() - chrono::Duration::hours(1));
+    storage.add_denylist_entry(&entry).await.unwrap();
+
+    assert!(storage
+        .find_denylist_entry(DENYLIST_KIND_IP, "192.0.2.50")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn audit_log_write_and_list_newest_first() {
+    let storage = setup_storage().await;
+
+    for i in 0..3 {
+        let mut entry = AuditLogEntry::new("admin", "admin@test.example", &format!("a.{i}"));
+        entry.created_at = chrono::Utc::now() + chrono::Duration::seconds(i);
+        storage.write_audit_log(&entry).await.unwrap();
+    }
+
+    let page = storage.list_audit_log(&ListQuery::default()).await.unwrap();
+    assert_eq!(page.total, 3);
+    assert_eq!(
+        page.items[0].action, "a.2",
+        "desc order returns newest first"
+    );
+}
+
+#[actix_web::test]
+async fn audit_log_respects_limit_offset() {
+    let storage = setup_storage().await;
+    for i in 0..7 {
+        let mut entry = AuditLogEntry::new("admin", "admin@test.example", &format!("a.{i:02}"));
+        entry.created_at = chrono::Utc::now() + chrono::Duration::seconds(i);
+        storage.write_audit_log(&entry).await.unwrap();
+    }
+
+    let q = ListQuery {
+        limit: Some(2),
+        offset: Some(2),
+        ..Default::default()
+    };
+    let page = storage.list_audit_log(&q).await.unwrap();
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.total, 7);
+}
+
+// ---------------------------------------------------------------------------
+// Bulk token revocation
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn revoke_tokens_by_client_id_only_touches_that_client() {
+    let storage = setup_storage().await;
+    let c1 = seed_client("a");
+    let c2 = seed_client("b");
+    storage.save_client(&c1).await.unwrap();
+    storage.save_client(&c2).await.unwrap();
+
+    for (id, client) in [("t1", &c1), ("t2", &c2), ("t3", &c1)] {
+        storage
+            .save_token(&Token::new(
+                id.to_string(),
+                None,
+                client.client_id.clone(),
+                None,
+                "read".to_string(),
+                3600,
+                None,
+            ))
+            .await
+            .unwrap();
+    }
+
+    let count = storage
+        .revoke_tokens_by_client_id(&c1.client_id)
+        .await
+        .unwrap();
+    assert_eq!(count, 2);
+
+    let t1 = storage
+        .get_token_by_access_token("t1")
+        .await
+        .unwrap()
+        .unwrap();
+    let t2 = storage
+        .get_token_by_access_token("t2")
+        .await
+        .unwrap()
+        .unwrap();
+    let t3 = storage
+        .get_token_by_access_token("t3")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(t1.revoked);
+    assert!(!t2.revoked);
+    assert!(t3.revoked);
+}
+
+#[actix_web::test]
+async fn revoke_tokens_by_client_id_idempotent() {
+    let storage = setup_storage().await;
+    let c = seed_client("idem");
+    storage.save_client(&c).await.unwrap();
+    storage
+        .save_token(&Token::new(
+            "t".to_string(),
+            None,
+            c.client_id.clone(),
+            None,
+            "read".to_string(),
+            3600,
+            None,
+        ))
+        .await
+        .unwrap();
+
+    let first = storage
+        .revoke_tokens_by_client_id(&c.client_id)
+        .await
+        .unwrap();
+    let second = storage
+        .revoke_tokens_by_client_id(&c.client_id)
+        .await
+        .unwrap();
+    assert_eq!(first, 1);
+    assert_eq!(second, 0, "already-revoked tokens are not counted again");
+}


### PR DESCRIPTION
## Summary

Full admin maintainer surface: **user CRUD**, **client CRUD extensions**, **denylist with middleware enforcement**, **admin audit log**, and **bulk token revocation**. UI fully wired (Alpine.js SPA).

## What's new

### Storage / Schema
- Migration **V17__admin_extensions.sql**: `clients.enabled` column, `denylist` table, `audit_log` table + indexes
- DynStorage trait: 13 new admin methods — `update_user`, `delete_user`, `set_user_enabled`, `set_user_role`, `set_user_password_hash`, `set_client_enabled`, `set_client_secret`, `add_denylist_entry`, `remove_denylist_entry`, `list_denylist`, `find_denylist_entry`, `write_audit_log`, `list_audit_log`, `revoke_tokens_by_client_id`
- SQLx backend: full impl for SQLite + Postgres
- Mongo backend: user/client admin + bulk revoke (denylist + audit fall through to trait no-op)
- `ObservedStorage` wrapper forwards all new methods (tracing span per call)

### API — `/admin/api/*`
- Users: `POST /users`, `PUT /users/{id}`, `DELETE /users/{id}`, `POST /users/{id}/enabled`, `POST /users/{id}/role`, `POST /users/{id}/password`
- Clients: `POST /clients`, `PUT /clients/{id}`, `POST /clients/{id}/enabled`, `POST /clients/{id}/regenerate-secret`
- Denylist: `GET /denylist`, `POST /denylist`, `DELETE /denylist/{id}`
- Audit: `GET /audit`
- Bulk: `POST /tokens/revoke-by-user`, `POST /tokens/revoke-by-client`

### Middleware
- `DenylistGuard` — IP denylist check runs before rate-limit so denylisted IPs don't consume quota
- `build_audit` + `record_audit` helpers — every admin mutation records actor_id, actor_email, IP, user-agent, JSON metadata

### Admin UI (Alpine.js SPA, no build step)
- New pages: Denylist, Audit Log
- Per-row actions on Clients: Enable/Disable, Rotate Secret, Revoke All Tokens, Delete
- Per-row actions on Users: Enable/Disable, Toggle Admin/User, Reset Password, Delete
- Modals: client create/edit, user create/edit, password reset, denylist add

### Tests
- **55 new tests** (tests/admin_extra.rs, admin_storage_contract.rs, admin_denylist_middleware.rs, admin_rbac.rs)
- Covers: HTTP round-trip per endpoint, storage-layer contract, middleware integration, RBAC negative paths (session + bearer-token)

## Stats
- 22 files changed
- +5,031 / −26
- CI: fmt ✓ clippy ✓ tests 296 pass / 0 fail (up from 241)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --verbose --all-features --locked`
- [ ] Manual smoke test admin UI in browser
- [ ] Verify V17 migration runs cleanly on staging Postgres
- [ ] Verify denylist middleware rejects from prod ingress IP header (X-Forwarded-For)

## Follow-ups (not in scope)
- MongoDB impl for denylist + audit log (currently no-op)
- Consents / scopes / sessions management (deferred)
- Postgres-specific migration test in tests/migrations_postgres.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)