### PR TITLE
feat(config): RFC 9700 Phase 6.4 — configurable token TTLs

### DIFF
--- a/crates/oauth2-actix/src/actors/auth_actor.rs
+++ b/crates/oauth2-actix/src/actors/auth_actor.rs
@@ -26,7 +26,12 @@ pub struct AuthActor {
     /// RFC 9126: in-memory store of pushed authorization requests.
     /// Key = `request_uri` (urn:ietf:params:oauth:request-uri:{uuid}).
     par_store: Arc<Mutex<HashMap<String, PAREntry>>>,
+    /// Authorization code lifetime in seconds (RFC 6749 §4.1.2 / RFC 9700 §2.1.5).
+    auth_code_ttl_secs: i64,
 }
+
+/// Default authorization code lifetime: 10 minutes (RFC 6749 §4.1.2 max).
+const DEFAULT_AUTH_CODE_TTL_SECS: i64 = 600;
 
 impl AuthActor {
     pub fn new(db: DynStorage) -> Self {
@@ -34,6 +39,7 @@ impl AuthActor {
             db,
             event_bus: None,
             par_store: Arc::new(Mutex::new(HashMap::new())),
+            auth_code_ttl_secs: DEFAULT_AUTH_CODE_TTL_SECS,
         }
     }
 
@@ -42,7 +48,15 @@ impl AuthActor {
             db,
             event_bus: Some(event_bus),
             par_store: Arc::new(Mutex::new(HashMap::new())),
+            auth_code_ttl_secs: DEFAULT_AUTH_CODE_TTL_SECS,
         }
+    }
+
+    /// Configure the authorization-code lifetime. Values > 600 are clamped
+    /// to the RFC 6749 §4.1.2 maximum inside `AuthorizationCode::new_with_ttl`.
+    pub fn with_auth_code_ttl(mut self, ttl_secs: i64) -> Self {
+        self.auth_code_ttl_secs = ttl_secs;
+        self
     }
 
     /// PAR TTL: pushed requests expire after 60 seconds (RFC 9126 §2.2).
