### PR TITLE
feat(metrics): http status_class counter + duration histogram

### DIFF
--- a/crates/oauth2-observability/src/actix.rs
+++ b/crates/oauth2-observability/src/actix.rs
@@ -67,7 +67,15 @@ where
 
             let res = svc.call(req).await?;
 
-            let status = res.status().as_u16().to_string();
+            let status_code = res.status().as_u16();
+            let status = status_code.to_string();
+            let status_class = match status_code {
+                200..=299 => "2xx",
+                300..=399 => "3xx",
+                400..=499 => "4xx",
+                500..=599 => "5xx",
+                _ => "other",
+            };
             let route = res
                 .request()
                 .match_pattern()
@@ -77,6 +85,11 @@ where
             metrics
                 .http_request_duration_seconds
                 .observe(duration.as_secs_f64());
+
+            metrics
+                .http_requests_by_class_total
+                .with_label_values(&[status_class])
+                .inc();
 
             metrics
                 .http_requests_total_by_route

--- a/crates/oauth2-observability/src/metrics.rs
+++ b/crates/oauth2-observability/src/metrics.rs
@@ -12,6 +12,13 @@ pub struct Metrics {
     pub http_requests_total: Counter,
     pub http_request_duration_seconds: Histogram,
 
+    /// HTTP request counter bucketed by response status class.
+    ///
+    /// Label `status_class` values: `2xx`, `3xx`, `4xx`, `5xx`, `other`.
+    /// Kept separate from `http_requests_total_by_route` so existing
+    /// time-series (without a `status_class` label) are not broken.
+    pub http_requests_by_class_total: CounterVec,
+
     /// Labeled HTTP request counter.
     ///
     /// Labels:
@@ -86,9 +93,22 @@ impl Metrics {
                 "http_request_duration_seconds",
                 "HTTP request duration in seconds",
             )
-            .namespace("oauth2_server"),
+            .namespace("oauth2_server")
+            .buckets(vec![
+                0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+            ]),
         )?;
         registry.register(Box::new(http_request_duration_seconds.clone()))?;
