### PR TITLE
feat(metrics): wire oauth_authorization_codes_issued counter

### DIFF
--- a/tests/metrics_wiring.rs
+++ b/tests/metrics_wiring.rs
@@ -1,13 +1,20 @@
 //! Integration tests asserting the Prometheus metrics are actually wired:
 //! - `MetricsMiddleware` emits the `status_class`-labelled request counter and
 //!   observes the request-duration histogram.
-//! - Admin handlers increment the counters they own (e.g. token revoke).
+//! - Admin handlers increment the counters they own (token revoke, authz code).
 //!
 //! Admin dashboard charts depend on all of the above being populated.
 
-use actix_web::{test, web, App, HttpResponse};
+use std::sync::Arc;
 
+use actix::Actor;
+use actix_session::{storage::CookieSessionStore, Session, SessionMiddleware};
+use actix_web::{cookie::Key, test, web, App, HttpResponse};
+use tokio::sync::RwLock;
+
+use oauth2_actix::actors::TokenActorPool;
 use oauth2_actix::handlers::admin;
+use oauth2_actix::handlers::wellknown::OidcConfig;
 use oauth2_core::{Client, Token, User};
 use oauth2_observability::{actix::MetricsMiddleware, encode_prometheus_text, Metrics};
 use oauth2_ports::DynStorage;
@@ -44,6 +51,32 @@ fn parse_value(line: &str) -> f64 {
     line.rsplit_once(' ')
         .and_then(|(_, v)| v.trim().parse::<f64>().ok())
         .unwrap_or(0.0)
+}
+
+fn s256(verifier: &str) -> String {
+    use base64::{engine::general_purpose, Engine as _};
+    use sha2::{Digest, Sha256};
+    general_purpose::URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()))
+}
+
+async fn test_set_session(session: Session) -> HttpResponse {
+    session.insert("user_id", "user_metrics").unwrap();
+    session.insert("authenticated", true).unwrap();
+    HttpResponse::Ok().finish()
+}
+
+fn extract_session_cookie(
+    resp: &actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+) -> String {
+    resp.response()
+        .headers()
+        .get(actix_web::http::header::SET_COOKIE)
+        .and_then(|h| h.to_str().ok())
+        .expect("session cookie")
+        .split(';')
+        .next()
+        .unwrap()
+        .to_string()
 }
 
 #[actix_web::test]
