### PR TITLE
feat(security): RFC 9700 Phase 6.8 — application-layer HTTPS enforcement

### DIFF
--- a/crates/oauth2-actix/src/middleware/https_redirect.rs
+++ b/crates/oauth2-actix/src/middleware/https_redirect.rs
@@ -1,0 +1,160 @@
+//! HTTPS enforcement middleware (RFC 9700 §2.6).
+//!
+//! When `enforce_https = true`, any request arriving over plain HTTP is
+//! rewritten to `https://` and returned with an HTTP 308 Permanent Redirect.
+//!
+//! Scheme detection:
+//! - When `trust_proxy_headers = true`, prefer the `X-Forwarded-Proto` header
+//!   (set by TLS-terminating reverse proxies such as nginx / Envoy / AGIC).
+//! - Otherwise fall back to the request's connection scheme. Binary tests
+//!   run over `actix_web::test` report `http` by default, which is exactly
+//!   the condition this middleware is meant to catch in production.
+//!
+//! Dev-mode escape hatch: leaving `enforce_https = false` (the default) makes
+//! the middleware a no-op, so local `cargo run` + `curl http://localhost:8080`
+//! still works.
+
+use actix_web::{
+    body::EitherBody,
+    dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
+    Error, HttpResponse,
+};
+use futures::future::LocalBoxFuture;
+use std::future::{ready, Ready};
+use std::rc::Rc;
+
+/// Factory configuration for [`HttpsRedirect`].
+#[derive(Clone, Copy, Debug)]
+pub struct HttpsRedirect {
+    pub enforce: bool,
+    pub trust_proxy_headers: bool,
+}
+
+impl HttpsRedirect {
+    pub fn new(enforce: bool, trust_proxy_headers: bool) -> Self {
+        Self {
+            enforce,
+            trust_proxy_headers,
+        }
+    }
+}
+
+impl<S, B> Transform<S, ServiceRequest> for HttpsRedirect
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = HttpsRedirectService<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(HttpsRedirectService {
+            service: Rc::new(service),
+            enforce: self.enforce,
+            trust_proxy_headers: self.trust_proxy_headers,
+        }))
+    }
+}
+
+pub struct HttpsRedirectService<S> {
+    service: Rc<S>,
+    enforce: bool,
+    trust_proxy_headers: bool,
+}
+
+impl<S, B> Service<ServiceRequest> for HttpsRedirectService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let svc = self.service.clone();
+        let enforce = self.enforce;
+        let trust_proxy = self.trust_proxy_headers;
+
+        Box::pin(async move {
+            if enforce && !request_is_secure(&req, trust_proxy) {
+                if let Some(https_url) = to_https_url(&req) {
+                    tracing::info!(
+                        original_uri = %req.uri(),
+                        redirect = %https_url,
+                        "RFC 9700 §2.6: redirecting plain-HTTP request to HTTPS"
+                    );
+                    let resp = HttpResponse::PermanentRedirect()
+                        .append_header(("Location", https_url))
+                        // Prevent caching of the redirect so that once TLS is
+                        // terminated at a different layer the upgrade sticks.
+                        .append_header(("Cache-Control", "no-store"))
+                        .finish();
+                    return Ok(req.into_response(resp).map_into_right_body());
+                }
+            }
+            let res = svc.call(req).await?;
+            Ok(res.map_into_left_body())
+        })
+    }
+}
+
+/// Returns `true` when the request arrived over TLS.
+///
+/// We intentionally do NOT use `ServiceRequest::connection_info()` here:
+/// Actix's `ConnectionInfo` always reads `Forwarded` / `X-Forwarded-Proto`
+/// regardless of configuration, so it would silently honor a spoofed header
+/// even when the operator set `trust_proxy_headers = false`. This helper
+/// inspects the forwarded header only when explicitly trusted, and
+/// otherwise consults the raw URI scheme on the `ServiceRequest` — which
+/// is populated by actix from the socket, not from client-supplied headers.
+///
+/// Unknown or missing values are treated as insecure so the middleware
+/// fails safe.
+fn request_is_secure(req: &ServiceRequest, trust_proxy: bool) -> bool {
+    if trust_proxy {
+        if let Some(value) = req.headers().get("X-Forwarded-Proto") {
+            if let Ok(s) = value.to_str() {
+                // Comma-separated list — the first value is the closest proxy.
+                let first = s.split(',').next().unwrap_or("").trim();
+                return first.eq_ignore_ascii_case("https");
+            }
+        }
+    }
+    match req.uri().scheme_str() {
+        Some(scheme) => scheme.eq_ignore_ascii_case("https"),
+        None => false,
+    }
+}
+
+/// Build the `https://` equivalent of the current request URL so the browser
+/// can follow the redirect. Uses the `Host` header directly so we do not rely
+/// on `connection_info()` (which merges forwarded headers unconditionally).
+/// Returns `None` when the host is not recoverable.
+fn to_https_url(req: &ServiceRequest) -> Option<String> {
+    let host = req
+        .headers()
+        .get("Host")
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            req.uri()
+                .authority()
+                .map(|a| a.as_str().to_string())
+                .filter(|s| !s.is_empty())
+        })?;
+    let path_and_query = req
+        .uri()
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+    Some(format!("https://{host}{path_and_query}"))
+}

