### PR TITLE
feat(events): fanout admin audit to RecentEventsStore

### DIFF
--- a/crates/oauth2-actix/src/handlers/admin_extra.rs
+++ b/crates/oauth2-actix/src/handlers/admin_extra.rs
@@ -12,6 +12,7 @@ use oauth2_core::{
 };
 use oauth2_ports::DynStorage;
 
+use super::events::RecentEventsStore;
 use super::login::hash_password;
 
 // --- Audit helper -----------------------------------------------------------
@@ -45,12 +46,32 @@ pub fn build_audit(
         .with_metadata_json(metadata)
 }
 
-/// Write an audit log entry. Errors are logged but never surfaced to the caller —
-/// audit failures must not block the original admin action.
-async fn record_audit(db: &DynStorage, entry: AuditLogEntry) {
+/// Write an audit log entry and mirror it into the in-memory recent-events
+/// ring buffer so admin mutations show up on the dashboard Events tab.
+///
+/// Errors are logged but never surfaced to the caller — audit failures must
+/// not block the original admin action.
+async fn record_audit(db: &DynStorage, store: &RecentEventsStore, entry: AuditLogEntry) {
     if let Err(e) = db.write_audit_log(&entry).await {
         tracing::warn!(error = %e, action = %entry.action, "Failed to write audit log");
     }
+
+    // Metadata is stored as a JSON string; re-parse so consumers see structured fields.
+    let metadata: serde_json::Value = serde_json::from_str(&entry.metadata)
+        .unwrap_or_else(|_| serde_json::Value::String(entry.metadata.clone()));
+
+    let envelope = serde_json::json!({
+        "event_type": entry.action,
+        "source": "admin",
+        "idempotency_key": entry.id,
+        "received_at": entry.created_at.to_rfc3339(),
+        "actor_id": entry.actor_id,
+        "actor_email": entry.actor_email,
+        "target_kind": entry.target_kind,
+        "target_id": entry.target_id,
+        "metadata": metadata,
+    });
+    store.push(envelope).await;
 }
 
 // --- User CRUD --------------------------------------------------------------
@@ -94,6 +115,7 @@ impl From<User> for UserResponse {
 pub async fn create_user(
     req: HttpRequest,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<CreateUserRequest>,
 ) -> Result<HttpResponse> {
     let CreateUserRequest {
@@ -149,7 +171,7 @@ pub async fn create_user(
             "enabled": user.enabled,
         }),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Created().json(UserResponse::from(user)))
 }
@@ -168,6 +190,7 @@ pub async fn update_user(
     req: HttpRequest,
     path: web::Path<String>,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<UpdateUserRequest>,
 ) -> Result<HttpResponse> {
     let user_id = path.into_inner();
@@ -212,7 +235,7 @@ pub async fn update_user(
             "enabled": body.enabled,
         }),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(UserResponse::from(user)))
 }
@@ -221,6 +244,7 @@ pub async fn delete_user(
     req: HttpRequest,
     path: web::Path<String>,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
 ) -> Result<HttpResponse> {
     let user_id = path.into_inner();
     if db
@@ -237,7 +261,7 @@ pub async fn delete_user(
     let _ = db.revoke_tokens_by_user_id(&user_id).await;
 
     let audit = build_audit(&req, "user.delete", "user", &user_id, serde_json::json!({}));
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "message": "User deleted" })))
 }
@@ -251,6 +275,7 @@ pub async fn set_user_enabled(
     req: HttpRequest,
     path: web::Path<String>,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<SetEnabledRequest>,
 ) -> Result<HttpResponse> {
     let user_id = path.into_inner();
@@ -272,7 +297,7 @@ pub async fn set_user_enabled(
         &user_id,
         serde_json::json!({ "enabled": body.enabled }),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "enabled": body.enabled })))
 }
@@ -286,6 +311,7 @@ pub async fn set_user_role(
     req: HttpRequest,
     path: web::Path<String>,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<SetRoleRequest>,
 ) -> Result<HttpResponse> {
     let user_id = path.into_inner();
@@ -307,7 +333,7 @@ pub async fn set_user_role(
         &user_id,
         serde_json::json!({ "role": role }),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "role": role })))
 }
