### PR TITLE
feat(security): RFC 9700 Phase 6.6 — per-client require_state policy flag

### DIFF
--- a/crates/oauth2-actix/src/handlers/oauth.rs
+++ b/crates/oauth2-actix/src/handlers/oauth.rs
@@ -598,6 +598,19 @@ pub async fn authorize(
         ));
     }
 
+    // RFC 9700 §4.7: per-client `require_state` enforcement. When the
+    // client has opted in, the `state` parameter is mandatory on the
+    // authorization request. PKCE already covers the CSRF case on its
+    // own; this flag is a defense-in-depth layer for clients that also
+    // bind their user-agent session to `state` on the redirect.
+    // Checked before JAR overlay — a client that requires state must
+    // carry it on the outer request too, not just in the JAR payload.
+    if client.require_state && query.state.is_none() {
+        return Err(OAuth2Error::invalid_request(
+            "state parameter is required for this client (RFC 9700 §4.7)",
+        ));
+    }
+
     // RFC 9101 §4: If a JAR `request` parameter is present, verify its signature and
     // overlay the JWT payload claims on top of the current effective parameters.
     // JAR claims take precedence over the corresponding query-string parameters.

--- a/crates/oauth2-core/src/models/client.rs
+++ b/crates/oauth2-core/src/models/client.rs
@@ -83,6 +83,13 @@ pub struct Client {
     /// unaffected.
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// RFC 9700 §4.7: when `true`, the AS rejects authorization requests that
+    /// omit the `state` parameter. Defense-in-depth for CSRF on the redirect
+    /// path that PKCE already covers. Defaults to `false` so existing clients
+    /// continue to work; operators opt in per-client.
+    #[serde(default)]
+    #[cfg_attr(feature = "sqlx", sqlx(default))]
+    pub require_state: bool,
 }
 
 fn default_true() -> bool {
@@ -126,6 +133,7 @@ impl Client {
             frontchannel_logout_session_required: false,
             post_logout_redirect_uris: String::new(),
             enabled: true,
+            require_state: false,
         }
     }
 

--- a/crates/oauth2-storage-sqlx/src/sqlx.rs
+++ b/crates/oauth2-storage-sqlx/src/sqlx.rs
@@ -192,7 +192,8 @@ impl SqlxStorage {
                 frontchannel_logout_uri TEXT NOT NULL DEFAULT '',
                 frontchannel_logout_session_required INTEGER NOT NULL DEFAULT 0,
                 post_logout_redirect_uris TEXT NOT NULL DEFAULT '[]',
-                enabled INTEGER NOT NULL DEFAULT 1
+                enabled INTEGER NOT NULL DEFAULT 1,
+                require_state INTEGER NOT NULL DEFAULT 0
             );
             "#,
         )
