### PR TITLE
feat(admin): capabilities reflect storage backend

### DIFF
--- a/crates/oauth2-actix/src/handlers/admin.rs
+++ b/crates/oauth2-actix/src/handlers/admin.rs
@@ -419,15 +419,15 @@ pub struct Capabilities {
     pub bulk_revoke: bool,
 }
 
-pub async fn capabilities() -> Result<HttpResponse> {
+pub async fn capabilities(db: web::Data<DynStorage>) -> Result<HttpResponse> {
     Ok(HttpResponse::Ok().json(Capabilities {
         events: true,
         device_flow: true,
         key_rotation: true,
         user_crud: true,
         client_crud: true,
-        denylist: true,
-        audit_log: true,
+        denylist: db.supports_denylist().await,
+        audit_log: db.supports_audit_log().await,
         bulk_revoke: true,
     }))
 }

--- a/crates/oauth2-observability/src/storage.rs
+++ b/crates/oauth2-observability/src/storage.rs
@@ -668,4 +668,14 @@ impl Storage for ObservedStorage {
             .instrument(span)
             .await
     }
+
+    // --- Backend capability flags ---
+
+    async fn supports_denylist(&self) -> bool {
+        self.inner.supports_denylist().await
+    }
+
+    async fn supports_audit_log(&self) -> bool {
+        self.inner.supports_audit_log().await
+    }
 }

--- a/crates/oauth2-ports/src/storage.rs
+++ b/crates/oauth2-ports/src/storage.rs
@@ -300,6 +300,22 @@ pub trait Storage: Send + Sync {
         let _ = client_id;
         Ok(0)
     }
+
+    // --- Backend capability flags ---
+    //
+    // These let the admin UI hide sections that would silently no-op on the
+    // current backend (e.g. Mongo, which has not yet implemented denylist
+    // / audit log). Default `false` so backends opt in explicitly.
+
+    /// Whether this backend persists denylist entries.
+    async fn supports_denylist(&self) -> bool {
+        false
+    }
+
+    /// Whether this backend persists audit-log entries.
+    async fn supports_audit_log(&self) -> bool {
+        false
+    }
 }
 
 pub type DynStorage = Arc<dyn Storage>;

--- a/crates/oauth2-storage-sqlx/src/sqlx.rs
+++ b/crates/oauth2-storage-sqlx/src/sqlx.rs
@@ -1986,6 +1986,14 @@ impl Storage for SqlxStorage {
         };
         Ok(rows)
     }
+
+    async fn supports_denylist(&self) -> bool {
+        true
+    }
+
+    async fn supports_audit_log(&self) -> bool {
+        true
+    }
 }
 
 fn sqlite_db_path(database_url: &str) -> Option<PathBuf> {

--- a/tests/admin_extra.rs
+++ b/tests/admin_extra.rs
@@ -1190,7 +1190,8 @@ async fn bulk_revoke_by_client_revokes_only_that_client() {
 
 #[actix_web::test]
 async fn capabilities_exposes_new_feature_flags() {
-    let app = test::init_service(App::new().route(
+    let storage = setup_storage().await;
+    let app = test::init_service(App::new().app_data(web::Data::new(storage.clone())).route(
         "/admin/api/capabilities",
         web::get().to(admin::capabilities),
     ))
@@ -1216,3 +1217,10 @@ async fn capabilities_exposes_new_feature_flags() {
         assert_eq!(body[flag], true, "cap flag {flag} should be true");
     }
 }
+
+// NOTE: No Mongo-backed capabilities test is included here.
+// `MongoStorage::new()` opens a real client and requires a running Mongo
+// server, which is out of scope for unit tests. Mongo inherits the
+// trait defaults (`false` for both `supports_denylist` /
+// `supports_audit_log` on `oauth2_ports::Storage`) until real impls ship
+// in v0.7.0.


### PR DESCRIPTION
Unit 6/6 of dashboard wiring batch (see plan /Users/ianlintner/.claude/plans/tranquil-inventing-dragonfly.md).

## Summary

`/admin/api/capabilities` previously hardcoded `denylist: true` and `audit_log: true` regardless of the active storage backend. On Mongo (where denylist and audit-log `Storage` trait methods fall through to no-op defaults) this misled the admin UI into showing feature pages whose writes were silently swallowed.

Changes:

- `oauth2-ports::Storage`: new `supports_denylist` / `supports_audit_log` default-`false` trait methods.
- `oauth2-storage-sqlx::SqlxStorage`: overrides both to `true` (real impls exist).
- `oauth2-storage-mongo::MongoStorage`: inherits defaults (`false`) until v0.7.0 Mongo impls.
- `oauth2-observability::ObservedStorage`: forwards both to inner.
- `oauth2-actix::handlers::admin::capabilities`: now takes `web::Data<DynStorage>` and returns the actual flags.
- `tests/admin_extra.rs`: updated existing test to wire in sqlx storage (still asserts both flags `true`). A Mongo-backend test is intentionally omitted; `MongoStorage::new()` opens a real client, and standing up Mongo in `cargo test` is out of scope.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --locked --test admin_extra` (28 passed, 0 failed)

E2E against prod not authorized.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>