@@ -321,6 +347,7 @@ pub async fn reset_user_password(
     req: HttpRequest,
     path: web::Path<String>,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<ResetPasswordRequest>,
 ) -> Result<HttpResponse> {
     let user_id = path.into_inner();
@@ -346,7 +373,7 @@ pub async fn reset_user_password(
         &user_id,
         serde_json::json!({}),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "message": "Password reset" })))
 }
@@ -379,6 +406,7 @@ fn default_auth_method() -> String {
 pub async fn create_client(
     req: HttpRequest,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<CreateClientRequest>,
 ) -> Result<HttpResponse> {
     let body = body.into_inner();
@@ -456,7 +484,7 @@ pub async fn create_client(
             "grant_types": client.get_grant_types(),
         }),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     // Return secret exactly once on creation.
     Ok(HttpResponse::Created().json(serde_json::json!({
@@ -494,6 +522,7 @@ pub async fn update_client(
     req: HttpRequest,
     path: web::Path<String>,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<UpdateClientRequest>,
 ) -> Result<HttpResponse> {
     let id = path.into_inner();
@@ -544,7 +573,7 @@ pub async fn update_client(
             "enabled": body.enabled,
         }),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({
         "id": client.id,
@@ -559,6 +588,7 @@ pub async fn set_client_enabled(
     req: HttpRequest,
     path: web::Path<String>,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<SetEnabledRequest>,
 ) -> Result<HttpResponse> {
     // Resolve internal id → client_id (same pattern as delete_client).
@@ -592,7 +622,7 @@ pub async fn set_client_enabled(
         &target.client_id,
         serde_json::json!({ "enabled": body.enabled }),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "enabled": body.enabled })))
 }
@@ -601,6 +631,7 @@ pub async fn regenerate_client_secret(
     req: HttpRequest,
     path: web::Path<String>,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
 ) -> Result<HttpResponse> {
     let all = db
         .list_all_clients()
@@ -632,7 +663,7 @@ pub async fn regenerate_client_secret(
         &target.client_id,
         serde_json::json!({}),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({
         "client_id": target.client_id,
@@ -650,6 +681,7 @@ pub struct BulkRevokeByUserRequest {
 pub async fn bulk_revoke_by_user(
     req: HttpRequest,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<BulkRevokeByUserRequest>,
 ) -> Result<HttpResponse> {
     let count = db
@@ -664,7 +696,7 @@ pub async fn bulk_revoke_by_user(
         &body.user_id,
         serde_json::json!({ "revoked": count }),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "revoked": count })))
 }
@@ -677,6 +709,7 @@ pub struct BulkRevokeByClientRequest {
 pub async fn bulk_revoke_by_client(
     req: HttpRequest,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<BulkRevokeByClientRequest>,
 ) -> Result<HttpResponse> {
     let count = db
@@ -691,7 +724,7 @@ pub async fn bulk_revoke_by_client(
         &body.client_id,
         serde_json::json!({ "revoked": count }),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "revoked": count })))
 }
@@ -755,6 +788,7 @@ pub async fn list_denylist(
 pub async fn add_denylist(
     req: HttpRequest,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
     body: web::Json<AddDenylistRequest>,
 ) -> Result<HttpResponse> {
     let kind = body.kind.to_lowercase();
@@ -795,7 +829,7 @@ pub async fn add_denylist(
             "reason": entry.reason,
         }),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Created().json(DenylistResponse::from(entry)))
 }
@@ -804,6 +838,7 @@ pub async fn remove_denylist(
     req: HttpRequest,
     path: web::Path<String>,
     db: web::Data<DynStorage>,
+    events_store: web::Data<RecentEventsStore>,
 ) -> Result<HttpResponse> {
     let id = path.into_inner();
     db.remove_denylist_entry(&id)
@@ -817,7 +852,7 @@ pub async fn remove_denylist(
         &id,
         serde_json::json!({}),
     );
-    record_audit(db.as_ref(), audit).await;
+    record_audit(db.as_ref(), events_store.as_ref(), audit).await;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "message": "Denylist entry removed" })))
 }

--- a/tests/admin_extra.rs
+++ b/tests/admin_extra.rs
@@ -9,7 +9,8 @@ use actix_session::{storage::CookieSessionStore, Session, SessionMiddleware};
 use actix_web::{cookie::Key, test, web, App, HttpResponse};
 use serde_json::{json, Value};
 