@@ -454,8 +455,8 @@ impl Storage for SqlxStorage {
             DatabasePool::Sqlite(pool) => {
                 sqlx::query(
                     r#"
-                    INSERT INTO clients (id, client_id, client_secret, redirect_uris, grant_types, scope, name, created_at, updated_at, token_endpoint_auth_method, registration_access_token, response_types, contacts, logo_uri, client_uri, policy_uri, tos_uri, jwks, jwks_uri, backchannel_logout_uri, backchannel_logout_session_required, frontchannel_logout_uri, frontchannel_logout_session_required, post_logout_redirect_uris, enabled)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    INSERT INTO clients (id, client_id, client_secret, redirect_uris, grant_types, scope, name, created_at, updated_at, token_endpoint_auth_method, registration_access_token, response_types, contacts, logo_uri, client_uri, policy_uri, tos_uri, jwks, jwks_uri, backchannel_logout_uri, backchannel_logout_session_required, frontchannel_logout_uri, frontchannel_logout_session_required, post_logout_redirect_uris, enabled, require_state)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     "#,
                 )
                 .bind(&client.id)
@@ -483,14 +484,15 @@ impl Storage for SqlxStorage {
                 .bind(client.frontchannel_logout_session_required)
                 .bind(&client.post_logout_redirect_uris)
                 .bind(client.enabled)
+                .bind(client.require_state)
                 .execute(pool)
                 .await?;
             }
             DatabasePool::Postgres(pool) => {
                 sqlx::query(
                     r#"
-                    INSERT INTO clients (id, client_id, client_secret, redirect_uris, grant_types, scope, name, created_at, updated_at, token_endpoint_auth_method, registration_access_token, response_types, contacts, logo_uri, client_uri, policy_uri, tos_uri, jwks, jwks_uri, backchannel_logout_uri, backchannel_logout_session_required, frontchannel_logout_uri, frontchannel_logout_session_required, post_logout_redirect_uris, enabled)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)
+                    INSERT INTO clients (id, client_id, client_secret, redirect_uris, grant_types, scope, name, created_at, updated_at, token_endpoint_auth_method, registration_access_token, response_types, contacts, logo_uri, client_uri, policy_uri, tos_uri, jwks, jwks_uri, backchannel_logout_uri, backchannel_logout_session_required, frontchannel_logout_uri, frontchannel_logout_session_required, post_logout_redirect_uris, enabled, require_state)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
                     "#,
                 )
                 .bind(&client.id)
@@ -518,6 +520,7 @@ impl Storage for SqlxStorage {
                 .bind(client.frontchannel_logout_session_required)
                 .bind(&client.post_logout_redirect_uris)
                 .bind(client.enabled)
+                .bind(client.require_state)
                 .execute(pool)
                 .await?;
             }

--- a/k8s/base/configmap-migrations.yaml
+++ b/k8s/base/configmap-migrations.yaml
@@ -276,3 +276,11 @@ data:
     -- detection the AS looks up the family from the used auth-code record and
     -- cascade-revokes every access/refresh token in the family.
     ALTER TABLE authorization_codes ADD COLUMN token_family TEXT;
+
+  V19__add_require_state_to_clients.sql: |
+    -- RFC 9700 §4.7: defense-in-depth for the CSRF case that PKCE already
+    -- covers. When `require_state = true` the AS rejects authorization
+    -- requests that omit `state`, forcing the client to carry and verify
+    -- a CSRF token on the redirect. Defaults to FALSE so existing clients
+    -- continue to work without churn.
+    ALTER TABLE clients ADD COLUMN require_state BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/sql/V19__add_require_state_to_clients.sql
+++ b/migrations/sql/V19__add_require_state_to_clients.sql
@@ -1,0 +1,6 @@
+-- RFC 9700 §4.7: defense-in-depth for the CSRF case that PKCE already
+-- covers. When `require_state = true` the AS rejects authorization
+-- requests that omit `state`, forcing the client to carry and verify
+-- a CSRF token on the redirect. Defaults to FALSE so existing clients
+-- continue to work without churn.
+ALTER TABLE clients ADD COLUMN require_state BOOLEAN NOT NULL DEFAULT FALSE;

--- a/tests/rfc9700_require_state.rs
+++ b/tests/rfc9700_require_state.rs
@@ -1,0 +1,168 @@
+//! RFC 9700 §4.7 — per-client `require_state` policy flag conformance.
+
+use actix::Actor;
+use actix_session::{storage::CookieSessionStore, Session, SessionMiddleware};
+use actix_web::{cookie::Key, test, web, App, HttpResponse};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use oauth2_actix::actors::TokenActorPool;
+use oauth2_actix::handlers::wellknown::OidcConfig;
+use oauth2_core::{Client, User};
+use oauth2_observability::Metrics;
+
+fn s256(verifier: &str) -> String {
+    use base64::{engine::general_purpose, Engine as _};
+    use sha2::{Digest, Sha256};
+    general_purpose::URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()))
+}
+
+async fn set_session(session: Session) -> HttpResponse {
+    session.insert("user_id", "user_rs").unwrap();
+    session.insert("authenticated", true).unwrap();
+    HttpResponse::Ok().finish()
+}
+
+fn session_cookie(
+    resp: &actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+) -> String {
+    resp.response()
+        .headers()
+        .get(actix_web::http::header::SET_COOKIE)
+        .and_then(|h| h.to_str().ok())
+        .expect("session cookie")
+        .split(';')
+        .next()
+        .unwrap()
+        .to_string()
+}
+
+async fn run_authorize(require_state: bool, send_state: bool) -> u16 {
+    const ISSUER: &str = "https://auth.example.com";
+    const VERIFIER: &str = "verifier-require-state-abcdefghijklmnopqrstuvwxyz12";
+
+    let mut client = Client::new(
+        "client_rs".to_string(),
+        "secret_rs".to_string(),
+        vec!["https://client.example.test/cb".to_string()],
+        vec!["authorization_code".to_string()],
+        "read".to_string(),
+        "RS Client".to_string(),
+    );
+    client.require_state = require_state;
+
+    let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
+        .await
+        .expect("storage");
+    storage.init().await.expect("init");
+    storage.save_client(&client).await.expect("save_client");
+
+    let now = chrono::Utc::now();
+    let user = User {
+        id: "user_rs".to_string(),
+        username: "user_rs".to_string(),
+        password_hash: "unused".to_string(),
+        email: "rs@example.test".to_string(),
+        enabled: true,
+        role: "user".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+    storage.save_user(&user).await.expect("save_user");
+
+    let jwt_secret = "require_state_test_secret_at_least_32_chars".to_string();
+    let metrics = Metrics::new().expect("metrics");
+    let token_actor = oauth2_actix::actors::TokenActor::new(
+        storage.clone(),
+        jwt_secret.clone(),
+        ISSUER.to_string(),
+    )
+    .start();
+    let token_pool = TokenActorPool::new(vec![token_actor]);
+    let client_actor = oauth2_actix::actors::ClientActor::new(storage.clone()).start();
+    let auth_actor = oauth2_actix::actors::AuthActor::new(storage).start();
+    let oidc_config = OidcConfig {
+        issuer: ISSUER.to_string(),
+        jwt_secret: jwt_secret.clone(),
+        id_token_alg: "HS256".to_string(),
+        id_token_kid: None,
+        id_token_private_key_pem: None,
+    };
+    let keyset = Arc::new(RwLock::new(oauth2_core::models::key_set::KeySet::default()));
+
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                Key::generate(),
+            ))
+            .app_data(web::Data::new(token_pool))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(keyset))
+            .app_data(web::Data::new(false))
+            .route("/_set_session", web::get().to(set_session))
+            .service(web::scope("/oauth").route(
+                "/authorize",
+                web::get().to(oauth2_actix::handlers::oauth::authorize),
+            )),
+    )
+    .await;
+
+    let session_resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/_set_session").to_request(),
+    )
+    .await;
+    let cookie = session_cookie(&session_resp);
+
+    let mut uri = format!(
+        "/oauth/authorize?response_type=code&client_id=client_rs\
+         &redirect_uri=https%3A%2F%2Fclient.example.test%2Fcb&scope=read\
+         &code_challenge={}&code_challenge_method=S256",
+        s256(VERIFIER)
+    );
+    if send_state {
+        uri.push_str("&state=xyz");
+    }
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("Cookie", cookie.as_str()))
+            .to_request(),
+    )
+    .await;
+    resp.status().as_u16()
+}
+
+#[actix_web::test]
+async fn require_state_off_accepts_missing_state() {
+    let status = run_authorize(false, false).await;
+    assert_eq!(
+        status, 302,
+        "default client (require_state=false) must accept authorize without state"
+    );
+}
+
+#[actix_web::test]
+async fn require_state_on_rejects_missing_state() {
+    let status = run_authorize(true, false).await;
+    assert_eq!(
+        status, 400,
+        "RFC 9700 §4.7: require_state=true must reject authorize requests missing state"
+    );
+}
+
+#[actix_web::test]
+async fn require_state_on_accepts_present_state() {
+    let status = run_authorize(true, true).await;
+    assert_eq!(
+        status, 302,
+        "require_state=true must accept authorize when state is present"
+    );
+}