@@ -176,5 +209,138 @@ async fn admin_revoke_token_increments_prometheus_counter() {
     assert!(
         value >= 1,
         "oauth2_server_oauth_token_revoked_total should be >= 1 after revoke, got {value}"
+    );
+}
+
+/// A successful authorization_code flow must increment
+/// `oauth2_server_oauth_authorization_codes_issued`. This metric backs the
+/// "Auth Codes" bar on the admin dashboard's Metrics page.
+#[actix_web::test]
+async fn authorize_increments_authorization_codes_issued_counter() {
+    const ISSUER: &str = "https://auth.example.com";
+
+    let client = Client::new(
+        "client_metrics".to_string(),
+        "secret_metrics".to_string(),
+        vec!["https://app.example/cb".to_string()],
+        vec!["authorization_code".to_string()],
+        "read".to_string(),
+        "test".to_string(),
+    );
+
+    let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
+        .await
+        .expect("create storage");
+    storage.init().await.expect("init");
+    storage.save_client(&client).await.expect("save client");
+
+    let now = chrono::Utc::now();
+    let user = User {
+        id: "user_metrics".to_string(),
+        username: "user_metrics".to_string(),
+        password_hash: "unused".to_string(),
+        email: "user_metrics@example.test".to_string(),
+        enabled: true,
+        role: "user".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+    storage.save_user(&user).await.expect("save user");
+
+    let jwt_secret = "metrics_test_jwt_secret_at_least_32_chars".to_string();
+    let metrics = Metrics::new().expect("metrics");
+
+    let token_actor = oauth2_actix::actors::TokenActor::new(
+        storage.clone(),
+        jwt_secret.clone(),
+        ISSUER.to_string(),
+    )
+    .start();
+    let token_pool = TokenActorPool::new(vec![token_actor]);
+    let client_actor = oauth2_actix::actors::ClientActor::new(storage.clone()).start();
+    let auth_actor = oauth2_actix::actors::AuthActor::new(storage).start();
+
+    let oidc_config = OidcConfig {
+        issuer: ISSUER.to_string(),
+        jwt_secret: jwt_secret.clone(),
+        id_token_alg: "HS256".to_string(),
+        id_token_kid: None,
+        id_token_private_key_pem: None,
+    };
+
+    let keyset = Arc::new(RwLock::new(oauth2_core::models::key_set::KeySet::default()));
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                Key::generate(),
+            ))
+            .route("/test/login", web::get().to(test_set_session))
+            .app_data(web::Data::new(token_pool))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(keyset))
+            .app_data(web::Data::new(false))
+            .service(web::scope("/oauth").route(
+                "/authorize",
+                web::get().to(oauth2_actix::handlers::oauth::authorize),
+            ))
+            .route(
+                "/metrics",
+                web::get().to(oauth2_actix::handlers::admin::system_metrics),
+            ),
+    )
+    .await;
+
+    // Establish session so /oauth/authorize sees an authenticated user.
+    let login_resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/test/login").to_request(),
+    )
+    .await;
+    let cookie = extract_session_cookie(&login_resp);
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = s256(verifier);
+
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/oauth/authorize?response_type=code&client_id=client_metrics\
+             &redirect_uri=https%3A%2F%2Fapp.example%2Fcb&scope=read\
+             &code_challenge={challenge}&code_challenge_method=S256&state=abc"
+        ))
+        .insert_header(("Cookie", cookie.as_str()))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 302, "authorize must redirect on success");
+
+    let metrics_resp =
+        test::call_service(&app, test::TestRequest::get().uri("/metrics").to_request()).await;
+    assert_eq!(metrics_resp.status(), 200);
+    let body_bytes = test::read_body(metrics_resp).await;
+    let body = std::str::from_utf8(&body_bytes).expect("utf8 metrics body");
+
+    let line = body
+        .lines()
+        .find(|l| {
+            !l.starts_with('#') && l.starts_with("oauth2_server_oauth_authorization_codes_issued ")
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "metric `oauth2_server_oauth_authorization_codes_issued` missing in /metrics output:\n{body}"
+            )
+        });
+    let value: f64 = line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| panic!("could not parse metric value from line: {line}"));
+    assert!(
+        value >= 1.0,
+        "expected oauth_authorization_codes_issued >= 1 after successful authorize, got {value}"
     );
 }


### PR DESCRIPTION
## Summary

Unit 2/6 of dashboard wiring batch (see plan `/Users/ianlintner/.claude/plans/tranquil-inventing-dragonfly.md`).

Adds an integration test that drives a successful authorization_code flow through `/oauth/authorize` and asserts the Prometheus counter `oauth2_server_oauth_authorization_codes_issued` is incremented. This metric backs the "Auth Codes" bar on the admin dashboard's Metrics page.

The counter `.inc()` itself already exists in `crates/oauth2-actix/src/handlers/oauth.rs` (right after the `CreateAuthorizationCode` actor message resolves). This test locks the behavior in place so the chart can't silently regress to empty again.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --verbose --all-features --locked` (new test passes; full suite green)
- [x] New test `tests/metrics_wiring.rs::authorize_increments_authorization_codes_issued_counter`:
  - Walks `/oauth/authorize` with `response_type=code` + PKCE + valid session
  - Scrapes `/metrics` via `admin::system_metrics`
  - Asserts `oauth2_server_oauth_authorization_codes_issued >= 1`

Generated with [Claude Code](https://claude.com/claude-code)