+
+        let http_requests_by_class_total = CounterVec::new(
+            Opts::new(
+                "http_requests_by_class_total",
+                "Total number of HTTP requests bucketed by response status class (2xx/3xx/4xx/5xx/other)",
+            )
+            .namespace("oauth2_server"),
+            &["status_class"],
+        )?;
+        registry.register(Box::new(http_requests_by_class_total.clone()))?;
 
         let http_requests_total_by_route = CounterVec::new(
             Opts::new(
@@ -261,6 +281,7 @@ impl Metrics {
             registry: Arc::new(registry),
             http_requests_total,
             http_request_duration_seconds,
+            http_requests_by_class_total,
             http_requests_total_by_route,
             http_request_duration_seconds_by_route,
             oauth_token_issued_total,

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -358,10 +358,10 @@ function dashboardPage() {
       });
 
       // HTTP status distribution
-      const s2xx = prometheusLabeled(m, 'oauth2_server_http_requests_total', 'status_class', '2xx')
+      const s2xx = prometheusLabeled(m, 'oauth2_server_http_requests_by_class_total', 'status_class', '2xx')
         || prometheusScalar(m, 'oauth2_server_http_requests_total');
-      const s4xx = prometheusLabeled(m, 'oauth2_server_http_requests_total', 'status_class', '4xx');
-      const s5xx = prometheusLabeled(m, 'oauth2_server_http_requests_total', 'status_class', '5xx');
+      const s4xx = prometheusLabeled(m, 'oauth2_server_http_requests_by_class_total', 'status_class', '4xx');
+      const s5xx = prometheusLabeled(m, 'oauth2_server_http_requests_by_class_total', 'status_class', '5xx');
       createOrUpdateChart('requestChart', {
         type: 'doughnut',
         data: {

--- a/tests/metrics_wiring.rs
+++ b/tests/metrics_wiring.rs
@@ -1,0 +1,91 @@
+//! Integration tests for the Prometheus metrics middleware.
+//!
+//! These assert that `MetricsMiddleware`:
+//! - Emits `oauth2_server_http_requests_by_class_total` with a `status_class`
+//!   label for both successful (2xx) and client-error (4xx) responses.
+//! - Observes samples into the `oauth2_server_http_request_duration_seconds`
+//!   histogram (the scraped `..._bucket` series has a nonzero `+Inf` count).
+//!
+//! Admin dashboard charts depend on both series being populated.
+
+use actix_web::{test, web, App, HttpResponse};
+use oauth2_observability::{actix::MetricsMiddleware, encode_prometheus_text, Metrics};
+
+async fn ok_handler() -> HttpResponse {
+    HttpResponse::Ok().body("ok")
+}
+
+async fn not_found_handler() -> HttpResponse {
+    HttpResponse::NotFound().body("not found")
+}
+
+async fn metrics_dump(metrics: web::Data<Metrics>) -> HttpResponse {
+    let body = encode_prometheus_text(&metrics.registry).expect("encode");
+    HttpResponse::Ok().body(body)
+}
+
+#[actix_web::test]
+async fn metrics_middleware_emits_status_class_counter_and_duration_histogram() {
+    let metrics = Metrics::new().expect("metrics");
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(metrics.clone()))
+            .wrap(MetricsMiddleware::new(metrics.clone()))
+            .route("/ok", web::get().to(ok_handler))
+            .route("/missing", web::get().to(not_found_handler))
+            .route("/metrics", web::get().to(metrics_dump)),
+    )
+    .await;
+
+    for _ in 0..3 {
+        let req = test::TestRequest::get().uri("/ok").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 200);
+    }
+
+    for _ in 0..2 {
+        let req = test::TestRequest::get().uri("/missing").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 404);
+    }
+
+    let req = test::TestRequest::get().uri("/metrics").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body = test::read_body(resp).await;
+    let body = std::str::from_utf8(&body).expect("utf8 metrics body");
+
+    // New status_class counter: at least one 2xx and one 4xx sample.
+    assert!(
+        body.lines().any(|l| l
+            .starts_with("oauth2_server_http_requests_by_class_total{status_class=\"2xx\"}")
+            && parse_value(l) > 0.0),
+        "expected 2xx status_class counter > 0\n{body}"
+    );
+    assert!(
+        body.lines().any(|l| l
+            .starts_with("oauth2_server_http_requests_by_class_total{status_class=\"4xx\"}")
+            && parse_value(l) > 0.0),
+        "expected 4xx status_class counter > 0\n{body}"
+    );
+
+    // Duration histogram: the +Inf bucket's cumulative count equals total
+    // observed samples. With requests above, this must be > 0.
+    let inf_line = body
+        .lines()
+        .find(|l| l.starts_with("oauth2_server_http_request_duration_seconds_bucket{le=\"+Inf\"}"))
+        .unwrap_or_else(|| panic!("expected +Inf bucket line\n{body}"));
+    assert!(
+        parse_value(inf_line) > 0.0,
+        "expected +Inf bucket > 0, got: {inf_line}"
+    );
+}
+
+/// Parse the trailing numeric value from a Prometheus text-format line like
+/// `name{labels} 3` or `name 3`.
+fn parse_value(line: &str) -> f64 {
+    line.rsplit_once(' ')
+        .and_then(|(_, v)| v.trim().parse::<f64>().ok())
+        .unwrap_or(0.0)
+}


### PR DESCRIPTION
Unit 4/6 of dashboard wiring batch (see plan /Users/ianlintner/.claude/plans/tranquil-inventing-dragonfly.md).

## Summary
- Add `oauth2_server_http_requests_by_class_total{status_class}` counter in the Prometheus registry (values `2xx`/`3xx`/`4xx`/`5xx`/`other`). Kept separate from `oauth2_server_http_requests_total` so existing time-series aren't broken.
- Configure explicit buckets on `oauth2_server_http_request_duration_seconds` (`0.001..=10.0` seconds) so the admin latency chart has useful samples.
- Extend `MetricsMiddleware` to classify responses and increment the new counter; the duration histogram is already observed.
- Update admin.js HTTP status doughnut to read from `oauth2_server_http_requests_by_class_total`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --locked` (all test suites pass)
- [x] New `tests/metrics_wiring.rs` exercises the middleware end-to-end: hits 200 and 404 routes, scrapes `/metrics`, asserts `status_class="2xx"` and `status_class="4xx"` counters > 0 and the `..._duration_seconds_bucket{le="+Inf"}` cumulative count > 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)