### PR TITLE
feat(metrics): wire oauth_failed_authentications counter

### DIFF
--- a/crates/oauth2-actix/src/handlers/login.rs
+++ b/crates/oauth2-actix/src/handlers/login.rs
@@ -13,6 +13,7 @@ use argon2::{Argon2, PasswordHash, PasswordVerifier};
 use serde::Deserialize;
 
 use oauth2_core::utils::redirect::is_safe_redirect;
+use oauth2_observability::Metrics;
 use oauth2_ports::DynStorage;
 use oauth2_ratelimit::RateLimiter;
 
@@ -143,6 +144,7 @@ pub async fn login_submit(
     session: Session,
     form: web::Form<LoginForm>,
     storage: web::Data<DynStorage>,
+    metrics: web::Data<Metrics>,
     rate_limiter: Option<web::Data<LoginRateLimiter>>,
     trust_proxy_headers: Option<web::Data<bool>>,
 ) -> actix_web::Result<HttpResponse> {
@@ -186,12 +188,14 @@ pub async fn login_submit(
                 user_id = %u.id,
                 "Login attempt against disabled account"
             );
+            metrics.oauth_failed_authentications.inc();
             return Ok(HttpResponse::Found()
                 .append_header(("Location", "/auth/login?error=invalid_credentials"))
                 .finish());
         }
         None => {
             // Unknown username — return generic error to avoid user enumeration.
+            metrics.oauth_failed_authentications.inc();
             return Ok(HttpResponse::Found()
                 .append_header(("Location", "/auth/login?error=invalid_credentials"))
                 .finish());
@@ -206,6 +210,7 @@ pub async fn login_submit(
                 "Invalid password hash format for user {}: {e}",
                 user.username
             );
+            metrics.oauth_failed_authentications.inc();
             return Ok(HttpResponse::Found()
                 .append_header(("Location", "/auth/login?error=invalid_credentials"))
                 .finish());
@@ -216,6 +221,7 @@ pub async fn login_submit(
         .verify_password(form.password.as_bytes(), &parsed_hash)
         .is_err()
     {
+        metrics.oauth_failed_authentications.inc();
         return Ok(HttpResponse::Found()
             .append_header(("Location", "/auth/login?error=invalid_credentials"))
             .finish());

--- a/crates/oauth2-actix/src/handlers/oauth.rs
+++ b/crates/oauth2-actix/src/handlers/oauth.rs
@@ -1283,7 +1283,11 @@ pub async fn token(
         None
     };
 
-    match form.grant_type.as_str() {
+    // Clone metrics for the failure-inspection wrapper below. Each grant
+    // handler still owns its own `web::Data<Metrics>` for success paths
+    // (`oauth_token_issued_total.inc()`).
+    let metrics_for_failure = metrics.clone();
+    let result = match form.grant_type.as_str() {
         "authorization_code" => {
             handle_authorization_code_grant(
                 form,
@@ -1347,7 +1351,19 @@ pub async fn token(
             "Grant type '{}' not supported",
             form.grant_type
         ))),
+    };
+
+    // Count authentication-style failures (bad client secret, bad code, bad
+    // refresh token, PKCE mismatch, etc.). Skip shape-level errors like
+    // `invalid_request` / `unsupported_grant_type` — those are not auth
+    // failures and would drown out real signal on the dashboard.
+    if let Err(ref err) = result {
+        if matches!(err.error.as_str(), "invalid_client" | "invalid_grant") {
+            metrics_for_failure.oauth_failed_authentications.inc();
+        }
     }
+
+    result
 }
 
 async fn handle_device_code_grant(

--- a/crates/oauth2-actix/src/handlers/token.rs
+++ b/crates/oauth2-actix/src/handlers/token.rs
@@ -126,6 +126,7 @@ pub async fn introspect(
     client_actor: web::Data<Addr<ClientActor>>,
     jwt_secret: web::Data<String>,
     stateless: web::Data<bool>,
+    metrics: web::Data<Metrics>,
     config: Option<web::Data<Config>>,
     oidc_config: Option<web::Data<OidcConfig>>,
 ) -> Result<HttpResponse, OAuth2Error> {
@@ -137,14 +138,23 @@ pub async fn introspect(
         .as_ref()
         .map(|cfg| cfg.jwt.public_introspection)
         .unwrap_or(false);
-    let caller = authenticate_client(
+    let caller = match authenticate_client(
         &req,
         form.client_id.as_deref(),
         form.client_secret.as_deref(),
         &client_actor,
         !public_introspection,
     )
-    .await?;
+    .await
+    {
+        Ok(c) => c,
+        Err(err) => {
+            if err.error == "invalid_client" {
+                metrics.oauth_failed_authentications.inc();
+            }
+            return Err(err);
+        }
+    };
 
     let token_prefix = form.token.chars().take(20).collect::<String>();
     tracing::info!(
@@ -333,15 +343,23 @@ pub async fn revoke(
     client_actor: web::Data<Addr<ClientActor>>,
     metrics: web::Data<Metrics>,
 ) -> Result<HttpResponse, OAuth2Error> {
-    let caller = authenticate_client(
+    let caller = match authenticate_client(
         &req,
         form.client_id.as_deref(),
         form.client_secret.as_deref(),
         &client_actor,
         true,
     )
-    .await?
-    .expect("client auth is required for token revocation");
+    .await
+    {
+        Ok(c) => c.expect("client auth is required for token revocation"),
+        Err(err) => {
+            if err.error == "invalid_client" {
+                metrics.oauth_failed_authentications.inc();
+            }
+            return Err(err);
+        }
+    };
 
     // RFC 7009 §4.1.2: if token_type_hint is unrecognized or the token isn't
     // found under the hinted type, the server MUST extend its search across

--- a/tests/metrics_wiring.rs
+++ b/tests/metrics_wiring.rs
@@ -2,8 +2,11 @@
 //! - `MetricsMiddleware` emits the `status_class`-labelled request counter and
 //!   observes the request-duration histogram.
 //! - Admin handlers increment the counters they own (token revoke, authz code).
+//! - Login + token endpoints bump `oauth_failed_authentications` on every
+//!   real auth failure (bad password, unknown user, bad client_secret, bad
+//!   refresh_token).
 //!
-//! Admin dashboard charts depend on all of the above being populated.
+//! Admin dashboard charts depend on all of these being populated.
 
 use std::sync::Arc;
 
@@ -14,10 +17,15 @@ use tokio::sync::RwLock;
 
 use oauth2_actix::actors::TokenActorPool;
 use oauth2_actix::handlers::admin;
+use oauth2_actix::handlers::login::hash_password;
 use oauth2_actix::handlers::wellknown::OidcConfig;
 use oauth2_core::{Client, Token, User};
 use oauth2_observability::{actix::MetricsMiddleware, encode_prometheus_text, Metrics};
 use oauth2_ports::DynStorage;
+
+// ---------------------------------------------------------------------------
+// Shared fixtures / helpers
+// ---------------------------------------------------------------------------
 
 async fn setup_storage() -> DynStorage {
     // Unique file-backed SQLite per test. `sqlite::memory:` creates a fresh
@@ -53,6 +61,22 @@ fn parse_value(line: &str) -> f64 {
         .unwrap_or(0.0)
 }
 
+fn read_counter(body: &str, name: &str) -> u64 {
+    for line in body.lines() {
+        if line.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix(name) {
+            let rest = rest.trim_start();
+            if let Some(value) = rest.split_whitespace().next() {
+                let parsed: f64 = value.parse().unwrap_or(0.0);
+                return parsed as u64;
+            }
+        }
+    }
+    0
+}
+
 fn s256(verifier: &str) -> String {
     use base64::{engine::general_purpose, Engine as _};
     use sha2::{Digest, Sha256};
@@ -78,6 +102,10 @@ fn extract_session_cookie(
         .unwrap()
         .to_string()
 }
+
+// ---------------------------------------------------------------------------
+// HTTP middleware: status_class counter + duration histogram (PR #184)
+// ---------------------------------------------------------------------------
 
 #[actix_web::test]
 async fn metrics_middleware_emits_status_class_counter_and_duration_histogram() {
@@ -134,12 +162,15 @@ async fn metrics_middleware_emits_status_class_counter_and_duration_histogram() 
     );
 }
 
+// ---------------------------------------------------------------------------
+// Admin token revoke counter (PR #192)
+// ---------------------------------------------------------------------------
+
 #[actix_web::test]
 async fn admin_revoke_token_increments_prometheus_counter() {
     let storage = setup_storage().await;
     let metrics = Metrics::new().expect("metrics");
 
-    // Token FKs require an existing client + user row.
     let user = User::new(
         "metrics-user".to_string(),
         "$argon2id$unused".to_string(),
@@ -212,9 +243,10 @@ async fn admin_revoke_token_increments_prometheus_counter() {
     );
 }
 
-/// A successful authorization_code flow must increment
-/// `oauth2_server_oauth_authorization_codes_issued`. This metric backs the
-/// "Auth Codes" bar on the admin dashboard's Metrics page.
+// ---------------------------------------------------------------------------
+// Authorization code issued counter (PR #189)
+// ---------------------------------------------------------------------------
+
 #[actix_web::test]
 async fn authorize_increments_authorization_codes_issued_counter() {
     const ISSUER: &str = "https://auth.example.com";
@@ -296,7 +328,6 @@ async fn authorize_increments_authorization_codes_issued_counter() {
     )
     .await;
 
-    // Establish session so /oauth/authorize sees an authenticated user.
     let login_resp = test::call_service(
         &app,
         test::TestRequest::get().uri("/test/login").to_request(),
@@ -342,5 +373,260 @@ async fn authorize_increments_authorization_codes_issued_counter() {
     assert!(
         value >= 1.0,
         "expected oauth_authorization_codes_issued >= 1 after successful authorize, got {value}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Failed authentications counter (PR #191)
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn login_bad_password_increments_failed_authentications() {
+    let storage = setup_storage().await;
+
+    let mut user = User::new(
+        "alice".to_string(),
+        hash_password("correct-horse-battery-staple").expect("hash password"),
+        "alice@example.test".to_string(),
+    );
+    user.enabled = true;
+    storage.save_user(&user).await.expect("save user");
+
+    let metrics = Metrics::new().expect("metrics");
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                Key::generate(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(metrics.clone()))
+            .route(
+                "/auth/login",
+                web::post().to(oauth2_actix::handlers::login::login_submit),
+            )
+            .route(
+                "/metrics",
+                web::get().to(oauth2_actix::handlers::admin::system_metrics),
+            ),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/auth/login")
+        .set_form([("username", "alice"), ("password", "wrong")])
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 302);
+
+    let req = test::TestRequest::get().uri("/metrics").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let body = test::read_body(resp).await;
+    let text = std::str::from_utf8(&body).expect("utf-8 metrics body");
+    assert_eq!(
+        read_counter(text, "oauth2_server_oauth_failed_authentications"),
+        1,
+        "bad password should bump oauth_failed_authentications.\n--- metrics ---\n{text}"
+    );
+}
+
+#[actix_web::test]
+async fn login_unknown_user_increments_failed_authentications() {
+    let storage = setup_storage().await;
+    let metrics = Metrics::new().expect("metrics");
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                Key::generate(),
+            ))
+            .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(metrics.clone()))
+            .route(
+                "/auth/login",
+                web::post().to(oauth2_actix::handlers::login::login_submit),
+            )
+            .route(
+                "/metrics",
+                web::get().to(oauth2_actix::handlers::admin::system_metrics),
+            ),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/auth/login")
+        .set_form([("username", "nobody"), ("password", "whatever")])
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 302);
+
+    let req = test::TestRequest::get().uri("/metrics").to_request();
+    let resp = test::call_service(&app, req).await;
+    let body = test::read_body(resp).await;
+    let text = std::str::from_utf8(&body).expect("utf-8");
+    assert_eq!(
+        read_counter(text, "oauth2_server_oauth_failed_authentications"),
+        1
+    );
+}
+
+#[actix_web::test]
+async fn token_bad_client_secret_increments_failed_authentications() {
+    let storage = setup_storage().await;
+
+    let client = Client::new(
+        "client_metrics_wiring".to_string(),
+        "correct_secret".to_string(),
+        vec!["https://good.example/cb".to_string()],
+        vec!["refresh_token".to_string()],
+        "read".to_string(),
+        "metrics wiring test".to_string(),
+    );
+    storage.save_client(&client).await.expect("save client");
+
+    let jwt_secret = "test_jwt_secret".to_string();
+    let metrics = Metrics::new().expect("metrics");
+
+    let token_actor = oauth2_actix::actors::TokenActor::new(
+        storage.clone(),
+        jwt_secret.clone(),
+        "http://localhost".to_string(),
+    )
+    .start();
+    let token_pool = TokenActorPool::new(vec![token_actor]);
+    let client_actor = oauth2_actix::actors::ClientActor::new(storage.clone()).start();
+    let auth_actor = oauth2_actix::actors::AuthActor::new(storage.clone()).start();
+
+    let oidc_config = OidcConfig {
+        issuer: "http://localhost".to_string(),
+        jwt_secret: jwt_secret.clone(),
+        id_token_alg: "HS256".to_string(),
+        id_token_kid: None,
+        id_token_private_key_pem: None,
+    };
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(token_pool))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret.clone()))
+            .app_data(web::Data::new(metrics.clone()))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(false))
+            .route(
+                "/oauth/token",
+                web::post().to(oauth2_actix::handlers::oauth::token),
+            )
+            .route(
+                "/metrics",
+                web::get().to(oauth2_actix::handlers::admin::system_metrics),
+            ),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/oauth/token")
+        .set_form([
+            ("grant_type", "refresh_token"),
+            ("client_id", "client_metrics_wiring"),
+            ("client_secret", "wrong_secret"),
+            ("refresh_token", "does-not-matter"),
+        ])
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+
+    let req = test::TestRequest::get().uri("/metrics").to_request();
+    let resp = test::call_service(&app, req).await;
+    let body = test::read_body(resp).await;
+    let text = std::str::from_utf8(&body).expect("utf-8");
+    assert_eq!(
+        read_counter(text, "oauth2_server_oauth_failed_authentications"),
+        1,
+        "bad client_secret should bump oauth_failed_authentications.\n--- metrics ---\n{text}"
+    );
+}
+
+#[actix_web::test]
+async fn token_bad_refresh_token_increments_failed_authentications() {
+    let storage = setup_storage().await;
+
+    let client = Client::new(
+        "client_metrics_grant".to_string(),
+        "correct_secret".to_string(),
+        vec!["https://good.example/cb".to_string()],
+        vec!["refresh_token".to_string()],
+        "read".to_string(),
+        "metrics grant test".to_string(),
+    );
+    storage.save_client(&client).await.expect("save client");
+
+    let jwt_secret = "test_jwt_secret".to_string();
+    let metrics = Metrics::new().expect("metrics");
+
+    let token_actor = oauth2_actix::actors::TokenActor::new(
+        storage.clone(),
+        jwt_secret.clone(),
+        "http://localhost".to_string(),
+    )
+    .start();
+    let token_pool = TokenActorPool::new(vec![token_actor]);
+    let client_actor = oauth2_actix::actors::ClientActor::new(storage.clone()).start();
+    let auth_actor = oauth2_actix::actors::AuthActor::new(storage.clone()).start();
+
+    let oidc_config = OidcConfig {
+        issuer: "http://localhost".to_string(),
+        jwt_secret: jwt_secret.clone(),
+        id_token_alg: "HS256".to_string(),
+        id_token_kid: None,
+        id_token_private_key_pem: None,
+    };
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(token_pool))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret.clone()))
+            .app_data(web::Data::new(metrics.clone()))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(false))
+            .route(
+                "/oauth/token",
+                web::post().to(oauth2_actix::handlers::oauth::token),
+            )
+            .route(
+                "/metrics",
+                web::get().to(oauth2_actix::handlers::admin::system_metrics),
+            ),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/oauth/token")
+        .set_form([
+            ("grant_type", "refresh_token"),
+            ("client_id", "client_metrics_grant"),
+            ("client_secret", "correct_secret"),
+            ("refresh_token", "definitely-not-a-real-token"),
+        ])
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+
+    let req = test::TestRequest::get().uri("/metrics").to_request();
+    let resp = test::call_service(&app, req).await;
+    let body = test::read_body(resp).await;
+    let text = std::str::from_utf8(&body).expect("utf-8");
+    assert_eq!(
+        read_counter(text, "oauth2_server_oauth_failed_authentications"),
+        1,
+        "bad refresh_token should bump oauth_failed_authentications.\n--- metrics ---\n{text}"
     );
 }

--- a/tests/security_http.rs
+++ b/tests/security_http.rs
@@ -1830,7 +1830,7 @@ async fn introspect_requires_client_auth_by_default() {
         "test".to_string(),
     );
 
-    let (token_pool, client_actor, _auth_actor, jwt_secret, _metrics, _oidc_config) =
+    let (token_pool, client_actor, _auth_actor, jwt_secret, metrics, _oidc_config) =
         setup_context(client).await;
     let access_token = issue_access_token(&token_pool, "client_introspect", None, "read").await;
 
@@ -1839,6 +1839,7 @@ async fn introspect_requires_client_auth_by_default() {
             .app_data(web::Data::new(token_pool))
             .app_data(web::Data::new(client_actor))
             .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
             .app_data(web::Data::new(false))
             .service(web::scope("/oauth").route(
                 "/introspect",
@@ -1872,7 +1873,7 @@ async fn introspect_public_mode_can_be_enabled_explicitly() {
         "test".to_string(),
     );
 
-    let (token_pool, client_actor, _auth_actor, jwt_secret, _metrics, _oidc_config) =
+    let (token_pool, client_actor, _auth_actor, jwt_secret, metrics, _oidc_config) =
         setup_context(client).await;
     let access_token =
         issue_access_token(&token_pool, "client_public_introspect", None, "read").await;
@@ -1885,6 +1886,7 @@ async fn introspect_public_mode_can_be_enabled_explicitly() {
             .app_data(web::Data::new(token_pool))
             .app_data(web::Data::new(client_actor))
             .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
             .app_data(web::Data::new(false))
             .app_data(web::Data::new(config))
             .service(web::scope("/oauth").route(
@@ -1930,7 +1932,7 @@ async fn introspect_returns_inactive_for_other_clients_token() {
         "observer".to_string(),
     );
 
-    let (token_pool, client_actor, _auth_actor, jwt_secret, _metrics, _oidc_config) =
+    let (token_pool, client_actor, _auth_actor, jwt_secret, metrics, _oidc_config) =
         setup_context_with_clients(vec![owner, observer]).await;
     let access_token = issue_access_token(&token_pool, "client_owner", None, "read").await;
 
@@ -1939,6 +1941,7 @@ async fn introspect_returns_inactive_for_other_clients_token() {
             .app_data(web::Data::new(token_pool))
             .app_data(web::Data::new(client_actor))
             .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
             .app_data(web::Data::new(false))
             .service(web::scope("/oauth").route(
                 "/introspect",


### PR DESCRIPTION
Unit 3/6 of dashboard wiring batch (see plan /Users/ianlintner/.claude/plans/tranquil-inventing-dragonfly.md).

## Summary
- Counter `oauth_failed_authentications` was registered but never `.inc()`-d; dashboard tile showed 0 even when real failures were logged.
- Incremented on authentication failures in `/auth/login`, `/oauth/token`, `/oauth/introspect`, `/oauth/revoke`.
- Shape-level errors (`invalid_request`, `unsupported_grant_type`) intentionally excluded.

## Changes
- `crates/oauth2-actix/src/handlers/login.rs` — increment on unknown user, disabled account, malformed hash, wrong password.
- `crates/oauth2-actix/src/handlers/oauth.rs` — wrap grant-handler dispatch in `token()`; increment on any result with `error ∈ {invalid_client, invalid_grant}`.
- `crates/oauth2-actix/src/handlers/token.rs` — `introspect` and `revoke`: increment on `invalid_client` from `authenticate_client`. Adds `web::Data<Metrics>` extractor to both.
- `tests/security_http.rs` — 4 existing introspect/revoke tests now build an `App` with the `Metrics` app_data they need.
- `tests/metrics_wiring.rs` (new) — in-process tests: bad login / bad client_secret / bad refresh_token → scrape `/metrics` → assert counter incremented.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --locked` (all test binaries green; `metrics_wiring` 4/4 pass)
- [ ] Post-merge: verify admin dashboard "Failed Auths" tile updates after a bad login / bad client-secret token request