### PR TITLE
feat(security): RFC 9700 Phase 6.1 — cascade-revoke tokens on auth-code replay

### DIFF
--- a/crates/oauth2-actix/src/actors/auth_actor.rs
+++ b/crates/oauth2-actix/src/actors/auth_actor.rs
@@ -167,6 +167,37 @@ pub struct MarkAuthorizationCodeUsed {
     pub span: tracing::Span,
 }
 
+/// RFC 9700 §2.1.5: fetch an authorization code by its value WITHOUT
+/// enforcing `is_valid()`. Used by the replay-detection path in the
+/// token handler to recover the stored `token_family` so the entire
+/// token lineage can be cascade-revoked.
+#[derive(Message)]
+#[rtype(result = "Result<Option<AuthorizationCode>, OAuth2Error>")]
+pub struct LookupAuthorizationCode {
+    pub code: String,
+    pub span: tracing::Span,
+}
+
+impl Handler<LookupAuthorizationCode> for AuthActor {
+    type Result = ResponseFuture<Result<Option<AuthorizationCode>, OAuth2Error>>;
+
+    fn handle(&mut self, msg: LookupAuthorizationCode, _: &mut Self::Context) -> Self::Result {
+        let db = self.db.clone();
+        let code_prefix = msg.code.chars().take(12).collect::<String>();
+        let actor_span = tracing::info_span!(
+            parent: &msg.span,
+            "actor.auth.lookup_authorization_code",
+            trace_id = tracing::field::Empty,
+            span_id = tracing::field::Empty,
+            code_prefix = %code_prefix,
+            code_len = msg.code.len()
+        );
+        annotate_span_with_trace_ids(&actor_span);
+
+        Box::pin(async move { db.get_authorization_code(&msg.code).await }.instrument(actor_span))
+    }
+}
+
 impl Handler<ValidateAuthorizationCode> for AuthActor {
     type Result = ResponseFuture<Result<AuthorizationCode, OAuth2Error>>;
 

--- a/crates/oauth2-actix/src/actors/token_actor.rs
+++ b/crates/oauth2-actix/src/actors/token_actor.rs
@@ -594,6 +594,53 @@ impl Handler<RevokeToken> for TokenActor {
     }
 }
 
