### PR TITLE
feat(security): RFC 9700 Phase 6.11 — scope introspection PII

### DIFF
--- a/crates/oauth2-actix/src/handlers/token.rs
+++ b/crates/oauth2-actix/src/handlers/token.rs
@@ -219,11 +219,26 @@ pub async fn introspect(
             let client_id = token.client_id.clone();
             let token_type = token.token_type.clone();
 
+            // RFC 7662 §5 / RFC 9700 §2.5: limit PII returned to callers who
+            // do not own the token. The cross-client case is already rejected
+            // above with `inactive`. The remaining ambiguous case is the
+            // anonymous / public-introspection path: resource servers that
+            // validate bearer tokens without client credentials should not
+            // receive the token subject's identity (username, sub). They
+            // still need the non-PII lifecycle fields (active, scope, exp,
+            // iat, nbf, aud, iss, token_type) plus client_id and jti for
+            // correlation.
+            let is_authenticated_owner = caller.is_some();
+
             let response = IntrospectionResponse {
                 active,
                 scope: Some(scope),
                 client_id: Some(client_id.clone()),
-                username: user_id.clone(),
+                username: if is_authenticated_owner {
+                    user_id.clone()
+                } else {
+                    None
+                },
                 token_type: Some(token_type),
                 exp: claims
                     .as_ref()
@@ -238,7 +253,11 @@ pub async fn introspect(
                     .as_ref()
                     .map(|c| c.iat)
                     .or(Some(token.created_at.timestamp())),
-                sub: claims.as_ref().map(|c| c.sub.clone()).or(user_id),
+                sub: if is_authenticated_owner {
+                    claims.as_ref().map(|c| c.sub.clone()).or(user_id)
+                } else {
+                    None
+                },
                 aud: claims.as_ref().map(|c| c.aud.clone()).or(Some(client_id)),
                 jti: claims
                     .as_ref()

--- a/tests/rfc9700_introspection_pii.rs
+++ b/tests/rfc9700_introspection_pii.rs
@@ -1,0 +1,264 @@
+//! RFC 7662 §5 / RFC 9700 §2.5 — introspection PII scoping.
+//!
+//! When the introspection endpoint is opened to anonymous callers via
+//! `public_introspection = true`, the response MUST NOT leak the token
+//! subject's identity (username, sub). Resource servers validating a
+//! bearer token still need the lifecycle fields (active, scope, exp, iss,
+//! aud, iat, nbf, client_id, token_type, jti).
+
+use actix::Actor;
+use actix_web::{test, web, App};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use oauth2_actix::actors::TokenActorPool;
+use oauth2_actix::handlers::wellknown::OidcConfig;
+use oauth2_core::{Client, IntrospectionResponse, TokenResponse, User};
+use oauth2_observability::Metrics;
+
+/// Anonymous caller (public_introspection=true) gets lifecycle claims but
+/// NOT the token subject's identity fields.
+#[actix_web::test]
+async fn rfc9700_anonymous_introspection_strips_username_and_sub() {
+    const ISSUER: &str = "https://auth.example.com";
+
+    let client = Client::new(
+        "client_pii".to_string(),
+        "secret_pii".to_string(),
+        vec!["https://unused/cb".to_string()],
+        vec!["client_credentials".to_string()],
+        "read".to_string(),
+        "test".to_string(),
+    );
+
+    let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
+        .await
+        .expect("storage");
+    storage.init().await.expect("init");
+    storage.save_client(&client).await.expect("save_client");
+
+    let now = chrono::Utc::now();
+    let user = User {
+        id: "user_pii".to_string(),
+        username: "alice".to_string(),
+        password_hash: "unused".to_string(),
+        email: "alice@example.test".to_string(),
+        enabled: true,
+        role: "user".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+    storage.save_user(&user).await.expect("save_user");
+
+    let jwt_secret = "pii_test_secret_at_least_32_chars_long".to_string();
+    let metrics = Metrics::new().expect("metrics");
+    let token_actor = oauth2_actix::actors::TokenActor::new(
+        storage.clone(),
+        jwt_secret.clone(),
+        ISSUER.to_string(),
+    )
+    .start();
+    let token_pool = TokenActorPool::new(vec![token_actor]);
+    let client_actor = oauth2_actix::actors::ClientActor::new(storage.clone()).start();
+    let auth_actor = oauth2_actix::actors::AuthActor::new(storage).start();
+    let oidc_config = OidcConfig {
+        issuer: ISSUER.to_string(),
+        jwt_secret: jwt_secret.clone(),
+        id_token_alg: "HS256".to_string(),
+        id_token_kid: None,
+        id_token_private_key_pem: None,
+    };
+    let keyset = Arc::new(RwLock::new(oauth2_core::models::key_set::KeySet::default()));
+    // Enable public_introspection so the anonymous caller path is exercised.
+    let mut config = oauth2_config::Config::default();
+    config.jwt.secret = jwt_secret.clone();
+    config.jwt.public_introspection = true;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(token_pool))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(keyset))
+            .app_data(web::Data::new(false))
+            .app_data(web::Data::new(config))
+            .service(
+                web::scope("/oauth")
+                    .route(
+                        "/token",
+                        web::post().to(oauth2_actix::handlers::oauth::token),
+                    )
+                    .route(
+                        "/introspect",
+                        web::post().to(oauth2_actix::handlers::token::introspect),
+                    ),
+            ),
+    )
+    .await;
+
+    // Issue a token authenticated as the client.
+    let token_resp: TokenResponse = test::read_body_json(
+        test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/oauth/token")
+                .set_form([
+                    ("grant_type", "client_credentials"),
+                    ("client_id", "client_pii"),
+                    ("client_secret", "secret_pii"),
+                    ("scope", "read"),
+                ])
+                .to_request(),
+        )
+        .await,
+    )
+    .await;
+
+    // Introspect WITHOUT client credentials (public_introspection path).
+    let intro_resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/oauth/introspect")
+            .set_form([("token", token_resp.access_token.as_str())])
+            .to_request(),
+    )
+    .await;
+    assert_eq!(intro_resp.status(), 200);
+    let body: IntrospectionResponse = test::read_body_json(intro_resp).await;
+
+    assert!(body.active, "token must still be reported active");
+    // PII stripped
+    assert!(
+        body.username.is_none(),
+        "RFC 7662 §5: anonymous introspection MUST NOT return username — got {:?}",
+        body.username
+    );
+    assert!(
+        body.sub.is_none(),
+        "RFC 7662 §5: anonymous introspection MUST NOT return sub — got {:?}",
+        body.sub
+    );
+    // Lifecycle fields still present
+    assert!(body.scope.is_some(), "scope must be returned to RS");
+    assert!(body.exp.is_some(), "exp must be returned to RS");
+    assert!(body.iat.is_some(), "iat must be returned to RS");
+    assert!(body.client_id.is_some(), "client_id may be returned");
+    assert!(body.iss.is_some(), "iss must be returned");
+}
+
+/// Owner (authenticated as the token-issuing client) gets the full
+/// response including PII. Token_client_credentials grant has no user, so
+/// we exercise this via authorization_code elsewhere; here we assert the
+/// owner simply gets `username` populated when it exists on the token.
+#[actix_web::test]
+async fn rfc9700_owner_introspection_still_returns_pii() {
+    const ISSUER: &str = "https://auth.example.com";
+
+    let client = Client::new(
+        "client_owner".to_string(),
+        "secret_owner".to_string(),
+        vec!["https://unused/cb".to_string()],
+        vec!["client_credentials".to_string()],
+        "read".to_string(),
+        "test".to_string(),
+    );
+
+    let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
+        .await
+        .expect("storage");
+    storage.init().await.expect("init");
+    storage.save_client(&client).await.expect("save_client");
+
+    let jwt_secret = "pii_test_secret_at_least_32_chars_long".to_string();
+    let metrics = Metrics::new().expect("metrics");
+    let token_actor = oauth2_actix::actors::TokenActor::new(
+        storage.clone(),
+        jwt_secret.clone(),
+        ISSUER.to_string(),
+    )
+    .start();
+    let token_pool = TokenActorPool::new(vec![token_actor]);
+    let client_actor = oauth2_actix::actors::ClientActor::new(storage.clone()).start();
+    let auth_actor = oauth2_actix::actors::AuthActor::new(storage).start();
+    let oidc_config = OidcConfig {
+        issuer: ISSUER.to_string(),
+        jwt_secret: jwt_secret.clone(),
+        id_token_alg: "HS256".to_string(),
+        id_token_kid: None,
+        id_token_private_key_pem: None,
+    };
+    let keyset = Arc::new(RwLock::new(oauth2_core::models::key_set::KeySet::default()));
+    let mut config = oauth2_config::Config::default();
+    config.jwt.secret = jwt_secret.clone();
+    // Require client auth — owner path.
+    config.jwt.public_introspection = false;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(token_pool))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(keyset))
+            .app_data(web::Data::new(false))
+            .app_data(web::Data::new(config))
+            .service(
+                web::scope("/oauth")
+                    .route(
+                        "/token",
+                        web::post().to(oauth2_actix::handlers::oauth::token),
+                    )
+                    .route(
+                        "/introspect",
+                        web::post().to(oauth2_actix::handlers::token::introspect),
+                    ),
+            ),
+    )
+    .await;
+
+    let token_resp: TokenResponse = test::read_body_json(
+        test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/oauth/token")
+                .set_form([
+                    ("grant_type", "client_credentials"),
+                    ("client_id", "client_owner"),
+                    ("client_secret", "secret_owner"),
+                    ("scope", "read"),
+                ])
+                .to_request(),
+        )
+        .await,
+    )
+    .await;
+
+    let intro_resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/oauth/introspect")
+            .set_form([
+                ("token", token_resp.access_token.as_str()),
+                ("client_id", "client_owner"),
+                ("client_secret", "secret_owner"),
+            ])
+            .to_request(),
+    )
+    .await;
+    assert_eq!(intro_resp.status(), 200);
+    let body: IntrospectionResponse = test::read_body_json(intro_resp).await;
+
+    assert!(body.active);
+    // sub is present; for client_credentials it equals the client_id (no user)
+    // but the field is NOT stripped as it would be for an anonymous caller.
+    assert!(
+        body.sub.is_some(),
+        "owner introspection must include sub (even for client_credentials tokens)"
+    );
+    assert_eq!(body.client_id.as_deref(), Some("client_owner"));
+}


