### PR TITLE
feat(metrics): wire oauth_token_revoked_total counter

### DIFF
--- a/crates/oauth2-actix/src/handlers/admin.rs
+++ b/crates/oauth2-actix/src/handlers/admin.rs
@@ -293,10 +293,13 @@ pub async fn get_token(
 pub async fn admin_revoke_token(
     token_id: web::Path<String>,
     db: web::Data<DynStorage>,
+    metrics: web::Data<Metrics>,
 ) -> Result<HttpResponse> {
     db.revoke_token(&token_id)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    metrics.oauth_token_revoked_total.inc();
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "message": "Token revoked" })))
 }

--- a/crates/oauth2-actix/src/handlers/token.rs
+++ b/crates/oauth2-actix/src/handlers/token.rs
@@ -11,6 +11,7 @@ use crate::handlers::oauth::{client_secret_matches, parse_client_basic_auth};
 use crate::handlers::wellknown::OidcConfig;
 use oauth2_config::Config;
 use oauth2_core::{Claims, IntrospectionResponse, OAuth2Error};
+use oauth2_observability::Metrics;
 
 fn no_store_headers(mut response: HttpResponse) -> HttpResponse {
     response.headers_mut().insert(
@@ -330,6 +331,7 @@ pub async fn revoke(
     form: web::Form<RevokeRequest>,
     token_actor: web::Data<TokenActorPool>,
     client_actor: web::Data<Addr<ClientActor>>,
+    metrics: web::Data<Metrics>,
 ) -> Result<HttpResponse, OAuth2Error> {
     let caller = authenticate_client(
         &req,
@@ -377,6 +379,7 @@ pub async fn revoke(
                 })
                 .await
                 .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))??;
+            metrics.oauth_token_revoked_total.inc();
         }
         Some(token) => {
             tracing::warn!(

--- a/tests/metrics_wiring.rs
+++ b/tests/metrics_wiring.rs
@@ -1,15 +1,29 @@
-//! Integration tests for the Prometheus metrics middleware.
+//! Integration tests asserting the Prometheus metrics are actually wired:
+//! - `MetricsMiddleware` emits the `status_class`-labelled request counter and
+//!   observes the request-duration histogram.
+//! - Admin handlers increment the counters they own (e.g. token revoke).
 //!
-//! These assert that `MetricsMiddleware`:
-//! - Emits `oauth2_server_http_requests_by_class_total` with a `status_class`
-//!   label for both successful (2xx) and client-error (4xx) responses.
-//! - Observes samples into the `oauth2_server_http_request_duration_seconds`
-//!   histogram (the scraped `..._bucket` series has a nonzero `+Inf` count).
-//!
-//! Admin dashboard charts depend on both series being populated.
+//! Admin dashboard charts depend on all of the above being populated.
 
 use actix_web::{test, web, App, HttpResponse};
+
+use oauth2_actix::handlers::admin;
+use oauth2_core::{Client, Token, User};
 use oauth2_observability::{actix::MetricsMiddleware, encode_prometheus_text, Metrics};
+use oauth2_ports::DynStorage;
+
+async fn setup_storage() -> DynStorage {
+    // Unique file-backed SQLite per test. `sqlite::memory:` creates a fresh
+    // database per connection, which breaks the pool's multi-connection model.
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    let url = format!("sqlite://{}", tmp.path().display());
+    std::mem::forget(tmp);
+    let storage = oauth2_storage_factory::create_storage(&url)
+        .await
+        .expect("create storage");
+    storage.init().await.expect("init");
+    storage
+}
 
 async fn ok_handler() -> HttpResponse {
     HttpResponse::Ok().body("ok")
@@ -22,6 +36,14 @@ async fn not_found_handler() -> HttpResponse {
 async fn metrics_dump(metrics: web::Data<Metrics>) -> HttpResponse {
     let body = encode_prometheus_text(&metrics.registry).expect("encode");
     HttpResponse::Ok().body(body)
+}
+
+/// Parse the trailing numeric value from a Prometheus text-format line like
+/// `name{labels} 3` or `name 3`.
+fn parse_value(line: &str) -> f64 {
+    line.rsplit_once(' ')
+        .and_then(|(_, v)| v.trim().parse::<f64>().ok())
+        .unwrap_or(0.0)
 }
 
 #[actix_web::test]
@@ -56,7 +78,6 @@ async fn metrics_middleware_emits_status_class_counter_and_duration_histogram() 
     let body = test::read_body(resp).await;
     let body = std::str::from_utf8(&body).expect("utf8 metrics body");
 
-    // New status_class counter: at least one 2xx and one 4xx sample.
     assert!(
         body.lines().any(|l| l
             .starts_with("oauth2_server_http_requests_by_class_total{status_class=\"2xx\"}")
@@ -70,8 +91,6 @@ async fn metrics_middleware_emits_status_class_counter_and_duration_histogram() 
         "expected 4xx status_class counter > 0\n{body}"
     );
 
-    // Duration histogram: the +Inf bucket's cumulative count equals total
-    // observed samples. With requests above, this must be > 0.
     let inf_line = body
         .lines()
         .find(|l| l.starts_with("oauth2_server_http_request_duration_seconds_bucket{le=\"+Inf\"}"))
@@ -82,10 +101,80 @@ async fn metrics_middleware_emits_status_class_counter_and_duration_histogram() 
     );
 }
 
-/// Parse the trailing numeric value from a Prometheus text-format line like
-/// `name{labels} 3` or `name 3`.
-fn parse_value(line: &str) -> f64 {
-    line.rsplit_once(' ')
-        .and_then(|(_, v)| v.trim().parse::<f64>().ok())
-        .unwrap_or(0.0)
+#[actix_web::test]
+async fn admin_revoke_token_increments_prometheus_counter() {
+    let storage = setup_storage().await;
+    let metrics = Metrics::new().expect("metrics");
+
+    // Token FKs require an existing client + user row.
+    let user = User::new(
+        "metrics-user".to_string(),
+        "$argon2id$unused".to_string(),
+        "metrics-user@test.example".to_string(),
+    );
+    storage.save_user(&user).await.expect("save user");
+    let client = Client::new(
+        "client-metrics".to_string(),
+        "secret".to_string(),
+        vec!["https://example.com/cb".to_string()],
+        vec!["authorization_code".to_string()],
+        "read".to_string(),
+        "Metrics Client".to_string(),
+    );
+    storage.save_client(&client).await.expect("save client");
+
+    let token = Token::new(
+        "access-metrics-wire".to_string(),
+        None,
+        client.client_id.clone(),
+        Some(user.id.clone()),
+        "read".to_string(),
+        3600,
+        None,
+    );
+    storage.save_token(&token).await.expect("save token");
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(metrics))
+            .route(
+                "/admin/api/tokens/{id}/revoke",
+                web::post().to(admin::admin_revoke_token),
+            )
+            .route("/metrics", web::get().to(admin::system_metrics)),
+    )
+    .await;
+
+    let baseline = test::TestRequest::get().uri("/metrics").to_request();
+    let baseline_body = test::call_and_read_body(&app, baseline).await;
+    let baseline_text = std::str::from_utf8(&baseline_body).unwrap();
+    assert!(
+        baseline_text.contains("oauth2_server_oauth_token_revoked_total 0"),
+        "baseline metrics missing revoked counter line: {baseline_text}"
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/admin/api/tokens/access-metrics-wire/revoke")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let after = test::TestRequest::get().uri("/metrics").to_request();
+    let after_body = test::call_and_read_body(&app, after).await;
+    let after_text = std::str::from_utf8(&after_body).unwrap();
+
+    let line = after_text
+        .lines()
+        .find(|l| l.starts_with("oauth2_server_oauth_token_revoked_total "))
+        .expect("revoked_total line present");
+    let value: u64 = line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .expect("numeric counter value");
+    assert!(
+        value >= 1,
+        "oauth2_server_oauth_token_revoked_total should be >= 1 after revoke, got {value}"
+    );
 }

--- a/tests/security_http.rs
+++ b/tests/security_http.rs
@@ -1987,7 +1987,7 @@ async fn revoke_requires_authenticated_client_and_preserves_other_clients_tokens
         "observer".to_string(),
     );
 
-    let (token_pool, client_actor, _auth_actor, _jwt_secret, _metrics, _oidc_config) =
+    let (token_pool, client_actor, _auth_actor, _jwt_secret, metrics, _oidc_config) =
         setup_context_with_clients(vec![owner, observer]).await;
     let token_pool_for_assert = token_pool.clone();
     let access_token = issue_access_token(&token_pool, "client_revoke_owner", None, "read").await;
@@ -1996,6 +1996,7 @@ async fn revoke_requires_authenticated_client_and_preserves_other_clients_tokens
         App::new()
             .app_data(web::Data::new(token_pool))
             .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(metrics))
             .service(web::scope("/oauth").route(
                 "/revoke",
                 web::post().to(oauth2_actix::handlers::token::revoke),


### PR DESCRIPTION
## Summary

- Wires the `oauth2_server_oauth_token_revoked_total` Prometheus counter so the admin dashboard "Tokens Revoked" chart actually reflects revocations.
- Calls `metrics.oauth_token_revoked_total.inc()` after each successful revoke in the RFC 7009 `/revoke` endpoint and the admin `admin_revoke_token` handler.
- Adds a new `tests/metrics_wiring.rs` backstop that exercises the admin revoke path and asserts the Prometheus `/metrics` dump reports `>= 1`.
- Adds the missing `web::Data::new(metrics)` in the one `security_http.rs` App builder that did not already register it (previously required only by `introspect`; now also required by `revoke`).

Unit 1/6 of the dashboard-wiring batch. Plan: `/Users/ianlintner/.claude/plans/tranquil-inventing-dragonfly.md`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --verbose --all-features --locked` (all integration tests pass, including the new `metrics_wiring::admin_revoke_token_increments_prometheus_counter`)
- [x] New test asserts the baseline counter line is `oauth2_server_oauth_token_revoked_total 0`, then parses the post-revoke value and asserts `>= 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)