+/// RFC 9700 §2.1.5 / §4.14.2: revoke every access + refresh token that
+/// carries the supplied `family` UUID. Used on authorization-code replay
+/// (cascade from the auth-code's family) and on refresh-token replay
+/// (cascade from the rotated token's family).
+#[derive(Message)]
+#[rtype(result = "Result<u64, OAuth2Error>")]
+pub struct RevokeTokenFamily {
+    pub family: String,
+    pub span: tracing::Span,
+}
+
+impl Handler<RevokeTokenFamily> for TokenActor {
+    type Result = ResponseFuture<Result<u64, OAuth2Error>>;
+
+    fn handle(&mut self, msg: RevokeTokenFamily, _: &mut Self::Context) -> Self::Result {
+        let db = self.db.clone();
+        let actor_span = tracing::info_span!(
+            parent: &msg.span,
+            "actor.token.revoke_family",
+            trace_id = tracing::field::Empty,
+            span_id = tracing::field::Empty,
+            token_family = %msg.family
+        );
+        annotate_span_with_trace_ids(&actor_span);
+
+        // A family revocation may invalidate many tokens whose access_token
+        // strings we do not know without a query. Dropping the whole LRU
+        // is the simplest correct answer — the cache is a TTL-bounded
+        // performance aid, not a source of truth. Repopulation happens
+        // lazily on subsequent ValidateToken calls.
+        self.token_cache.clear();
+
+        Box::pin(
+            async move {
+                let revoked = db.revoke_token_family(&msg.family).await?;
+                tracing::info!(
+                    token_family = %msg.family,
+                    revoked_count = revoked,
+                    "Revoked token family (RFC 9700 §2.1.5 cascade)"
+                );
+                Ok(revoked)
+            }
+            .instrument(actor_span),
+        )
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Refresh-token lookup (database round-trip, no cache)
 // ---------------------------------------------------------------------------

--- a/crates/oauth2-actix/src/handlers/oauth.rs
+++ b/crates/oauth2-actix/src/handlers/oauth.rs
@@ -1516,7 +1516,7 @@ async fn handle_authorization_code_grant(
     }
 
     // Validate authorization code
-    let auth_code = auth_actor
+    let auth_code = match auth_actor
         .send(ValidateAuthorizationCode {
             code: code.clone(),
             client_id: req.client_id.clone(),
@@ -1525,7 +1525,45 @@ async fn handle_authorization_code_grant(
             span: tracing::Span::current(),
         })
         .await
-        .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))??;
+        .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))?
+    {
+        Ok(code) => code,
+        Err(validation_err) => {
+            // RFC 9700 §2.1.5: on authorization-code replay the AS MUST
+            // revoke every token issued from that code. A *replay* is
+            // specifically a code that exists and is already `used` —
+            // distinct from an expired or never-issued code, which we
+            // ignore here. Fetch the raw record (bypassing `is_valid`)
+            // and, if we find a used entry carrying a `token_family`,
+            // cascade-revoke the entire lineage via the TokenActor.
+            if let Ok(Some(stale)) = auth_actor
+                .send(crate::actors::LookupAuthorizationCode {
+                    code: code.clone(),
+                    span: tracing::Span::current(),
+                })
+                .await
+                .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))?
+            {
+                if stale.used {
+                    if let Some(family) = stale.token_family.clone() {
+                        tracing::warn!(
+                            client_id = %req.client_id,
+                            token_family = %family,
+                            "RFC 9700 §2.1.5: authorization-code replay detected — cascade-revoking token family"
+                        );
+                        let _ = token_actor
+                            .route(&req.client_id)
+                            .send(crate::actors::RevokeTokenFamily {
+                                family,
+                                span: tracing::Span::current(),
+                            })
+                            .await;
+                    }
+                }
+            }
+            return Err(validation_err);
+        }
+    };
 
     // Validate client grant permissions + authenticate if required.
     let client = client_actor
@@ -1578,8 +1616,15 @@ async fn handle_authorization_code_grant(
     // to use the refresh_token grant and the `offline_access` scope was requested
     // (or the client explicitly supports refresh_token without scope restriction).
     let include_refresh = client.supports_grant_type("refresh_token");
+    // RFC 9700 §2.1.5: adopt the auth-code's token_family so every token
+    // derived from this grant shares a lineage that can be cascade-revoked
+    // on code replay. Fall back to a fresh UUID for legacy codes issued
+    // before migration V18 rolled out.
     let token_family = if include_refresh {
-        Some(Uuid::new_v4().to_string())
+        auth_code
+            .token_family
+            .clone()
+            .or_else(|| Some(Uuid::new_v4().to_string()))
     } else {
         None
     };

--- a/crates/oauth2-core/src/models/authorization.rs
+++ b/crates/oauth2-core/src/models/authorization.rs
@@ -34,6 +34,12 @@ pub struct AuthorizationCode {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "sqlx", sqlx(default))]
     pub claims_request: Option<String>,
+    /// RFC 9700 §2.1.5: same `token_family` UUID assigned to every access /
+    /// refresh token issued from this code. On authorization-code replay the
+    /// AS looks up this family and cascade-revokes the entire lineage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "sqlx", sqlx(default))]
+    pub token_family: Option<String>,
 }
 
 impl AuthorizationCode {
@@ -71,6 +77,10 @@ impl AuthorizationCode {
             resource,
             authorization_details,
             claims_request,
+            // RFC 9700 §2.1.5: mint a fresh token_family UUID per code so
+            // every derived access/refresh token shares a lineage that can
+            // be cascade-revoked on code replay.
+            token_family: Some(Uuid::new_v4().to_string()),
         }
     }
 