### PR DESCRIPTION
## Summary

Strips the token subject's identity fields (\`username\`, \`sub\`) from \`/oauth/introspect\` responses when the caller is anonymous (the \`jwt.public_introspection = true\` path used by resource servers that validate bearer tokens without client credentials).

## Why

RFC 7662 §5 / RFC 9700 §2.5 want the introspection response limited to what the caller needs. Authenticated cross-client calls already return \`inactive\`. The remaining window is public-introspection mode: a resource server validating a token currently gets the end-user's \`username\` and \`sub\`, which is more than it needs to make a validation decision.

## Response matrix (active token)

|          field | owner | anonymous |
|---------------:|:-----:|:---------:|
|        \`active\` |  ✅   |    ✅     |
|         \`scope\` |  ✅   |    ✅     |
|     \`client_id\` |  ✅   |    ✅     |
|    \`token_type\` |  ✅   |    ✅     |
|           \`exp\` |  ✅   |    ✅     |
|           \`iat\` |  ✅   |    ✅     |
|           \`nbf\` |  ✅   |    ✅     |
|           \`jti\` |  ✅   |    ✅     |
|           \`iss\` |  ✅   |    ✅     |
|           \`aud\` |  ✅   |    ✅     |
|      \`username\` |  ✅   |    ❌     |
|           \`sub\` |  ✅   |    ❌     |

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features --locked -- -D warnings\` clean
- [x] \`cargo test --all-features --locked\` — full suite green locally
- [x] New file \`tests/rfc9700_introspection_pii.rs\`, 2 tests, both pass:
  1. \`rfc9700_anonymous_introspection_strips_username_and_sub\`
  2. \`rfc9700_owner_introspection_still_returns_pii\`

## Files touched

| File | Change |
|---|---|
| \`crates/oauth2-actix/src/handlers/token.rs\` | \`is_authenticated_owner\` flag gates \`username\` / \`sub\` |
| \`tests/rfc9700_introspection_pii.rs\` | New — 2 conformance tests |

## Scope / non-goals

- Existing RFC 9701 JWT-introspection-response path (\`Accept: application/token-introspection+jwt\`) serializes the same \`IntrospectionResponse\` struct and therefore inherits the PII scoping automatically.
- Future extension (not in this PR): a per-client \`introspection_can_see_all\` flag for trusted introspectors that need full PII even when anonymous. Captured in \`docs/oauth2-spec-audit.md\` §9.2.

## References

- RFC 7662 §5 — introspection privacy
- RFC 9700 §2.5 — client authentication + information exposure
- \`docs/oauth2-spec-audit.md\` §9.2 item 6.11

Independent of #196, #197, #198. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)