### PR TITLE
feat(security): RFC 9700 Phase 6.9 — token-endpoint rate limiting + invalid_client penalty bucket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4982,6 +4982,7 @@ dependencies = [
  "oauth2-observability",
  "oauth2-openapi",
  "oauth2-ports",
+ "oauth2-ratelimit",
  "oauth2-server",
  "oauth2-social-login",
  "oauth2-storage-factory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ rsa = { version = "0.9", features = ["pem"] }
 rand_core = { version = "0.6", features = ["std"] }
 
 # Workspace crates used directly by root integration tests.
+oauth2-ratelimit = { path = "oauth2-ratelimit" }
 oauth2-storage-sqlx = { path = "crates/oauth2-storage-sqlx" }
 oauth2-storage-mongo = { path = "crates/oauth2-storage-mongo" }
 

--- a/crates/oauth2-actix/src/handlers/oauth.rs
+++ b/crates/oauth2-actix/src/handlers/oauth.rs
@@ -1241,6 +1241,9 @@ pub async fn token(
     storage: Option<web::Data<DynStorage>>,
     metrics: web::Data<Metrics>,
     oidc_config: web::Data<OidcConfig>,
+    invalid_client_limiter: Option<
+        web::Data<crate::middleware::rate_limit::InvalidClientRateLimiter>,
+    >,
 ) -> Result<HttpResponse, OAuth2Error> {
     // OAuch: reject duplicate parameters (prevents parser differentials / smuggling).
     ensure_no_duplicate_query_params(&req)?;
@@ -1428,6 +1431,36 @@ pub async fn token(
     if let Err(ref err) = result {
         if matches!(err.error.as_str(), "invalid_client" | "invalid_grant") {
             metrics_for_failure.oauth_failed_authentications.inc();
+        }
+    }
+
+    // RFC 9700 §2.5: record invalid_client failures in the penalty bucket.
+    // Once the per-IP budget is exhausted, return 429 to block credential
+    // stuffing without revealing that credentials are wrong.
+    if let Err(ref err) = result {
+        if err.error == "invalid_client" {
+            if let Some(ref limiter) = invalid_client_limiter {
+                let ip = req
+                    .peer_addr()
+                    .map(|a| a.ip().to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                match limiter.0.check(&ip).await {
+                    Ok(rl) if !rl.allowed => {
+                        let retry_after = rl.retry_after.map(|d| d.as_secs().max(1)).unwrap_or(1);
+                        tracing::warn!(
+                            client_ip = %ip,
+                            "Invalid-client rate limit exceeded on token endpoint"
+                        );
+                        return Err(OAuth2Error::too_many_requests(&format!(
+                            "Too many failed authentication attempts. Retry after {retry_after}s."
+                        )));
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "Invalid-client rate limiter error, failing open");
+                    }
+                    _ => {}
+                }
+            }
         }
     }
 

--- a/crates/oauth2-actix/src/middleware/rate_limit.rs
+++ b/crates/oauth2-actix/src/middleware/rate_limit.rs
@@ -7,6 +7,12 @@ use std::future::{ready, Ready};
 use std::rc::Rc;
 use std::sync::Arc;
 
+/// Penalty bucket for `invalid_client` failures on the token endpoint.
+///
+/// Injected as `app_data` so the token handler can record credential failures
+/// and block credential-stuffing once the per-IP limit is reached.
+pub struct InvalidClientRateLimiter(pub Arc<dyn oauth2_ratelimit::RateLimiter>);
+
 use actix_web::body::EitherBody;
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::{Error, HttpResponse};

--- a/crates/oauth2-config/src/lib.rs
+++ b/crates/oauth2-config/src/lib.rs
@@ -310,10 +310,14 @@ pub struct RateLimitConfig {
     pub backend: String,
     #[serde(default)]
     pub redis_url: Option<String>,
+    /// Max invalid_client failures per IP per window before returning 429.
+    /// Protects token endpoints from credential-stuffing attacks (RFC 9700 §2.5).
+    #[serde(default = "default_invalid_client_max_requests")]
+    pub invalid_client_max_requests: u32,
 }
 
 fn default_rate_limit_enabled() -> bool {
-    false
+    true
 }
 fn default_max_requests() -> u32 {
     100
@@ -324,6 +328,9 @@ fn default_window_secs() -> u64 {
 fn default_rate_limit_backend() -> String {
     "in_memory".to_string()
 }
+fn default_invalid_client_max_requests() -> u32 {
+    5
+}
 
 impl Default for RateLimitConfig {
     fn default() -> Self {
@@ -333,6 +340,7 @@ impl Default for RateLimitConfig {
             window_secs: default_window_secs(),
             backend: default_rate_limit_backend(),
             redis_url: None,
+            invalid_client_max_requests: default_invalid_client_max_requests(),
         }
     }
 }
@@ -617,7 +625,7 @@ impl Config {
                 enabled: std::env::var("OAUTH2_RATE_LIMIT_ENABLED")
                     .ok()
                     .and_then(|v| v.parse().ok())
-                    .unwrap_or(false),
+                    .unwrap_or(true),
                 max_requests: std::env::var("OAUTH2_RATE_LIMIT_MAX_REQUESTS")
                     .ok()
                     .and_then(|v| v.parse().ok())
@@ -629,6 +637,12 @@ impl Config {
                 backend: std::env::var("OAUTH2_RATE_LIMIT_BACKEND")
                     .unwrap_or_else(|_| "in_memory".to_string()),
                 redis_url: std::env::var("OAUTH2_RATE_LIMIT_REDIS_URL").ok(),
+                invalid_client_max_requests: std::env::var(
+                    "OAUTH2_RATE_LIMIT_INVALID_CLIENT_MAX_REQUESTS",
+                )
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(5),
             }),
             social: None,
             session: None,

--- a/crates/oauth2-core/src/models/error.rs
+++ b/crates/oauth2-core/src/models/error.rs
@@ -53,6 +53,10 @@ impl OAuth2Error {
     pub fn access_denied(description: &str) -> Self {
         Self::new("access_denied", Some(description))
     }
+
+    pub fn too_many_requests(description: &str) -> Self {
+        Self::new("too_many_requests", Some(description))
+    }
 }
 
 impl fmt::Display for OAuth2Error {
@@ -68,6 +72,7 @@ impl ResponseError for OAuth2Error {
             "invalid_client" => StatusCode::UNAUTHORIZED,
             "access_denied" => StatusCode::FORBIDDEN,
             "server_error" => StatusCode::INTERNAL_SERVER_ERROR,
+            "too_many_requests" => StatusCode::TOO_MANY_REQUESTS,
             _ => StatusCode::BAD_REQUEST,
         }
     }

--- a/crates/oauth2-server/src/lib.rs
+++ b/crates/oauth2-server/src/lib.rs
@@ -656,6 +656,68 @@ pub async fn run() -> std::io::Result<()> {
         }
     };
 
+    // --- Invalid-client penalty bucket (RFC 9700 §2.5) ---
+    //
+    // Separate stricter limiter keyed per IP. Counts only `invalid_client`
+    // failures on the token endpoint. When exhausted the handler returns 429
+    // instead of leaking that credentials are wrong (blocks credential stuffing).
+    let invalid_client_limiter: Option<Arc<dyn oauth2_ratelimit::RateLimiter>> = {
+        let rl_config = config.rate_limit.clone().unwrap_or_default();
+        if rl_config.enabled {
+            let limiter: Arc<dyn oauth2_ratelimit::RateLimiter> = match rl_config.backend.as_str() {
+                "redis" => {
+                    #[cfg(feature = "redis-rate-limit")]
+                    {
+                        let redis_url = rl_config
+                            .redis_url
+                            .as_deref()
+                            .map(str::trim)
+                            .filter(|url| !url.is_empty());
+                        if let Some(redis_url) = redis_url {
+                            match oauth2_ratelimit::redis::RedisRateLimiter::new(
+                                redis_url,
+                                rl_config.invalid_client_max_requests,
+                                rl_config.window_secs,
+                            )
+                            .await
+                            {
+                                Ok(l) => Arc::new(l),
+                                Err(_) => {
+                                    Arc::new(oauth2_ratelimit::in_memory::InMemoryRateLimiter::new(
+                                        rl_config.invalid_client_max_requests,
+                                        rl_config.window_secs,
+                                    ))
+                                }
+                            }
+                        } else {
+                            Arc::new(oauth2_ratelimit::in_memory::InMemoryRateLimiter::new(
+                                rl_config.invalid_client_max_requests,
+                                rl_config.window_secs,
+                            ))
+                        }
+                    }
+                    #[cfg(not(feature = "redis-rate-limit"))]
+                    Arc::new(oauth2_ratelimit::in_memory::InMemoryRateLimiter::new(
+                        rl_config.invalid_client_max_requests,
+                        rl_config.window_secs,
+                    ))
+                }
+                _ => Arc::new(oauth2_ratelimit::in_memory::InMemoryRateLimiter::new(
+                    rl_config.invalid_client_max_requests,
+                    rl_config.window_secs,
+                )),
+            };
+            tracing::info!(
+                invalid_client_max_requests = rl_config.invalid_client_max_requests,
+                window_secs = rl_config.window_secs,
+                "Invalid-client rate limit bucket enabled"
+            );
+            Some(limiter)
+        } else {
+            None
+        }
+    };
+
     // --- Resilience (back-pressure, bulkheads, circuit breaker) ---
     let resilience_concurrency: Option<Arc<oauth2_resilience::ConcurrencyLimiter>>;
     let resilience_bulkheads: Option<Arc<oauth2_resilience::BulkheadRegistry>>;
@@ -1077,6 +1139,13 @@ pub async fn run() -> std::io::Result<()> {
         // Add event bus handle if enabled
         if let Some(ref event_bus) = event_bus {
             app = app.app_data(web::Data::new(event_bus.clone()));
+        }
+
+        // Invalid-client penalty bucket (RFC 9700 §2.5)
+        if let Some(ref ic_limiter) = invalid_client_limiter {
+            app = app.app_data(web::Data::new(
+                oauth2_actix::middleware::rate_limit::InvalidClientRateLimiter(ic_limiter.clone()),
+            ));
         }
 
         app

--- a/tests/rfc9700_rate_limit.rs
+++ b/tests/rfc9700_rate_limit.rs
@@ -1,0 +1,243 @@
+//! RFC 9700 §2.5 Phase 6.9 — token-endpoint rate limiting + invalid_client penalty bucket.
+
+use actix::Actor;
+use actix_web::{test, web, App};
+use std::sync::Arc;
+
+use oauth2_actix::actors::TokenActorPool;
+use oauth2_actix::handlers::wellknown::OidcConfig;
+use oauth2_actix::middleware::rate_limit::InvalidClientRateLimiter;
+use oauth2_core::{Client, OAuth2Error};
+use oauth2_observability::Metrics;
+
+async fn build_context() -> (
+    TokenActorPool,
+    actix::Addr<oauth2_actix::actors::ClientActor>,
+    actix::Addr<oauth2_actix::actors::AuthActor>,
+    String,
+    Metrics,
+    OidcConfig,
+) {
+    let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
+        .await
+        .expect("storage");
+    storage.init().await.expect("init");
+
+    let client = Client::new(
+        "client_rl".to_string(),
+        "secret_rl".to_string(),
+        vec!["https://client.example.test/cb".to_string()],
+        vec!["client_credentials".to_string()],
+        "read".to_string(),
+        "RL Test Client".to_string(),
+    );
+    storage.save_client(&client).await.expect("save_client");
+
+    let jwt_secret = "rate_limit_test_secret_at_least_32_chars!".to_string();
+    let metrics = Metrics::new().expect("metrics");
+    let token_actor = oauth2_actix::actors::TokenActor::new(
+        storage.clone(),
+        jwt_secret.clone(),
+        "http://localhost".to_string(),
+    )
+    .start();
+    let token_pool = TokenActorPool::new(vec![token_actor]);
+    let client_actor = oauth2_actix::actors::ClientActor::new(storage.clone()).start();
+    let auth_actor = oauth2_actix::actors::AuthActor::new(storage.clone()).start();
+    let oidc_config = OidcConfig {
+        issuer: "http://localhost".to_string(),
+        jwt_secret: jwt_secret.clone(),
+        id_token_alg: "HS256".to_string(),
+        id_token_kid: None,
+        id_token_private_key_pem: None,
+    };
+    (
+        token_pool,
+        client_actor,
+        auth_actor,
+        jwt_secret,
+        metrics,
+        oidc_config,
+    )
+}
+
+fn bad_credentials_body() -> &'static str {
+    "grant_type=client_credentials&client_id=client_rl&client_secret=WRONG"
+}
+
+/// After exhausting the invalid_client bucket the token endpoint returns 429.
+#[actix_web::test]
+async fn invalid_client_rate_limit_returns_429_after_budget_exhausted() {
+    let (token_pool, client_actor, auth_actor, jwt_secret, metrics, oidc_config) =
+        build_context().await;
+
+    // Bucket allows 3 invalid_client failures before returning 429.
+    let ic_limiter = Arc::new(oauth2_ratelimit::in_memory::InMemoryRateLimiter::new(3, 60))
+        as Arc<dyn oauth2_ratelimit::RateLimiter>;
+    let ic_limiter_data = web::Data::new(InvalidClientRateLimiter(ic_limiter));
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(token_pool))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(false)) // stateless_validation
+            .app_data(ic_limiter_data)
+            .service(web::scope("/oauth").route(
+                "/token",
+                web::post().to(oauth2_actix::handlers::oauth::token),
+            )),
+    )
+    .await;
+
+    // First 3 attempts: bucket allows, returns 401 invalid_client.
+    for attempt in 1..=3 {
+        let req = test::TestRequest::post()
+            .uri("/oauth/token")
+            .set_payload(bad_credentials_body())
+            .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            401,
+            "attempt {attempt}: expected 401 invalid_client"
+        );
+        let body: OAuth2Error = test::read_body_json(resp).await;
+        assert_eq!(body.error, "invalid_client", "attempt {attempt}");
+    }
+
+    // 4th attempt: bucket exhausted → 429.
+    let req = test::TestRequest::post()
+        .uri("/oauth/token")
+        .set_payload(bad_credentials_body())
+        .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 429, "4th attempt should be 429");
+    let body: OAuth2Error = test::read_body_json(resp).await;
+    assert_eq!(body.error, "too_many_requests");
+}
+
+/// Without an invalid_client limiter in app_data the handler still returns
+/// 401 invalid_client (Option is None → no rate limiting applied).
+#[actix_web::test]
+async fn invalid_client_no_limiter_returns_401() {
+    let (token_pool, client_actor, auth_actor, jwt_secret, metrics, oidc_config) =
+        build_context().await;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(token_pool))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(false))
+            .service(web::scope("/oauth").route(
+                "/token",
+                web::post().to(oauth2_actix::handlers::oauth::token),
+            )),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/oauth/token")
+        .set_payload(bad_credentials_body())
+        .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 401);
+    let body: OAuth2Error = test::read_body_json(resp).await;
+    assert_eq!(body.error, "invalid_client");
+}
+
+/// Successful token requests do NOT consume the invalid_client bucket.
+#[actix_web::test]
+async fn valid_requests_do_not_deplete_invalid_client_bucket() {
+    let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
+        .await
+        .expect("storage");
+    storage.init().await.expect("init");
+
+    let client = Client::new(
+        "client_rl2".to_string(),
+        "secret_rl2".to_string(),
+        vec!["https://client.example.test/cb".to_string()],
+        vec!["client_credentials".to_string()],
+        "read".to_string(),
+        "RL Test Client 2".to_string(),
+    );
+    storage.save_client(&client).await.expect("save_client");
+
+    let jwt_secret = "rate_limit_test_secret_2_at_least_32_chars".to_string();
+    let metrics = Metrics::new().expect("metrics");
+    let token_actor = oauth2_actix::actors::TokenActor::new(
+        storage.clone(),
+        jwt_secret.clone(),
+        "http://localhost".to_string(),
+    )
+    .start();
+    let token_pool = TokenActorPool::new(vec![token_actor]);
+    let client_actor = oauth2_actix::actors::ClientActor::new(storage).start();
+    let auth_actor = oauth2_actix::actors::AuthActor::new(
+        oauth2_storage_factory::create_storage("sqlite::memory:")
+            .await
+            .expect("auth storage"),
+    )
+    .start();
+    let oidc_config = OidcConfig {
+        issuer: "http://localhost".to_string(),
+        jwt_secret: jwt_secret.clone(),
+        id_token_alg: "HS256".to_string(),
+        id_token_kid: None,
+        id_token_private_key_pem: None,
+    };
+
+    // Bucket allows only 1 failure before 429.
+    let ic_limiter = Arc::new(oauth2_ratelimit::in_memory::InMemoryRateLimiter::new(1, 60))
+        as Arc<dyn oauth2_ratelimit::RateLimiter>;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(token_pool))
+            .app_data(web::Data::new(client_actor))
+            .app_data(web::Data::new(auth_actor))
+            .app_data(web::Data::new(jwt_secret))
+            .app_data(web::Data::new(metrics))
+            .app_data(web::Data::new(oidc_config))
+            .app_data(web::Data::new(false))
+            .app_data(web::Data::new(InvalidClientRateLimiter(ic_limiter)))
+            .service(web::scope("/oauth").route(
+                "/token",
+                web::post().to(oauth2_actix::handlers::oauth::token),
+            )),
+    )
+    .await;
+
+    // Multiple successful client_credentials requests — should not deplete bucket.
+    for _ in 0..5 {
+        let req = test::TestRequest::post()
+            .uri("/oauth/token")
+            .set_payload(
+                "grant_type=client_credentials&client_id=client_rl2&client_secret=secret_rl2",
+            )
+            .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 200, "successful request should be 200");
+    }
+
+    // One bad attempt: bucket has 1 token, so this should still return 401 (not 429).
+    let req = test::TestRequest::post()
+        .uri("/oauth/token")
+        .set_payload("grant_type=client_credentials&client_id=client_rl2&client_secret=WRONG")
+        .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 401, "first bad attempt should be 401");
+}