--- a/crates/oauth2-storage-sqlx/src/sqlx.rs
+++ b/crates/oauth2-storage-sqlx/src/sqlx.rs
@@ -360,6 +360,7 @@ impl SqlxStorage {
                 resource TEXT,
                 authorization_details TEXT,
                 claims_request TEXT,
+                token_family TEXT,
                 FOREIGN KEY (client_id) REFERENCES clients(client_id),
                 FOREIGN KEY (user_id) REFERENCES users(id)
             );
@@ -938,8 +939,8 @@ impl Storage for SqlxStorage {
             DatabasePool::Sqlite(pool) => {
                 sqlx::query(
                     r#"
-                    INSERT INTO authorization_codes (id, code, client_id, user_id, redirect_uri, scope, created_at, expires_at, used, code_challenge, code_challenge_method, nonce, resource, authorization_details, claims_request)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    INSERT INTO authorization_codes (id, code, client_id, user_id, redirect_uri, scope, created_at, expires_at, used, code_challenge, code_challenge_method, nonce, resource, authorization_details, claims_request, token_family)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     "#,
                 )
                 .bind(&auth_code.id)
@@ -957,14 +958,15 @@ impl Storage for SqlxStorage {
                 .bind(&auth_code.resource)
                 .bind(&auth_code.authorization_details)
                 .bind(&auth_code.claims_request)
+                .bind(&auth_code.token_family)
                 .execute(pool)
                 .await?;
             }
             DatabasePool::Postgres(pool) => {
                 sqlx::query(
                     r#"
-                    INSERT INTO authorization_codes (id, code, client_id, user_id, redirect_uri, scope, created_at, expires_at, used, code_challenge, code_challenge_method, nonce, resource, authorization_details, claims_request)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+                    INSERT INTO authorization_codes (id, code, client_id, user_id, redirect_uri, scope, created_at, expires_at, used, code_challenge, code_challenge_method, nonce, resource, authorization_details, claims_request, token_family)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
                     "#,
                 )
                 .bind(&auth_code.id)
@@ -982,6 +984,7 @@ impl Storage for SqlxStorage {
                 .bind(&auth_code.resource)
                 .bind(&auth_code.authorization_details)
                 .bind(&auth_code.claims_request)
+                .bind(&auth_code.token_family)
                 .execute(pool)
                 .await?;
             }

--- a/k8s/base/configmap-migrations.yaml
+++ b/k8s/base/configmap-migrations.yaml
@@ -268,3 +268,11 @@ data:
     CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action);
     CREATE INDEX IF NOT EXISTS idx_audit_log_target ON audit_log(target_kind, target_id);
     CREATE INDEX IF NOT EXISTS idx_audit_log_created_at ON audit_log(created_at);
+
+  V18__add_token_family_to_auth_codes.sql: |
+    -- RFC 9700 §2.1.5: on authorization-code replay the AS MUST revoke every
+    -- token issued from that code. We implement this by tagging the code with
+    -- the same `token_family` UUID used by refresh-token rotation. On replay
+    -- detection the AS looks up the family from the used auth-code record and
+    -- cascade-revokes every access/refresh token in the family.
+    ALTER TABLE authorization_codes ADD COLUMN token_family TEXT;

--- a/migrations/sql/V18__add_token_family_to_auth_codes.sql
+++ b/migrations/sql/V18__add_token_family_to_auth_codes.sql
@@ -1,0 +1,6 @@
+-- RFC 9700 §2.1.5: on authorization-code replay the AS MUST revoke every
+-- token issued from that code. We implement this by tagging the code with
+-- the same `token_family` UUID used by refresh-token rotation. On replay
+-- detection the AS looks up the family from the used auth-code record and
+-- cascade-revokes every access/refresh token in the family.
+ALTER TABLE authorization_codes ADD COLUMN token_family TEXT;

--- a/tests/rfc9700_code_replay.rs
+++ b/tests/rfc9700_code_replay.rs
@@ -1,0 +1,263 @@
+//! RFC 9700 §2.1.5 — authorization-code replay cascade revocation.
+//!
+//! Goal: when an authorization code is exchanged a second time, the AS MUST
+//! invalidate every access / refresh token that was issued from the original
+//! (legitimate) exchange. This test drives the full grant through
+//! `/oauth/authorize` → `/oauth/token`, then replays the code and verifies
+//! that the previously-issued access token introspects as `active: false`.
+
+use actix::Actor;
+use actix_session::{storage::CookieSessionStore, Session, SessionMiddleware};
+use actix_web::{cookie::Key, test, web, App, HttpResponse};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use oauth2_actix::actors::TokenActorPool;
+use oauth2_actix::handlers::wellknown::OidcConfig;
+use oauth2_core::{Client, IntrospectionResponse, TokenResponse, User};
+use oauth2_observability::Metrics;
+
+fn s256(verifier: &str) -> String {
+    use base64::{engine::general_purpose, Engine as _};
+    use sha2::{Digest, Sha256};
+    general_purpose::URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()))
+}
+
+async fn set_session(session: Session) -> HttpResponse {
+    session.insert("user_id", "user_replay").unwrap();
+    session.insert("authenticated", true).unwrap();
+    HttpResponse::Ok().finish()
+}
+
+fn session_cookie(
+    resp: &actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+) -> String {
+    resp.response()
+        .headers()
+        .get(actix_web::http::header::SET_COOKIE)
+        .and_then(|h| h.to_str().ok())
+        .expect("session cookie")
+        .split(';')
+        .next()
+        .unwrap()
+        .to_string()
+}
+
+#[actix_web::test]
+async fn rfc9700_authorization_code_replay_revokes_issued_tokens() {
+    const ISSUER: &str = "https://auth.example.com";
+    const VERIFIER: &str = "verifier-replay-abcdefghijklmnopqrstuvwxyz1234567890";
+
+    let client = Client::new(
+        "client_replay".to_string(),
+        "secret_replay".to_string(),
+        vec!["https://client.example.test/cb".to_string()],
+        vec![
+            "authorization_code".to_string(),
+            "refresh_token".to_string(),
+        ],
+        "read".to_string(),
+        "Replay Test Client".to_string(),
+    );
+
+    let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
+        .await
+        .expect("storage");
+    storage.init().await.expect("init");
+    storage.save_client(&client).await.expect("save_client");
+
+    let now = chrono::Utc::now();
+    let user = User {
+        id: "user_replay".to_string(),
+        username: "user_replay".to_string(),
+        password_hash: "unused".to_string(),
+        email: "replay@example.test".to_string(),
+        enabled: true,
+        role: "user".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+    storage.save_user(&user).await.expect("save_user");
+
+    let jwt_secret = "replay_test_secret_at_least_32_chars_long".to_string();
+    let metrics = Metrics::new().expect("metrics");
+
+    let token_actor = oauth2_actix::actors::TokenActor::new(
+        storage.clone(),
+        jwt_secret.clone(),
+        ISSUER.to_string(),
+    )
+    .start();
+    let token_pool = TokenActorPool::new(vec![token_actor]);
+    let client_actor = oauth2_actix::actors::ClientActor::new(storage.clone()).start();
+    let auth_actor = oauth2_actix::actors::AuthActor::new(storage).start();
+    let oidc_config = OidcConfig {
+        issuer: ISSUER.to_string(),
+        jwt_secret: jwt_secret.clone(),
+        id_token_alg: "HS256".to_string(),
+        id_token_kid: None,
+        id_token_private_key_pem: None,
+    };
+    let keyset = Arc::new(RwLock::new(oauth2_core::models::key_set::KeySet::default()));
+    let mut config = oauth2_config::Config::default();
+    config.jwt.secret = jwt_secret.clone();
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                Key::generate(),
+            ))
+            .app_data(web::Data::new(token_pool))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(keyset))
+            .app_data(web::Data::new(false))
+            .app_data(web::Data::new(config))
+            .route("/_set_session", web::get().to(set_session))
+            .service(
+                web::scope("/oauth")
+                    .route(
+                        "/authorize",
+                        web::get().to(oauth2_actix::handlers::oauth::authorize),
+                    )
+                    .route(
+                        "/token",
+                        web::post().to(oauth2_actix::handlers::oauth::token),
+                    )
+                    .route(
+                        "/introspect",
+                        web::post().to(oauth2_actix::handlers::token::introspect),
+                    ),
+            ),
+    )
+    .await;
+
+    // Establish a session so /oauth/authorize does not bounce to /auth/login.
+    let session_resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/_set_session").to_request(),
+    )
+    .await;
+    let cookie = session_cookie(&session_resp);
+
+    // Drive a PKCE authorization_code grant.
+    let authorize_uri = format!(
+        "/oauth/authorize?response_type=code&client_id=client_replay&redirect_uri=https%3A%2F%2Fclient.example.test%2Fcb&scope=read&state=xyz&code_challenge={}&code_challenge_method=S256",
+        s256(VERIFIER)
+    );
+    let authz_resp = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&authorize_uri)
+            .insert_header(("Cookie", cookie.as_str()))
+            .to_request(),
+    )
+    .await;
+    if authz_resp.status() != 302 {
+        let status = authz_resp.status();
+        let body_bytes = test::read_body(authz_resp).await;
+        panic!(
+            "authorize returned {status}: {:?}",
+            std::str::from_utf8(&body_bytes).unwrap_or("<non-utf8>")
+        );
+    }
+    let location = authz_resp
+        .headers()
+        .get("Location")
+        .expect("Location")
+        .to_str()
+        .unwrap();
+    let code = location
+        .split_once("code=")
+        .map(|(_, rest)| rest.split('&').next().unwrap().to_string())
+        .expect("auth code in redirect");
+
+    // First (legitimate) exchange.
+    let token_resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/oauth/token")
+            .set_form([
+                ("grant_type", "authorization_code"),
+                ("code", code.as_str()),
+                ("client_id", "client_replay"),
+                ("client_secret", "secret_replay"),
+                ("redirect_uri", "https://client.example.test/cb"),
+                ("code_verifier", VERIFIER),
+            ])
+            .to_request(),
+    )
+    .await;
+    assert_eq!(token_resp.status(), 200, "first code exchange must succeed");
+    let token_body: TokenResponse = test::read_body_json(token_resp).await;
+    let access_token = token_body.access_token.clone();
+
+    // Confirm the token is active before the replay.
+    let intro_before: IntrospectionResponse = test::read_body_json(
+        test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/oauth/introspect")
+                .set_form([
+                    ("token", access_token.as_str()),
+                    ("client_id", "client_replay"),
+                    ("client_secret", "secret_replay"),
+                ])
+                .to_request(),
+        )
+        .await,
+    )
+    .await;
+    assert!(
+        intro_before.active,
+        "token from first exchange must be active before replay"
+    );
+
+    // Replay the same code. MUST fail AND MUST cascade-revoke the family.
+    let replay_resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/oauth/token")
+            .set_form([
+                ("grant_type", "authorization_code"),
+                ("code", code.as_str()),
+                ("client_id", "client_replay"),
+                ("client_secret", "secret_replay"),
+                ("redirect_uri", "https://client.example.test/cb"),
+                ("code_verifier", VERIFIER),
+            ])
+            .to_request(),
+    )
+    .await;
+    assert_eq!(
+        replay_resp.status(),
+        400,
+        "code replay must be rejected with invalid_grant"
+    );
+
+    // RFC 9700 §2.1.5: the originally-issued access token MUST now be
+    // inactive because the family was revoked.
+    let intro_after: IntrospectionResponse = test::read_body_json(
+        test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/oauth/introspect")
+                .set_form([
+                    ("token", access_token.as_str()),
+                    ("client_id", "client_replay"),
+                    ("client_secret", "secret_replay"),
+                ])
+                .to_request(),
+        )
+        .await,
+    )
+    .await;
+    assert!(
+        !intro_after.active,
+        "RFC 9700 §2.1.5: prior token from replayed auth code MUST be revoked — got active=true"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the RFC 9700 §2.1.5 requirement that an authorization-code replay MUST invalidate every access / refresh token already issued from that code.

- Extends the token-family lineage (today used by refresh-token rotation) to cover auth-code grants. Every auth code is minted with a fresh \`token_family\` UUID; every access + refresh token minted from that code inherits it.
- On replay, the AS looks the code up (bypassing \`is_valid\`), reads its family, and dispatches a new \`RevokeTokenFamily\` actor message that cascade-revokes the lineage in storage and drops the TokenActor validation cache.

## Why

Today a replayed code returns \`invalid_grant\` but the legitimate user's already-issued tokens keep working for their full TTL. Per RFC 9700 §2.1.5 that's non-compliant: replay detection should also burn the lineage so a thief who lost the race still cannot use the stolen token window.

## Migration

\`migrations/sql/V18__add_token_family_to_auth_codes.sql\`:
\`\`\`sql
ALTER TABLE authorization_codes ADD COLUMN token_family TEXT;
\`\`\`

Nullable so existing rows created before rollout continue to read as \`NULL\` (the code path tolerates legacy codes by minting a fresh family at token-issue time).

\`k8s/base/configmap-migrations.yaml\` updated to match.
\`crates/oauth2-storage-sqlx/src/sqlx.rs::init_sqlx\` (the fresh-DB \`CREATE TABLE\`) updated to match.
Mongo storage persists the full \`AuthorizationCode\` struct and needs no change.

## New actor messages

- \`LookupAuthorizationCode\` on \`AuthActor\` — fetches a code by value without the \`is_valid\` gate, so the replay path can recover the family from a used record.
- \`RevokeTokenFamily\` on \`TokenActor\` — calls \`db.revoke_token_family\` and drops the in-process LRU validation cache so subsequent introspections see the revoked state instead of a stale "active" hit.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features --locked -- -D warnings\` clean
- [x] \`cargo test --all-features --locked\` — full suite green locally, no regressions
- [x] New file \`tests/rfc9700_code_replay.rs\` — end-to-end test drives authorize → token → replay → introspect and asserts \`active=true\` before replay + \`active=false\` after

## Files touched

| File | Change |
|---|---|
| \`migrations/sql/V18__add_token_family_to_auth_codes.sql\` | New — adds \`token_family\` column |
| \`k8s/base/configmap-migrations.yaml\` | V18 entry |
| \`crates/oauth2-storage-sqlx/src/sqlx.rs\` | \`CREATE TABLE\` + \`INSERT\` updated |
| \`crates/oauth2-core/src/models/authorization.rs\` | \`token_family\` field, auto-UUID in \`new\` |
| \`crates/oauth2-actix/src/actors/auth_actor.rs\` | \`LookupAuthorizationCode\` message |
| \`crates/oauth2-actix/src/actors/token_actor.rs\` | \`RevokeTokenFamily\` message + cache drop |
| \`crates/oauth2-actix/src/handlers/oauth.rs\` | Inherit family from code; replay → family revoke |
| \`tests/rfc9700_code_replay.rs\` | New — 1 end-to-end conformance test |

## Scope / non-goals

- Cache invalidation on family revocation clears the entire \`TokenActor\` LRU. The cache is a TTL-bounded perf aid, not the source of truth, so this is correct; a targeted eviction would require tracking token→family reverse indexes and is not worth the complexity for a rare event.
- Per RFC 8628, device-authorization tokens do not carry a family today — not in scope for this PR.
- Legacy codes written before migration V18 read as \`token_family = NULL\`. The handler falls back to a fresh UUID so those continue to work; once the migration has rolled out and the oldest code has expired (10 minutes), every code will carry a family.

## References

- RFC 9700 §2.1.5 — authorization-code replay revocation
- RFC 6749 §4.1.2 — authorization-code single-use
- \`docs/oauth2-spec-audit.md\` §9.2 item 6.1

Independent of #196, #197, #198, #199. Has a migration — ship behind the usual migration rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)