### PR DESCRIPTION
## Summary

Adds an opt-in client metadata flag \`require_state\` that, when enabled, makes \`state\` mandatory on authorization requests for that client. Pure defense-in-depth alongside PKCE — for clients that bind their user-agent session to \`state\` and verify the echoed value on the redirect. Default \`false\`; existing clients unaffected.

## Migration

V19:
\`\`\`sql
ALTER TABLE clients ADD COLUMN require_state BOOLEAN NOT NULL DEFAULT FALSE;
\`\`\`
Applied to SQLite + Postgres via the migrations dir + k8s ConfigMap. Mongo persists the full struct.

## Enforcement

In \`handlers/oauth.rs::authorize\`, after \`GetClient\` and before JAR overlay:

\`\`\`rust
if client.require_state && query.state.is_none() {
    return Err(OAuth2Error::invalid_request(
        "state parameter is required for this client (RFC 9700 §4.7)",
    ));
}
\`\`\`

Checked on the outer request (not post-JAR-overlay) so a \`require_state\` client must carry \`state\` on both the outer URL and the JAR payload.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features --locked -- -D warnings\` clean
- [x] \`cargo test --all-features --locked\` — full suite green
- [x] \`tests/rfc9700_require_state.rs\` — 3 tests:
  1. flag off + no state → 302 (backwards compat)
  2. flag on + no state → 400 invalid_request
  3. flag on + state present → 302

## Files touched

| File | Change |
|---|---|
| \`migrations/sql/V19__add_require_state_to_clients.sql\` | New |
| \`k8s/base/configmap-migrations.yaml\` | V19 entry |
| \`crates/oauth2-core/src/models/client.rs\` | \`require_state: bool\` field + init |
| \`crates/oauth2-storage-sqlx/src/sqlx.rs\` | CREATE TABLE + INSERT updated |
| \`crates/oauth2-actix/src/handlers/oauth.rs\` | \`authorize\` enforcement |
| \`tests/rfc9700_require_state.rs\` | New — 3 conformance tests |

## Scope / non-goals

- RFC 7591 dynamic-registration surface for \`require_state\` not wired in this PR. Admin path can set it via direct DB / admin UI; dynamic-registration clients are stuck with default \`false\` until a follow-up extends the registration schema.
- Admin UI toggle not added — operator opts in via SQL UPDATE or admin API today.

## References

- RFC 9700 §4.7 — CSRF defense-in-depth
- \`docs/oauth2-spec-audit.md\` §9.2 item 6.6

Has a migration. Rolls out behind V19; existing clients continue working (\`require_state = FALSE\` default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)