-use oauth2_actix::handlers::{admin, admin_extra};
+use oauth2_actix::handlers::events::RecentEventsStore;
+use oauth2_actix::handlers::{admin, admin_extra, events as events_handler};
 use oauth2_core::{Client, DenylistEntry, ListQuery, Token, User};
 use oauth2_ports::DynStorage;
 
@@ -97,6 +98,7 @@ async fn create_user_succeeds_and_hashes_password() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route("/admin/api/users", web::post().to(admin_extra::create_user)),
     )
@@ -142,6 +144,7 @@ async fn create_user_rejects_missing_fields() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route("/admin/api/users", web::post().to(admin_extra::create_user)),
     )
@@ -169,6 +172,7 @@ async fn create_user_rejects_duplicate_username() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route("/admin/api/users", web::post().to(admin_extra::create_user)),
     )
@@ -201,6 +205,7 @@ async fn update_user_patches_email_and_role() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/users/{id}",
@@ -236,6 +241,7 @@ async fn update_user_ignores_invalid_role() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/users/{id}",
@@ -267,6 +273,7 @@ async fn update_user_404_for_missing() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/users/{id}",
@@ -312,6 +319,7 @@ async fn delete_user_removes_row_and_revokes_tokens() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/users/{id}",
@@ -363,6 +371,7 @@ async fn set_user_enabled_toggles_flag_and_revokes_on_disable() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/users/{id}/enabled",
@@ -416,6 +425,7 @@ async fn set_user_role_rejects_invalid_role() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/users/{id}/role",
@@ -447,6 +457,7 @@ async fn reset_user_password_rejects_weak_password() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/users/{id}/password",
@@ -490,6 +501,7 @@ async fn reset_user_password_updates_hash_and_revokes_tokens() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/users/{id}/password",
@@ -533,6 +545,7 @@ async fn create_client_confidential_returns_secret_once() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/clients",
@@ -574,6 +587,7 @@ async fn create_public_client_has_no_secret() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/clients",
@@ -610,6 +624,7 @@ async fn create_client_rejects_empty_name() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/clients",
@@ -641,6 +656,7 @@ async fn update_client_mutates_metadata() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/clients/{id}",
@@ -695,6 +711,7 @@ async fn set_client_enabled_toggles_and_revokes_tokens_on_disable() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/clients/{id}/enabled",
@@ -741,6 +758,7 @@ async fn regenerate_client_secret_rejects_public_clients() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/clients/{id}/regenerate-secret",
@@ -775,6 +793,7 @@ async fn regenerate_client_secret_replaces_secret() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/clients/{id}/regenerate-secret",
@@ -820,6 +839,7 @@ async fn add_denylist_entry_round_trips() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/denylist",
@@ -869,6 +889,7 @@ async fn add_denylist_rejects_unknown_kind() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/denylist",
@@ -897,6 +918,7 @@ async fn add_denylist_upserts_on_duplicate() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/denylist",
@@ -941,6 +963,7 @@ async fn remove_denylist_clears_entry() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/denylist/{id}",
@@ -989,6 +1012,7 @@ async fn admin_mutation_writes_audit_entry() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route("/admin/api/users", web::post().to(admin_extra::create_user)),
     )
