### PR TITLE
fix(admin): correct Events table field paths for EventEnvelope structure

### DIFF
--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -1103,12 +1103,12 @@
                 <template x-if="!loading && (error || items.length === 0)">
                   <tr><td colspan="4" class="table-cell py-10 text-center text-slate-400" x-text="error || 'No events recorded yet'"></td></tr>
                 </template>
-                <template x-for="item in items" :key="item.id || item.idempotency_key">
+                <template x-for="item in items" :key="(item.event && item.event.id) || item.correlation_id">
                   <tr class="table-row">
-                    <td class="table-cell"><span class="badge badge-blue" x-text="item.event_type || item.type || '—'"></span></td>
-                    <td class="table-cell text-slate-500" x-text="item.source || '—'"></td>
-                    <td class="table-cell"><code class="text-xs" x-text="(item.idempotency_key || '—').slice(0, 16) + '…'"></code></td>
-                    <td class="table-cell text-slate-500 whitespace-nowrap" x-text="relativeTime(item.received_at || item.created_at)"></td>
+                    <td class="table-cell"><span class="badge badge-blue" x-text="(item.event && item.event.event_type) || item.event_type || '—'"></span></td>
+                    <td class="table-cell text-slate-500" x-text="item.producer || item.source || '—'"></td>
+                    <td class="table-cell"><code class="text-xs" x-text="(item.idempotency_key || (item.event && item.event.id) || '—').slice(0, 16) + '…'"></code></td>
+                    <td class="table-cell text-slate-500 whitespace-nowrap" x-text="relativeTime(item.produced_at || item.received_at || item.created_at)"></td>
                   </tr>
                 </template>
               </tbody>


### PR DESCRIPTION
## Summary

The Events table in the admin dashboard was rendering 0 rows despite having 9 events in Redis. Two bugs:

1. **Wrong field paths**: template read `item.event_type`, `item.source`, `item.received_at` — these don't exist at the top level of `EventEnvelope`. Correct paths are `item.event.event_type`, `item.producer`, `item.produced_at`.
2. **Broken `x-for` key**: `:key="item.id || item.idempotency_key"` — `item.id` doesn't exist at top level; `item.idempotency_key` is optional. When all items have `undefined` key, Alpine may deduplicate or skip rendering. Fixed to use `item.event.id || item.correlation_id`.

Flat-field fallbacks preserved for forward compatibility with externally-ingested events that may use a flatter schema.

## Test plan

- [ ] Deploy and open admin Events page — rows should appear with event type, producer, and timestamp
- [ ] MCP token issue + revoke → events visible in table within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)