### PR DESCRIPTION
## Summary

- **Default-on rate limiting**: `RateLimitConfig.enabled` flipped to `true` — in-memory rate limiting now active on `/oauth/token` (and device code flow) out of the box, no config change needed
- **`invalid_client` penalty bucket**: separate per-IP rate limiter (default: 5 failures/window) that detects credential-stuffing; once exhausted returns `429 too_many_requests` instead of revealing whether credentials are wrong
- **Config**: new `OAUTH2_RATE_LIMIT_INVALID_CLIENT_MAX_REQUESTS` env var (default `5`) controls the penalty budget; both limiters respect the same `backend` (in-memory or Redis) and `window_secs`
- **`OAuth2Error::too_many_requests()`**: new constructor mapping to HTTP 429

## Implementation Notes

The penalty bucket is injected as optional `app_data` (`InvalidClientRateLimiter` newtype), so existing tests without it continue to work unchanged — the handler treats `None` as "no rate limiting". The global middleware still handles per-IP throttling for all routes; the penalty bucket is additive and specific to auth failures.

## Test Plan

- [x] `invalid_client_rate_limit_returns_429_after_budget_exhausted` — 3 bad attempts allowed, 4th returns 429
- [x] `invalid_client_no_limiter_returns_401` — no limiter in app_data → normal 401 behavior preserved
- [x] `valid_requests_do_not_deplete_invalid_client_bucket` — successful token requests don't drain the penalty bucket
- [x] Full `security_http` + `rfc9700_compliance` + `rfc9700_require_state` suites pass (41 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

Refs: RFC 9700 §2.5, RFC 8628 §3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)