@@ -1017,6 +1041,59 @@ async fn admin_mutation_writes_audit_entry() {
     assert_eq!(entry.actor_email, "admin@test.example");
     assert_eq!(entry.target_kind, "user");
     assert!(entry.metadata.contains("audit-target"));
+}
+
+#[actix_web::test]
+async fn admin_mutation_fans_out_to_recent_events_store() {
+    let storage = setup_storage().await;
+    let events_store = RecentEventsStore::new(32);
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                session_key(),
+            ))
+            .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(events_store))
+            .route("/test/login", web::get().to(seed_session))
+            .route("/admin/api/users", web::post().to(admin_extra::create_user))
+            .route(
+                "/admin/api/events/recent",
+                web::get().to(events_handler::recent_events),
+            ),
+    )
+    .await;
+    let cookie = admin_cookie!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/users")
+        .insert_header(("Cookie", cookie.clone()))
+        .set_json(json!({
+            "username": "event-target",
+            "email": "event@test.example",
+            "password": "passphrase-12345"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201);
+
+    let req = test::TestRequest::get()
+        .uri("/admin/api/events/recent")
+        .insert_header(("Cookie", cookie))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    let items = body["items"].as_array().expect("items array");
+    let ev = items
+        .iter()
+        .find(|i| i["event_type"] == "user.create")
+        .expect("user.create event fanned out to recent events store");
+    assert_eq!(ev["source"], "admin");
+    assert!(!ev["idempotency_key"].as_str().unwrap_or("").is_empty());
+    assert_eq!(ev["target_kind"], "user");
+    assert_eq!(ev["metadata"]["username"], "event-target");
 }
 
 #[actix_web::test]
@@ -1083,6 +1160,7 @@ async fn bulk_revoke_by_user_revokes_all_their_tokens() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/tokens/revoke-by-user",
@@ -1153,6 +1231,7 @@ async fn bulk_revoke_by_client_revokes_only_that_client() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/login", web::get().to(seed_session))
             .route(
                 "/admin/api/tokens/revoke-by-client",

--- a/tests/admin_rbac.rs
+++ b/tests/admin_rbac.rs
@@ -11,6 +11,7 @@ use actix_web::{cookie::Key, test, web, App, HttpResponse};
 use serde_json::json;
 
 use oauth2_actix::handlers::admin_extra;
+use oauth2_actix::handlers::events::RecentEventsStore;
 use oauth2_actix::middleware::admin_guard::AdminGuard;
 use oauth2_core::{Client, Token};
 use oauth2_ports::DynStorage;
@@ -71,6 +72,7 @@ async fn admin_api_without_session_returns_redirect_for_html_paths() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .service(
                 web::scope("/admin")
                     .wrap(AdminGuard)
@@ -109,6 +111,7 @@ async fn admin_api_without_session_returns_302_on_api_paths() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .service(web::scope("/admin").wrap(AdminGuard).service(
                 web::scope("/api").route("/users", web::post().to(admin_extra::create_user)),
             )),
@@ -141,6 +144,7 @@ async fn plain_user_session_gets_403_on_admin_api() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/user-login", web::get().to(as_plain_user))
             .service(
                 web::scope("/admin").wrap(AdminGuard).service(
@@ -189,6 +193,7 @@ async fn admin_session_can_invoke_admin_api() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .route("/test/admin-login", web::get().to(as_admin))
             .service(web::scope("/admin").wrap(AdminGuard).service(
                 web::scope("/api").route("/users", web::post().to(admin_extra::create_user)),
@@ -245,6 +250,7 @@ async fn bearer_token_without_admin_scope_is_403() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .service(web::scope("/admin").wrap(AdminGuard).service(
                 web::scope("/api").route("/users", web::post().to(admin_extra::create_user)),
             )),
@@ -297,6 +303,7 @@ async fn bearer_token_with_admin_scope_passes() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .service(web::scope("/admin").wrap(AdminGuard).service(
                 web::scope("/api").route("/denylist", web::post().to(admin_extra::add_denylist)),
             )),
@@ -326,6 +333,7 @@ async fn invalid_bearer_token_is_401() {
                 session_key(),
             ))
             .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(RecentEventsStore::new(16)))
             .service(web::scope("/admin").wrap(AdminGuard).service(
                 web::scope("/api").route("/users", web::post().to(admin_extra::create_user)),
             )),


### PR DESCRIPTION
Unit 5/6 of dashboard wiring batch (see plan /Users/ianlintner/.claude/plans/tranquil-inventing-dragonfly.md).

## Summary
- Admin mutations (user/client/denylist/bulk-revoke) write to the DB audit log but never landed in `RecentEventsStore`, so they were invisible on the dashboard Events tab. This PR mirrors every audit entry into the in-memory ring buffer that backs `/admin/api/events/recent`.
- `record_audit(db, store, entry)` now pushes a flat JSON envelope with the fields the dashboard template reads directly (`event_type`, `source="admin"`, `idempotency_key`, `received_at`, plus `actor_*`, `target_*`, parsed `metadata`).
- Threaded `web::Data<RecentEventsStore>` through every admin_extra handler that calls `record_audit`. The server app factory already registered the store (for `/events/ingest`); no wiring changes were needed there.
- Updated `tests/admin_extra.rs` and `tests/admin_rbac.rs` to register the store alongside `DynStorage` and added `admin_mutation_fans_out_to_recent_events_store` covering the POST-user -> GET /events/recent path.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --test admin_extra --test admin_rbac --all-features --locked` -> 29 + 7 passing
- [x] Full `cargo test --verbose --all-features --locked` -> exit 0

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>