@@ -93,6 +107,7 @@ impl Handler<CreateAuthorizationCode> for AuthActor {
     fn handle(&mut self, msg: CreateAuthorizationCode, _: &mut Self::Context) -> Self::Result {
         let db = self.db.clone();
         let event_bus = self.event_bus.clone();
+        let auth_code_ttl_secs = self.auth_code_ttl_secs;
 
         let parent_span = msg.span.clone();
         let actor_span = tracing::info_span!(
@@ -108,7 +123,7 @@ impl Handler<CreateAuthorizationCode> for AuthActor {
         Box::pin(
             async move {
                 let code = generate_code();
-                let auth_code = AuthorizationCode::new(
+                let auth_code = AuthorizationCode::new_with_ttl(
                     code,
                     msg.client_id.clone(),
                     msg.user_id.clone(),
@@ -120,6 +135,7 @@ impl Handler<CreateAuthorizationCode> for AuthActor {
                     msg.resource,
                     msg.authorization_details,
                     msg.claims_request,
+                    auth_code_ttl_secs,
                 );
 
                 db.save_authorization_code(&auth_code).await?;

--- a/crates/oauth2-actix/src/actors/token_actor.rs
+++ b/crates/oauth2-actix/src/actors/token_actor.rs
@@ -17,6 +17,12 @@ use oauth2_core::{Claims, OAuth2Error, Token};
 const TOKEN_CACHE_TTL_SECS: u64 = 60;
 /// Default max entries in the token validation cache.
 const TOKEN_CACHE_MAX_ENTRIES: usize = 10_000;
+/// Default access token lifetime in seconds. Overridable via config
+/// (`jwt.access_token_ttl_secs`) — see RFC 9700 §2.3.
+const DEFAULT_ACCESS_TOKEN_TTL_SECS: i64 = 3600;
+/// Default refresh token lifetime in seconds (30 days). Overridable via
+/// config (`jwt.refresh_token_ttl_secs`).
+const DEFAULT_REFRESH_TOKEN_TTL_SECS: i64 = 2_592_000;
 /// Redis key prefix for the L2 token cache.
 #[cfg(feature = "redis-cache")]
 const REDIS_TOKEN_PREFIX: &str = "oauth2:token:";
@@ -47,6 +53,10 @@ pub struct TokenActor {
     /// Optional Redis L2 cache behind the in-process LRU.
     #[allow(dead_code)]
     redis: RedisConn,
+    /// Access token lifetime in seconds (RFC 9700 §2.3).
+    access_token_ttl_secs: i64,
+    /// Refresh token lifetime in seconds.
+    refresh_token_ttl_secs: i64,
 }
 
 impl TokenActor {
@@ -61,6 +71,8 @@ impl TokenActor {
             token_cache: LruCache::new(NonZeroUsize::new(TOKEN_CACHE_MAX_ENTRIES).unwrap()),
             token_cache_ttl: std::time::Duration::from_secs(TOKEN_CACHE_TTL_SECS),
             redis: Default::default(),
+            access_token_ttl_secs: DEFAULT_ACCESS_TOKEN_TTL_SECS,
+            refresh_token_ttl_secs: DEFAULT_REFRESH_TOKEN_TTL_SECS,
         }
     }
 
@@ -80,7 +92,17 @@ impl TokenActor {
             token_cache: LruCache::new(NonZeroUsize::new(TOKEN_CACHE_MAX_ENTRIES).unwrap()),
             token_cache_ttl: std::time::Duration::from_secs(TOKEN_CACHE_TTL_SECS),
             redis: Default::default(),
+            access_token_ttl_secs: DEFAULT_ACCESS_TOKEN_TTL_SECS,
+            refresh_token_ttl_secs: DEFAULT_REFRESH_TOKEN_TTL_SECS,
         }
+    }
+
+    /// Configure access and refresh token lifetimes. Callers that do not
+    /// invoke this method retain the 1-hour access / 30-day refresh defaults.
+    pub fn with_token_ttls(mut self, access_ttl_secs: i64, refresh_ttl_secs: i64) -> Self {
+        self.access_token_ttl_secs = access_ttl_secs;
+        self.refresh_token_ttl_secs = refresh_ttl_secs;
+        self
     }
 
     pub fn with_keyset(mut self, keyset: Arc<RwLock<KeySet>>) -> Self {
@@ -152,6 +174,8 @@ impl Handler<CreateToken> for TokenActor {
         let event_bus = self.event_bus.clone();
         let keyset = self.keyset.clone();
         let access_tokens_opaque = self.access_tokens_opaque;
+        let access_token_ttl_secs = self.access_token_ttl_secs;
+        let refresh_token_ttl_secs = self.refresh_token_ttl_secs;
 
         let parent_span = msg.span.clone();
         let actor_span = tracing::info_span!(
@@ -205,7 +229,7 @@ impl Handler<CreateToken> for TokenActor {
                         subject.clone(),
                         aud.clone(),
                         msg.scope.clone(),
-                        3600, // 1 hour
+                        access_token_ttl_secs,
                         &issuer,
                     );
                     // Always preserve client_id claim even when aud is overridden.
@@ -229,7 +253,7 @@ impl Handler<CreateToken> for TokenActor {
                         subject,
                         msg.client_id.clone(),
                         msg.scope.clone(),
-                        2592000, // 30 days
+                        refresh_token_ttl_secs,
                         &issuer,
                     );
                     let token = if let Some(ref key) = signing_key {
@@ -249,7 +273,7 @@ impl Handler<CreateToken> for TokenActor {
                     msg.client_id.clone(),
                     msg.user_id.clone(),
                     msg.scope.clone(),
-                    3600,
+                    access_token_ttl_secs as i32,
                     msg.token_family,
                 );
 

--- a/crates/oauth2-config/src/lib.rs
+++ b/crates/oauth2-config/src/lib.rs
@@ -121,10 +121,42 @@ pub struct JwtConfig {
     /// Refresh tokens remain JWT-backed for rotation/replay checks.
     #[serde(default)]
     pub access_tokens_opaque: bool,
+    /// Access token lifetime, in seconds. RFC 9700 §2.3 recommends short
+    /// access-token lifetimes compensated by refresh rotation.
+    #[serde(default = "default_access_token_ttl_secs")]
+    pub access_token_ttl_secs: u64,
+    /// Refresh token lifetime, in seconds. Defaults to 30 days.
+    #[serde(default = "default_refresh_token_ttl_secs")]
+    pub refresh_token_ttl_secs: u64,
+    /// Authorization-code lifetime, in seconds. RFC 6749 §4.1.2 caps at
+    /// 10 minutes; RFC 9700 §2.1.5 encourages even shorter windows.
+    #[serde(default = "default_authorization_code_ttl_secs")]
+    pub authorization_code_ttl_secs: u64,
 }
 
 fn default_grace_hours() -> u64 {
     24
+}
+
+fn default_access_token_ttl_secs() -> u64 {
+    std::env::var("OAUTH2_ACCESS_TOKEN_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3600)
+}
+
+fn default_refresh_token_ttl_secs() -> u64 {
+    std::env::var("OAUTH2_REFRESH_TOKEN_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2_592_000) // 30 days
+}
+
+fn default_authorization_code_ttl_secs() -> u64 {
+    std::env::var("OAUTH2_AUTHORIZATION_CODE_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(600) // 10 minutes — RFC 6749 §4.1.2 max
 }
 
 /// Configuration for distributed caching (Redis L2 behind in-process LRU).
@@ -526,6 +558,9 @@ impl Config {
                     .ok()
                     .and_then(|v| v.parse().ok())
                     .unwrap_or(false),
+                access_token_ttl_secs: default_access_token_ttl_secs(),
+                refresh_token_ttl_secs: default_refresh_token_ttl_secs(),
+                authorization_code_ttl_secs: default_authorization_code_ttl_secs(),
             },
             events: EventConfig {
                 enabled: std::env::var("OAUTH2_EVENTS_ENABLED")

--- a/crates/oauth2-core/src/models/authorization.rs
+++ b/crates/oauth2-core/src/models/authorization.rs
@@ -37,7 +37,9 @@ pub struct AuthorizationCode {
 }
 
 impl AuthorizationCode {
-    #[allow(clippy::too_many_arguments)]
+    /// Build an authorization code with the RFC-default 10-minute lifetime.
+    ///
+    /// Prefer [`new_with_ttl`] when a configurable TTL is available.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         code: String,
@@ -52,8 +54,44 @@ impl AuthorizationCode {
         authorization_details: Option<String>,
         claims_request: Option<String>,
     ) -> Self {
+        Self::new_with_ttl(
+            code,
+            client_id,
+            user_id,
+            redirect_uri,
+            scope,
+            code_challenge,
+            code_challenge_method,
+            nonce,
+            resource,
+            authorization_details,
+            claims_request,
+            600,
+        )
+    }
+
+    /// Build an authorization code with an explicit TTL in seconds.
+    ///
+    /// Caps at RFC 6749 §4.1.2's 10-minute maximum; values greater than 600
+    /// are clamped. RFC 9700 §2.1.5 recommends values well under the max.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_ttl(
+        code: String,
+        client_id: String,
+        user_id: String,
+        redirect_uri: String,
+        scope: String,
+        code_challenge: Option<String>,
+        code_challenge_method: Option<String>,
+        nonce: Option<String>,
+        resource: Option<String>,
+        authorization_details: Option<String>,
+        claims_request: Option<String>,
+        ttl_seconds: i64,
+    ) -> Self {
         let now = Utc::now();
-        let expires_at = now + Duration::minutes(10);
+        let clamped_ttl = ttl_seconds.clamp(1, 600);
+        let expires_at = now + Duration::seconds(clamped_ttl);
 
         Self {
             id: Uuid::new_v4().to_string(),

--- a/crates/oauth2-server/src/lib.rs
+++ b/crates/oauth2-server/src/lib.rs
@@ -817,6 +817,8 @@ pub async fn run() -> std::io::Result<()> {
         .unwrap_or(1);
     let token_pool = {
         let mut shards = Vec::with_capacity(shard_count);
+        let access_ttl = config.jwt.access_token_ttl_secs as i64;
+        let refresh_ttl = config.jwt.refresh_token_ttl_secs as i64;
         for _ in 0..shard_count {
             let shard = if let Some(ref event_bus) = event_bus {
                 let eb = event_bus.clone();
@@ -830,7 +832,8 @@ pub async fn run() -> std::io::Result<()> {
                         eb,
                     )
                     .with_keyset(keyset.clone())
-                    .with_access_tokens_opaque(config.jwt.access_tokens_opaque);
+                    .with_access_tokens_opaque(config.jwt.access_tokens_opaque)
+                    .with_token_ttls(access_ttl, refresh_ttl);
                     attach_token_cache(actor, &cache_redis)
                 })
             } else {
@@ -843,7 +846,8 @@ pub async fn run() -> std::io::Result<()> {
                         issuer.clone(),
                     )
                     .with_keyset(keyset.clone())
-                    .with_access_tokens_opaque(config.jwt.access_tokens_opaque);
+                    .with_access_tokens_opaque(config.jwt.access_tokens_opaque)
+                    .with_token_ttls(access_ttl, refresh_ttl);
                     attach_token_cache(actor, &cache_redis)
                 })
             };
@@ -870,15 +874,17 @@ pub async fn run() -> std::io::Result<()> {
         })
     };
 
+    let auth_code_ttl = config.jwt.authorization_code_ttl_secs as i64;
     let auth_actor = if let Some(ref event_bus) = event_bus {
         actix::Actor::create(|ctx| {
             ctx.set_mailbox_capacity(ACTOR_MAILBOX_CAPACITY);
             oauth2_actix::actors::AuthActor::with_events(storage.clone(), event_bus.clone())
+                .with_auth_code_ttl(auth_code_ttl)
         })
     } else {
         actix::Actor::create(|ctx| {
             ctx.set_mailbox_capacity(ACTOR_MAILBOX_CAPACITY);
-            oauth2_actix::actors::AuthActor::new(storage.clone())
+            oauth2_actix::actors::AuthActor::new(storage.clone()).with_auth_code_ttl(auth_code_ttl)
         })
     };
 

--- a/tests/rfc9700_compliance.rs
+++ b/tests/rfc9700_compliance.rs
@@ -1,0 +1,328 @@
+//! RFC 9700 (OAuth 2.0 Security Best Current Practice) conformance tests.
+//!
+//! These tests assert the section-by-section guarantees listed in
+//! `docs/oauth2-spec-audit.md` §9.1. They are kept separate from
+//! `rfc_compliance.rs` so that Phase 6 hardening claims can be verified
+//! independently and cited by RFC section number.
+
+use actix::Actor;
+use actix_web::{test, web, App};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use oauth2_actix::actors::TokenActorPool;
+use oauth2_actix::handlers::wellknown::OidcConfig;
+use oauth2_core::{Client, TokenResponse};
+use oauth2_observability::Metrics;
+
+// ---------------------------------------------------------------------------
+// Shared setup.
+// ---------------------------------------------------------------------------
+
+async fn setup(
+    clients: Vec<Client>,
+    issuer: &str,
+    access_ttl_secs: Option<i64>,
+    refresh_ttl_secs: Option<i64>,
+) -> (
+    TokenActorPool,
+    actix::Addr<oauth2_actix::actors::ClientActor>,
+    actix::Addr<oauth2_actix::actors::AuthActor>,
+    String,
+    Metrics,
+    OidcConfig,
+) {
+    let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
+        .await
+        .expect("storage");
+    storage.init().await.expect("init");
+
+    for client in clients {
+        storage.save_client(&client).await.expect("save_client");
+    }
+
+    let jwt_secret = "rfc9700_test_secret_at_least_32_chars_long".to_string();
+    let metrics = Metrics::new().expect("metrics");
+
+    let mut token_actor = oauth2_actix::actors::TokenActor::new(
+        storage.clone(),
+        jwt_secret.clone(),
+        issuer.to_string(),
+    );
+    if let (Some(a), Some(r)) = (access_ttl_secs, refresh_ttl_secs) {
+        token_actor = token_actor.with_token_ttls(a, r);
+    }
+    let token_pool = TokenActorPool::new(vec![token_actor.start()]);
+    let client_actor = oauth2_actix::actors::ClientActor::new(storage.clone()).start();
+    let auth_actor = oauth2_actix::actors::AuthActor::new(storage).start();
+
+    let oidc_config = OidcConfig {
+        issuer: issuer.to_string(),
+        jwt_secret: jwt_secret.clone(),
+        id_token_alg: "HS256".to_string(),
+        id_token_kid: None,
+        id_token_private_key_pem: None,
+    };
+
+    (
+        token_pool,
+        client_actor,
+        auth_actor,
+        jwt_secret,
+        metrics,
+        oidc_config,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// §2.3 — Access token audience restriction via RFC 8707 `resource` parameter.
+// ---------------------------------------------------------------------------
+
+/// When the token request carries a `resource` parameter, the issued access
+/// token's `aud` claim MUST equal that resource URI (not the client_id).
+#[actix_web::test]
+async fn rfc9700_aud_reflects_resource_parameter_on_client_credentials() {
+    const ISSUER: &str = "https://auth.example.com";
+    const RESOURCE: &str = "https://api.example.com/widgets";
+
+    let client = Client::new(
+        "client_res".to_string(),
+        "secret_res".to_string(),
+        vec!["https://unused/cb".to_string()],
+        vec!["client_credentials".to_string()],
+        "read".to_string(),
+        "test".to_string(),
+    );
+
+    let (token_actor, client_actor, auth_actor, jwt_secret, metrics, oidc_config) =
+        setup(vec![client], ISSUER, None, None).await;
+    let keyset = Arc::new(RwLock::new(oauth2_core::models::key_set::KeySet::default()));
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(token_actor))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret.clone()))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(keyset))
+            .app_data(web::Data::new(false))
+            .service(web::scope("/oauth").route(
+                "/token",
+                web::post().to(oauth2_actix::handlers::oauth::token),
+            )),
+    )
+    .await;
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/oauth/token")
+            .set_form([
+                ("grant_type", "client_credentials"),
+                ("client_id", "client_res"),
+                ("client_secret", "secret_res"),
+                ("scope", "read"),
+                ("resource", RESOURCE),
+            ])
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "token endpoint should accept resource param"
+    );
+    let body: TokenResponse = test::read_body_json(resp).await;
+
+    let mut validation = jsonwebtoken::Validation::default();
+    validation.set_audience(&[RESOURCE]);
+    let decoded = jsonwebtoken::decode::<serde_json::Value>(
+        &body.access_token,
+        &jsonwebtoken::DecodingKey::from_secret(jwt_secret.as_bytes()),
+        &validation,
+    )
+    .expect("JWT must decode with resource as audience");
+
+    assert_eq!(
+        decoded.claims["aud"].as_str(),
+        Some(RESOURCE),
+        "RFC 9700 §2.3 / RFC 8707: aud MUST equal the resource parameter"
+    );
+    assert_eq!(
+        decoded.claims["client_id"].as_str(),
+        Some("client_res"),
+        "client_id claim must still identify the issuing client"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §2.1.1.2 / §2.1.2 / §2.4 — discovery document excludes deprecated flows.
+// ---------------------------------------------------------------------------
+
+/// The discovery document MUST NOT advertise insecure flows or PKCE methods
+/// prohibited by RFC 9700 (implicit grant, ROPC, `plain` PKCE).
+#[actix_web::test]
+async fn rfc9700_discovery_excludes_deprecated_flows() {
+    let (token_actor, client_actor, auth_actor, jwt_secret, metrics, oidc_config) =
+        setup(vec![], "https://auth.example.com", None, None).await;
+    let keyset = Arc::new(RwLock::new(oauth2_core::models::key_set::KeySet::default()));
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(token_actor))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(keyset))
+            .app_data(web::Data::new(false))
+            .route(
+                "/.well-known/openid-configuration",
+                web::get().to(oauth2_actix::handlers::wellknown::openid_configuration),
+            ),
+    )
+    .await;
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/.well-known/openid-configuration")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+
+    let grants = body["grant_types_supported"]
+        .as_array()
+        .expect("grant_types_supported array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        !grants.contains(&"password"),
+        "RFC 9700 §2.4: ROPC (`password`) grant MUST NOT be advertised — got {grants:?}"
+    );
+
+    let response_types = body["response_types_supported"]
+        .as_array()
+        .expect("response_types_supported array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        !response_types.contains(&"token"),
+        "RFC 9700 §2.1.2: implicit grant (`response_type=token`) MUST NOT be advertised — got {response_types:?}"
+    );
+
+    let pkce_methods = body["code_challenge_methods_supported"]
+        .as_array()
+        .expect("code_challenge_methods_supported array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        !pkce_methods.contains(&"plain"),
+        "RFC 9700 §4.8: `plain` PKCE MUST NOT be advertised — got {pkce_methods:?}"
+    );
+    assert!(
+        pkce_methods.contains(&"S256"),
+        "RFC 9700 §2.1.1.2: S256 PKCE method MUST be advertised — got {pkce_methods:?}"
+    );
+
+    assert_eq!(
+        body["authorization_response_iss_parameter_supported"].as_bool(),
+        Some(true),
+        "RFC 9207 / RFC 9700 §2.1.3: issuer parameter support MUST be advertised"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §2.3 / §4.14 — configurable token TTLs (Phase 6.4).
+// ---------------------------------------------------------------------------
+
+/// Access tokens honor the `jwt.access_token_ttl_secs` config knob. Operators
+/// tuning for RFC 9700 §2.3 ("short-lived access tokens") need this surface.
+#[actix_web::test]
+async fn rfc9700_access_token_ttl_is_configurable() {
+    const ISSUER: &str = "https://auth.example.com";
+    const CUSTOM_ACCESS_TTL: i64 = 90;
+    const CUSTOM_REFRESH_TTL: i64 = 1800;
+
+    let client = Client::new(
+        "client_ttl".to_string(),
+        "secret_ttl".to_string(),
+        vec!["https://unused/cb".to_string()],
+        vec!["client_credentials".to_string()],
+        "read".to_string(),
+        "test".to_string(),
+    );
+
+    let (token_actor, client_actor, auth_actor, jwt_secret, metrics, oidc_config) = setup(
+        vec![client],
+        ISSUER,
+        Some(CUSTOM_ACCESS_TTL),
+        Some(CUSTOM_REFRESH_TTL),
+    )
+    .await;
+    let keyset = Arc::new(RwLock::new(oauth2_core::models::key_set::KeySet::default()));
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(token_actor))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret.clone()))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(keyset))
+            .app_data(web::Data::new(false))
+            .service(web::scope("/oauth").route(
+                "/token",
+                web::post().to(oauth2_actix::handlers::oauth::token),
+            )),
+    )
+    .await;
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/oauth/token")
+            .set_form([
+                ("grant_type", "client_credentials"),
+                ("client_id", "client_ttl"),
+                ("client_secret", "secret_ttl"),
+                ("scope", "read"),
+            ])
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+    let body: TokenResponse = test::read_body_json(resp).await;
+
+    assert_eq!(
+        body.expires_in, CUSTOM_ACCESS_TTL as i32,
+        "expires_in must reflect configured access_token_ttl_secs"
+    );
+
+    // Access token JWT exp - iat must equal the configured access TTL.
+    let mut validation = jsonwebtoken::Validation::default();
+    validation.set_audience(&["client_ttl"]);
+    let decoded = jsonwebtoken::decode::<serde_json::Value>(
+        &body.access_token,
+        &jsonwebtoken::DecodingKey::from_secret(jwt_secret.as_bytes()),
+        &validation,
+    )
+    .expect("decodable JWT");
+    let exp = decoded.claims["exp"].as_i64().expect("exp claim");
+    let iat = decoded.claims["iat"].as_i64().expect("iat claim");
+    assert_eq!(
+        exp - iat,
+        CUSTOM_ACCESS_TTL,
+        "JWT exp - iat must equal configured access TTL"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `jwt.access_token_ttl_secs`, `jwt.refresh_token_ttl_secs`, and `jwt.authorization_code_ttl_secs` config fields (plus matching `OAUTH2_*` environment variables). Defaults match today's behavior — 3600 / 2_592_000 / 600.
- Wires them through `TokenActor::with_token_ttls(access, refresh)` and `AuthActor::with_auth_code_ttl(ttl)` builders so existing `new()` / `with_events()` call sites compile unchanged (5 `TokenActor::new` + 22 `AuthActor::new` sites across tests + `crates/oauth2-server/src/lib.rs`).
- `AuthorizationCode::new_with_ttl(..., ttl_seconds)` is the new constructor; the existing `AuthorizationCode::new` stays as a 10-minute-default shim. TTL is clamped to the RFC 6749 §4.1.2 10-minute maximum.
- Server bootstrap reads the three config fields and pipes them into the actor builders.

## Why

RFC 9700 §2.3 recommends short-lived access tokens compensated by refresh rotation. With hardcoded 1h/30d/10min values an operator cannot tighten either end of that tradeoff without a fork. This unblocks production deployments behind reverse proxies that want narrower windows.

## Scope / non-goals

- ID token TTL is still hardcoded to 3600 in three `handlers/oauth.rs` call sites — follows access TTL once `OidcConfig` grows the matching field. Captured as Phase 6.4 follow-up.
- Refresh-token absolute-max-lifetime cap for public clients (RFC 9700 §4.14.2 SHOULD) needs token-family first-issued tracking and is a separate task.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` clean
- [x] `cargo test --all-features --locked` full suite green locally, no regressions
- [x] New test `rfc9700_access_token_ttl_is_configurable` runs TokenActor with a 90s access / 1800s refresh TTL and asserts both `expires_in == 90` in `TokenResponse` and `exp - iat == 90` in the decoded JWT

## Files touched

| File | Change |
|---|---|
| `crates/oauth2-config/src/lib.rs` | 3 new `JwtConfig` fields + env-var defaults + fallback wiring |
| `crates/oauth2-actix/src/actors/token_actor.rs` | TTL fields, `with_token_ttls` builder, handler reads |
| `crates/oauth2-actix/src/actors/auth_actor.rs` | `auth_code_ttl_secs` field, `with_auth_code_ttl` builder, handler uses `AuthorizationCode::new_with_ttl` |
| `crates/oauth2-core/src/models/authorization.rs` | `new_with_ttl(..., ttl_seconds)` constructor; `new` is now a default-TTL shim |
| `crates/oauth2-server/src/lib.rs` | Thread 3 config fields into actor builders |
| `tests/rfc9700_compliance.rs` | +1 test; `setup()` grows optional TTL args |

## References

- RFC 9700 §2.3 — short access token lifetimes
- RFC 6749 §4.1.2 — authorization code 10-minute maximum
- `docs/oauth2-spec-audit.md` §9.2 item 6.4

Depends on nothing; can land before or after #196 (Phase 6 hardening). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)