### PR TITLE
feat(events): Redis-backed RecentEventsStore for cross-replica admin Events visibility

### DIFF
--- a/crates/oauth2-actix/src/handlers/events.rs
+++ b/crates/oauth2-actix/src/handlers/events.rs
@@ -77,22 +77,48 @@ impl IdempotencyStore {
     }
 }
 
-/// In-memory ring-buffer of recently ingested events (admin visibility, best-effort).
+/// Ring-buffer of recently ingested events (admin visibility, best-effort).
+///
+/// Backed by Redis when the `redis-cache` feature is enabled and a connection
+/// is provided; otherwise falls back to an in-process `VecDeque`.
 #[derive(Clone)]
 pub struct RecentEventsStore {
     capacity: usize,
     inner: Arc<Mutex<VecDeque<serde_json::Value>>>,
+    #[cfg(feature = "redis-cache")]
+    redis: Option<redis::aio::ConnectionManager>,
 }
 
 impl RecentEventsStore {
+    const REDIS_KEY: &'static str = "oauth2:recent_events";
+
     pub fn new(capacity: usize) -> Self {
         Self {
             capacity,
             inner: Arc::new(Mutex::new(VecDeque::with_capacity(capacity))),
+            #[cfg(feature = "redis-cache")]
+            redis: None,
         }
     }
 
+    #[cfg(feature = "redis-cache")]
+    pub fn with_redis(mut self, conn: redis::aio::ConnectionManager) -> Self {
+        self.redis = Some(conn);
+        self
+    }
+
     pub async fn push(&self, value: serde_json::Value) {
+        #[cfg(feature = "redis-cache")]
+        if let Some(mut conn) = self.redis.clone() {
+            use redis::AsyncCommands;
+            if let Ok(json) = serde_json::to_string(&value) {
+                let cap = self.capacity as isize - 1;
+                let _: Result<(), _> = conn.lpush(Self::REDIS_KEY, &json).await;
+                let _: Result<(), _> = conn.ltrim(Self::REDIS_KEY, 0, cap).await;
+                let _: Result<(), _> = conn.expire(Self::REDIS_KEY, 86400).await;
+            }
+            return;
+        }
         let mut guard = self.inner.lock().await;
         if guard.len() >= self.capacity {
             guard.pop_front();
@@ -101,6 +127,18 @@ impl RecentEventsStore {
     }
 
     pub async fn snapshot(&self) -> Vec<serde_json::Value> {
+        #[cfg(feature = "redis-cache")]
+        if let Some(mut conn) = self.redis.clone() {
+            use redis::AsyncCommands;
+            let raw: Vec<String> = conn
+                .lrange(Self::REDIS_KEY, 0, self.capacity as isize - 1)
+                .await
+                .unwrap_or_default();
+            return raw
+                .iter()
+                .filter_map(|s| serde_json::from_str(s).ok())
+                .collect();
+        }
         self.inner.lock().await.iter().rev().cloned().collect()
     }
 }

--- a/crates/oauth2-server/src/lib.rs
+++ b/crates/oauth2-server/src/lib.rs
@@ -397,9 +397,23 @@ pub async fn run() -> std::io::Result<()> {
         Key::generate()
     };
 
+    // Optional Redis L2 cache — must be built before recent_events_store so we can attach it.
+    let cache_redis_manager = build_cache_redis_manager(&config).await;
+
     // Ring-buffer of recent events for the admin dashboard events page.
     // Constructed here so the event bridge plugin can hold a clone.
-    let recent_events_store = oauth2_actix::handlers::events::RecentEventsStore::new(500);
+    // When Redis is available, push/snapshot go through Redis so all replicas share the view.
+    let recent_events_store = {
+        let store = oauth2_actix::handlers::events::RecentEventsStore::new(500);
+        #[cfg(feature = "redis-cache")]
+        let store = if let Some(conn) = cache_redis_manager.clone() {
+            tracing::info!("RecentEventsStore backed by Redis (cross-replica visibility)");
+            store.with_redis(conn)
+        } else {
+            store
+        };
+        store
+    };
 
     // Bridge: forwards every event published through the actor bus into RecentEventsStore
     // so the admin Events page shows OAuth flow events (token issued, revoked, etc.).
@@ -610,9 +624,6 @@ pub async fn run() -> std::io::Result<()> {
         oauth2_actix::handlers::events::IdempotencyStore::new(Duration::from_secs(5 * 60))
             // Explicitly set to default to make it configurable without changing call sites.
             .with_max_entries(100_000);
-
-    // Optional Redis L2 cache shared across all replicas.
-    let cache_redis_manager = build_cache_redis_manager(&config).await;
 
     // --- Rate limiting ---
     let rate_limiter: Option<Arc<dyn oauth2_ratelimit::RateLimiter>> = {


### PR DESCRIPTION
## Summary

- With HPA min=2, each pod had its own in-memory ring-buffer; the admin Events page returned different data depending on which pod answered — and all events were lost on pod restart.
- When `redis-cache` feature is enabled and `OAUTH2_CACHE_REDIS_URL` is set, `RecentEventsStore` now routes `push`/`snapshot` through a Redis list (`LPUSH` + `LTRIM` + `LRANGE`) at key `oauth2:recent_events`. All replicas share one view; events survive restarts.
- Falls back to the in-process `VecDeque` when Redis is unavailable — no behavior change without the feature/env var.

## Changes

- `crates/oauth2-actix/src/handlers/events.rs`: `RecentEventsStore` gains optional `redis::aio::ConnectionManager` backend under `#[cfg(feature = "redis-cache")]`; `with_redis()` builder method
- `crates/oauth2-server/src/lib.rs`: move `cache_redis_manager` construction before `recent_events_store`; attach Redis connection via `store.with_redis(conn)` when available

## Deployment

Rebuild with `CARGO_FEATURES=mongo,distributed` (enables `redis-cache`) and set `OAUTH2_CACHE_REDIS_URL` from the `oauth2-server-redis-urls` secret already created in the cluster.

## Test plan

- [ ] Deploy with `distributed` feature + Redis URL → issue a token on pod A, verify event visible via pod B's admin Events page
- [ ] Without Redis URL → falls back to in-memory, no crash
- [ ] `cargo build -p oauth2-server --all-features` clean
- [ ] `cargo clippy --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)