--- a/crates/oauth2-actix/src/middleware/mod.rs
+++ b/crates/oauth2-actix/src/middleware/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin_guard;
 pub mod auth_middleware;
 pub mod denylist;
+pub mod https_redirect;
 pub mod rate_limit;
 pub mod resilience;

--- a/crates/oauth2-config/src/lib.rs
+++ b/crates/oauth2-config/src/lib.rs
@@ -55,6 +55,14 @@ pub struct ServerConfig {
     /// When empty, CORS is fail-closed (all cross-origin requests are denied).
     #[serde(default)]
     pub allowed_origins: Vec<String>,
+    /// RFC 9700 §2.6: when `true`, application-layer middleware rejects
+    /// plain-HTTP requests with an HTTP 308 redirect to the matching
+    /// `https://` URL. Safe to enable behind TLS-terminating reverse proxies
+    /// that set `X-Forwarded-Proto`; requires `trust_proxy_headers = true`
+    /// for the header to be honored. Defaults to `false` so development
+    /// setups keep working without TLS.
+    #[serde(default)]
+    pub enforce_https: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -493,6 +501,11 @@ impl Config {
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty()),
                 allowed_origins: vec![],
+                enforce_https: std::env::var("OAUTH2_SERVER_ENFORCE_HTTPS")
+                    .ok()
+                    .or_else(|| std::env::var("OAUTH2_ENFORCE_HTTPS").ok())
+                    .and_then(|v| v.parse::<bool>().ok())
+                    .unwrap_or(false),
             },
             database: DatabaseConfig {
                 url: std::env::var("OAUTH2_DATABASE_URL")

--- a/crates/oauth2-server/src/lib.rs
+++ b/crates/oauth2-server/src/lib.rs
@@ -1018,10 +1018,17 @@ pub async fn run() -> std::io::Result<()> {
             // IP denylist check runs before rate limiting so that
             // denylisted IPs don't consume rate-limit quota.
             .wrap(oauth2_actix::middleware::denylist::DenylistGuard)
-            // Resilience is the outermost layer (last .wrap() call).
-            // Tripped circuit / full concurrency pool → 503 on the cheapest
-            // path, before rate-limiting, session, or logging run.
+            // Resilience is next-outermost. Tripped circuit / full concurrency
+            // pool → 503 on the cheapest path, before rate-limiting, session,
+            // or logging run.
             .wrap(resilience_mw)
+            // RFC 9700 §2.6: outermost layer — reject plain HTTP before any
+            // other processing when `server.enforce_https = true`. No-op
+            // when disabled (the dev default).
+            .wrap(oauth2_actix::middleware::https_redirect::HttpsRedirect::new(
+                config.server.enforce_https,
+                config.server.trust_proxy_headers,
+            ))
             // Shared state
             .app_data(web::Data::new(token_pool.clone()))
             .app_data(web::Data::new(client_actor.clone()))

--- a/tests/rfc9700_https_enforcement.rs
+++ b/tests/rfc9700_https_enforcement.rs
@@ -1,0 +1,130 @@
+//! RFC 9700 §2.6 — HTTPS enforcement middleware conformance tests.
+
+use actix_web::{test, web, App, HttpResponse};
+use oauth2_actix::middleware::https_redirect::HttpsRedirect;
+
+async fn probe() -> HttpResponse {
+    HttpResponse::Ok().body("reached handler")
+}
+
+/// When `enforce = false` the middleware is a no-op and plain-HTTP requests
+/// reach the inner handler. This is the dev default and must stay that way.
+#[actix_web::test]
+async fn disabled_by_default_passes_plain_http_through() {
+    let app = test::init_service(
+        App::new()
+            .wrap(HttpsRedirect::new(false, false))
+            .route("/probe", web::get().to(probe)),
+    )
+    .await;
+
+    let resp = test::call_service(&app, test::TestRequest::get().uri("/probe").to_request()).await;
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "no-op middleware must pass request through"
+    );
+}
+
+/// With enforcement on, a plain-HTTP request is rewritten to the matching
+/// `https://` URL and returned as HTTP 308 Permanent Redirect.
+#[actix_web::test]
+async fn enforced_plain_http_is_redirected_308_to_https() {
+    let app = test::init_service(
+        App::new()
+            .wrap(HttpsRedirect::new(true, false))
+            .route("/oauth/authorize", web::get().to(probe)),
+    )
+    .await;
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/oauth/authorize?foo=bar")
+            .insert_header(("Host", "auth.example.com"))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(
+        resp.status(),
+        308,
+        "RFC 9700 §2.6: plain HTTP must 308 → HTTPS"
+    );
+    let location = resp
+        .headers()
+        .get("Location")
+        .expect("Location header")
+        .to_str()
+        .unwrap();
+    assert_eq!(location, "https://auth.example.com/oauth/authorize?foo=bar");
+
+    // Redirect must not be cached — otherwise a temporary HTTPS outage could
+    // lock clients to a stale URL.
+    let cache_control = resp
+        .headers()
+        .get("Cache-Control")
+        .expect("Cache-Control header")
+        .to_str()
+        .unwrap();
+    assert!(cache_control.contains("no-store"));
+}
+
+/// With `trust_proxy_headers = true`, the middleware honors
+/// `X-Forwarded-Proto: https` set by a TLS-terminating reverse proxy and
+/// lets the request through even though the local scheme is plain.
+#[actix_web::test]
+async fn trusted_forwarded_proto_https_passes_through() {
+    let app = test::init_service(
+        App::new()
+            .wrap(HttpsRedirect::new(true, true))
+            .route("/oauth/token", web::post().to(probe)),
+    )
+    .await;
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/oauth/token")
+            .insert_header(("Host", "auth.example.com"))
+            .insert_header(("X-Forwarded-Proto", "https"))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "request terminated at proxy as HTTPS must reach handler"
+    );
+}
+
+/// When `trust_proxy_headers = false`, even `X-Forwarded-Proto: https` is
+/// ignored — prevents a spoofed header from bypassing the redirect when the
+/// server is not actually behind a trusted proxy.
+#[actix_web::test]
+async fn untrusted_forwarded_proto_header_is_ignored() {
+    let app = test::init_service(
+        App::new()
+            .wrap(HttpsRedirect::new(true, false))
+            .route("/oauth/token", web::post().to(probe)),
+    )
+    .await;
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/oauth/token")
+            .insert_header(("Host", "auth.example.com"))
+            .insert_header(("X-Forwarded-Proto", "https"))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(
+        resp.status(),
+        308,
+        "spoofed X-Forwarded-Proto must NOT bypass the redirect when proxy headers are untrusted"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in `HttpsRedirect` middleware that 308-redirects plain-HTTP requests to the matching `https://` URL. Registered as the outermost `.wrap()` so insecure requests short-circuit before any other processing (CORS, rate limiting, session, handlers).
- New config field `server.enforce_https` (default `false`; env `OAUTH2_SERVER_ENFORCE_HTTPS` / `OAUTH2_ENFORCE_HTTPS`).
- Scheme detection deliberately avoids `ServiceRequest::connection_info()`, which always merges `Forwarded` / `X-Forwarded-Proto` regardless of configuration. When `trust_proxy_headers = true`, the middleware reads `X-Forwarded-Proto` directly; when it's `false`, it falls back to the raw URI scheme on the request so a client-spoofed header cannot bypass the redirect.
- Location URL uses the `Host` header (falls back to URI authority) for the same reason.

## Why

RFC 9700 §2.6 requires OAuth endpoints to be served over TLS. Today the server relies entirely on an upstream proxy for this guarantee — if the proxy is misconfigured, there is no application-layer backstop. This middleware closes that gap without introducing any change for operators who leave `enforce_https` off.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` clean
- [x] `cargo test --all-features --locked` full suite green locally — no regressions
- [x] New file `tests/rfc9700_https_enforcement.rs`, 4 tests all pass:
  1. `disabled_by_default_passes_plain_http_through` — no-op when off
  2. `enforced_plain_http_is_redirected_308_to_https` — HTTP → 308, `Location` preserves path+query, `Cache-Control: no-store`
  3. `trusted_forwarded_proto_https_passes_through` — honors trusted `X-Forwarded-Proto: https`
  4. `untrusted_forwarded_proto_header_is_ignored` — spoofed header does NOT bypass when trust_proxy=false

## Files touched

| File | Change |
|---|---|
| `crates/oauth2-actix/src/middleware/https_redirect.rs` | New — `HttpsRedirect` Transform/Service |
| `crates/oauth2-actix/src/middleware/mod.rs` | Add `pub mod https_redirect;` |
| `crates/oauth2-config/src/lib.rs` | `server.enforce_https: bool` + env-var fallback |
| `crates/oauth2-server/src/lib.rs` | Wire `HttpsRedirect` as outermost middleware |
| `tests/rfc9700_https_enforcement.rs` | New — 4 conformance tests |

## Scope / non-goals

- HSTS header value stays hardcoded at `max-age=31536000; includeSubDomains`. Making it configurable (max-age override, `preload` flag) is a separate follow-up under Phase 6.8.
- Binding actix-web directly to rustls so the scheme check can consult the real socket even without a trusted proxy is a deeper change and remains out of scope.

## References

- RFC 9700 §2.6 — TLS for OAuth endpoints
- RFC 9110 §15.4.9 — HTTP 308 Permanent Redirect
- `docs/oauth2-spec-audit.md` §9.2 item 6.8

Independent of #196 and #197; can land in any order. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)