### PR TITLE
feat(flux): GitOps + image automation for bigboy AKS

### DIFF
--- a/docs/flux.md
+++ b/docs/flux.md
@@ -104,19 +104,71 @@ After a release completes:
 This keeps prod rollouts as reviewable PRs with full history, at the
 cost of one extra PR per release.
 
-## 5. Optional: image automation
+## 5. Image automation (enabled)
 
-Flux's `ImageRepository` / `ImagePolicy` / `ImageUpdateAutomation` CRs can
-automate step 4 by watching the registry for new semver tags and opening
-commits that bump the overlay automatically. Enabling that requires:
+Flux's `ImageRepository` / `ImagePolicy` / `ImageUpdateAutomation` CRs
+automate step 4 by watching Docker Hub for new semver tags and committing
+overlay tag bumps directly to `main`. The CRs live in
+`k8s/flux/clusters/bigboy/image-automation.yaml` and are reconciled by the
+same root kustomization as `oauth2-server.yaml`.
 
-- A Kubernetes `Secret` with a Git write token (PAT) mounted into
-  `image-automation-controller`.
-- A branch protection exception or a separate `flux-image-updates`
-  branch with auto-merge.
+Moving pieces:
 
-This repo does not enable image automation yet. Start with the manual
-PR flow in §4 and opt in later if the cadence justifies the moving parts.
+- **`GitRepository/oauth2-server-write`** — a second `GitRepository` in
+  `flux-system` that carries HTTPS credentials so the
+  `image-automation-controller` can push commits. The Azure-managed
+  `GitRepository` (provisioned by the `FluxConfig`) is read-only and
+  cannot be reused for writes.
+- **`ImageRepository/oauth2-server`** — polls `docker.io/ianlintner068/oauth2-server`
+  every 5m.
+- **`ImagePolicy/oauth2-server`** — selects the highest semver tag matching
+  `^[0-9]+\.[0-9]+\.[0-9]+$`. Pre-release variants (`-mongo`, `-mongo-only`,
+  `sha-*`) are filtered out so they never get promoted to production.
+- **`ImageUpdateAutomation/oauth2-server`** — scans
+  `k8s/overlays/production/kustomization.yaml` for the Setters marker
+  `# {"$imagepolicy": "flux-system:oauth2-server:tag"}` and commits
+  `chore(flux): bump oauth2-server image to <tag>` to `main` when the
+  policy picks a newer version.
+
+### 5.1 One-time Secret provisioning
+
+The write path needs a Git PAT. Create it out-of-band — the Secret is
+intentionally not committed to this repo:
+
+```bash
+kubectl -n flux-system create secret generic oauth2-server-git-auth \
+  --from-literal=username=x-access-token \
+  --from-literal=password="$GITHUB_TOKEN"
+```
+
+`GITHUB_TOKEN` must be a classic or fine-grained PAT with `repo` (or
+`contents: write`) scope on `ianlintner/rust-oauth2-server`. Rotate by
+replacing the Secret; no controller restart required.
+
+### 5.2 Branch protection
+
+Because the automation pushes directly to `main`, `main` must either:
+
+- allow the PAT identity (`x-access-token`) to bypass branch protection, or
+- have no protection rule requiring PR review.
+
+If you want PR review on automated bumps, change `push.branch` in the
+`ImageUpdateAutomation` CR to a dedicated branch (e.g. `flux-image-updates`)
+and add a GitHub auto-merge workflow.
+
+### 5.3 Opting a new overlay into automation
+
+Add the Setters marker next to the `newTag` line in the overlay's
+`kustomization.yaml`:
+
+```yaml
+images:
+  - name: docker.io/ianlintner068/oauth2-server
+    newTag: 0.7.0 # {"$imagepolicy": "flux-system:oauth2-server:tag"}
+```
+
+The `production-distributed` overlay is not wired yet; add the marker
+there if/when that variant starts tracking releases in lockstep.
 
 ## 6. Rollback
 

--- a/docs/flux.md
+++ b/docs/flux.md
@@ -1,0 +1,139 @@
+# GitOps with Flux on the `bigboy` AKS Cluster
+
+This runbook covers the GitOps path for deploying `rust_oauth2_server` to the
+production AKS cluster (`bigboy`, resource group `nekoc`, location `centralus`).
+It replaces the historical "apply with raw `kubectl`" flow documented in
+`docs/observability.md` §9.
+
+Flux on `bigboy` is installed as the **Azure-managed** extension
+(`microsoft.flux`) — configurations are provisioned through the Azure CLI
+(`az k8s-configuration flux create`) rather than by applying FluxCD CRs
+directly with `kubectl`. The extension still runs the standard upstream
+`source-controller`, `kustomize-controller`, and `notification-controller`,
+plus `image-reflector-controller` and `image-automation-controller` for
+image automation when we opt in.
+
+## 1. Repository layout
+
+```
+k8s/
+├── base/                              # vendor-neutral base manifests
+├── overlays/
+│   ├── production/                    # production overlay (Flux reconciles this)
+│   └── production-distributed/        # distributed variant (Redis cache + rate-limit)
+└── flux/
+    └── clusters/
+        └── bigboy/
+            ├── kustomization.yaml     # root kustomize, resources: [oauth2-server.yaml]
+            └── oauth2-server.yaml     # Flux Kustomization CR pointing at overlays/production
+```
+
+The Azure `FluxConfig` reconciles `k8s/flux/clusters/bigboy/` on every sync.
+The `Kustomization` CR it finds there points Flux at
+`k8s/overlays/production`, which is what actually renders into the cluster.
+
+## 2. One-time provisioning
+
+Run this from a workstation with `az login` already done and the AKS
+`bigboy` context kubeconfig on hand. The command creates (or upserts) a
+`FluxConfig` in the `flux-system` namespace.
+
+```bash
+az k8s-configuration flux create \
+  --resource-group nekoc \
+  --cluster-name bigboy \
+  --cluster-type managedClusters \
+  --name oauth2-server \
+  --namespace flux-system \
+  --scope cluster \
+  --source-kind git \
+  --url https://github.com/ianlintner/rust-oauth2-server.git \
+  --branch main \
+  --interval 1m \
+  --kustomization \
+      name=oauth2-server \
+      path=k8s/flux/clusters/bigboy \
+      prune=true \
+      sync_interval=1m \
+      retry_interval=5m \
+      timeout=10m
+```
+
+Notes:
+
+- The `FluxConfig` `name` (`oauth2-server`) becomes the name of the
+  generated `GitRepository` in `flux-system`. The inner `Kustomization`
+  CR at `k8s/flux/clusters/bigboy/oauth2-server.yaml` references that
+  name via `spec.sourceRef.name: oauth2-server` — keep the two in sync.
+- `scope=cluster` gives Flux permission to create resources outside
+  `flux-system`. The overlay targets `namespace: default`.
+- For a private repo, add `--https-user <user> --https-key <PAT>`.
+  Public repos (like this one today) need no credentials.
+
+## 3. Verifying the initial sync
+
+```bash
+kubectl -n flux-system get fluxconfig oauth2-server -o yaml
+kubectl -n flux-system get gitrepository,kustomization | grep oauth2-server
+kubectl -n default rollout status deploy/oauth2-server --timeout=5m
+```
+
+Expected: the `FluxConfig` reports `complianceState: Compliant`, the
+`Kustomization` shows `READY=True`, and the deployment rolls out the image
+tag pinned in `k8s/overlays/production/kustomization.yaml`.
+
+## 4. Release workflow + image tag bumps
+
+The release workflow (`.github/workflows/release.yml`) bumps
+`Cargo.toml` / `Cargo.lock`, tags `vX.Y.Z`, and publishes multi-arch
+images to GHCR and Docker Hub. It does **not** edit the Kubernetes
+overlays — that is a separate step so a release is never tangled up with
+a production rollout.
+
+After a release completes:
+
+1. Open a PR that updates
+   `k8s/overlays/production/kustomization.yaml` (and the distributed
+   variant, if applicable) to pin `images[].newTag` to the new version.
+2. Optionally bump `IMAGE_SHA` in
+   `k8s/overlays/production/observability-patch.yaml` to the matching
+   commit SHA so `service.version` in traces lines up with the build.
+3. Merge. Flux reconciles within one sync interval (`1m` above) and
+   rolls the deployment.
+
+This keeps prod rollouts as reviewable PRs with full history, at the
+cost of one extra PR per release.
+
+## 5. Optional: image automation
+
+Flux's `ImageRepository` / `ImagePolicy` / `ImageUpdateAutomation` CRs can
+automate step 4 by watching the registry for new semver tags and opening
+commits that bump the overlay automatically. Enabling that requires:
+
+- A Kubernetes `Secret` with a Git write token (PAT) mounted into
+  `image-automation-controller`.
+- A branch protection exception or a separate `flux-image-updates`
+  branch with auto-merge.
+
+This repo does not enable image automation yet. Start with the manual
+PR flow in §4 and opt in later if the cadence justifies the moving parts.
+
+## 6. Rollback
+
+Because the overlay is a Git artifact, rollback is a `git revert` of the
+PR that bumped the tag. Flux reconciles the revert the same way it
+reconciled the bump.
+
+For emergency rollback when you cannot wait for a PR, suspend the
+`FluxConfig` with:
+
+```bash
+az k8s-configuration flux update \
+  --resource-group nekoc --cluster-name bigboy \
+  --cluster-type managedClusters --name oauth2-server \
+  --suspend true
+```
+
+then apply a `kubectl rollout undo deploy/oauth2-server` directly. Resume
+Flux (`--suspend false`) once the repo matches the intended state again,
+otherwise the next reconcile will re-apply the broken version.

--- a/k8s/flux/clusters/bigboy/image-automation.yaml
+++ b/k8s/flux/clusters/bigboy/image-automation.yaml
@@ -1,0 +1,93 @@
+# Flux image automation for oauth2-server.
+#
+# Watches Docker Hub for new semver tags, writes the winning tag back
+# into `k8s/overlays/production/kustomization.yaml` as a commit to `main`,
+# and lets the `oauth2-server` Flux Kustomization reconcile the new tag.
+#
+# The Azure-managed FluxConfig provisions a read-only `GitRepository`
+# (`oauth2-server`) for the kustomize pipeline. Image automation needs
+# write access, so this file declares a second `GitRepository`
+# (`oauth2-server-write`) that carries HTTPS credentials from the
+# `oauth2-server-git-auth` Secret.
+#
+# The `oauth2-server-git-auth` Secret is created out-of-band with:
+#
+#   kubectl -n flux-system create secret generic oauth2-server-git-auth \
+#     --from-literal=username=x-access-token \
+#     --from-literal=password="$GITHUB_TOKEN"
+#
+# The Secret is intentionally NOT committed to this repo. See
+# `docs/flux.md` §5 for the full provisioning walk-through.
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: oauth2-server-write
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: https://github.com/ianlintner/rust-oauth2-server.git
+  ref:
+    branch: main
+  secretRef:
+    name: oauth2-server-git-auth
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: oauth2-server
+  namespace: flux-system
+spec:
+  image: docker.io/ianlintner068/oauth2-server
+  interval: 5m
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: oauth2-server
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: oauth2-server
+  policy:
+    semver:
+      # Match stable semver releases. Pre-release variants (`-mongo`,
+      # `-mongo-only`, `sha-*`) are excluded by the `filterTags` regex
+      # below so they never get promoted to production.
+      range: ">=0.7.0"
+  filterTags:
+    pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: oauth2-server
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: oauth2-server-write
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: flux@ianlintner.dev
+        name: flux-image-automation
+      messageTemplate: |
+        chore(flux): bump oauth2-server image to {{range .Updated.Images}}{{.}}{{end}}
+
+        Automated tag bump from Flux ImageUpdateAutomation. The underlying
+        release was already cut from `main`; this commit only moves the
+        production overlay forward so the cluster picks up the new image.
+    push:
+      branch: main
+  update:
+    path: ./k8s/overlays/production
+    strategy: Setters

--- a/k8s/flux/clusters/bigboy/kustomization.yaml
+++ b/k8s/flux/clusters/bigboy/kustomization.yaml
@@ -1,0 +1,12 @@
+# Root kustomization for the `bigboy` AKS cluster.
+#
+# This path is referenced by an Azure-managed Flux `FluxConfig` (the
+# `microsoft.flux` extension). The FluxConfig generates a `GitRepository`
+# named after the Flux config, and this kustomization is the entry point
+# it reconciles. See `docs/flux.md` for the canonical `az` command that
+# provisions the FluxConfig.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - oauth2-server.yaml

--- a/k8s/flux/clusters/bigboy/kustomization.yaml
+++ b/k8s/flux/clusters/bigboy/kustomization.yaml
@@ -10,3 +10,4 @@ kind: Kustomization
 
 resources:
   - oauth2-server.yaml
+  - image-automation.yaml

--- a/k8s/flux/clusters/bigboy/oauth2-server.yaml
+++ b/k8s/flux/clusters/bigboy/oauth2-server.yaml
@@ -1,0 +1,29 @@
+# Flux Kustomization for the oauth2-server production overlay.
+#
+# `sourceRef.name` matches the Azure FluxConfig name — the `microsoft.flux`
+# extension creates a `GitRepository` in `flux-system` with that name when
+# the FluxConfig is provisioned.
+#
+# The reconciled path (`k8s/overlays/production`) renders the base manifests
+# with the observability patch applied, and pins the image tag. Bump the
+# `newTag` in `k8s/overlays/production/kustomization.yaml` on each release.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: oauth2-server
+  namespace: flux-system
+spec:
+  interval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: oauth2-server
+  path: ./k8s/overlays/production
+  prune: true
+  wait: true
+  targetNamespace: default
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: oauth2-server
+      namespace: default

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -12,4 +12,4 @@ patchesStrategicMerge:
 
 images:
   - name: docker.io/ianlintner068/oauth2-server
-    newTag: v1.0.0
+    newTag: 0.7.0 # {"$imagepolicy": "flux-system:oauth2-server:tag"}


### PR DESCRIPTION
## Summary

- Wires up Flux (Azure-managed `microsoft.flux` extension) to reconcile `k8s/overlays/production` on the `bigboy` AKS cluster.
- Enables Flux image automation so new semver tags on Docker Hub (`ianlintner068/oauth2-server`) roll forward into the overlay without a human PR.
- Pins the production overlay to `0.7.0` (first release shipping OTEL Wave 1) and replaces the stale `v1.0.0` placeholder.
- Adds `docs/flux.md` as the runbook for provisioning, verification, release cadence, image automation, and rollback.

## What's in the PR

### GitOps reconciliation

- `k8s/flux/clusters/bigboy/kustomization.yaml` — root kustomization, entry point for the Azure `FluxConfig`.
- `k8s/flux/clusters/bigboy/oauth2-server.yaml` — Flux `Kustomization` CR pointing at `k8s/overlays/production` with `prune=true`, `wait=true`, a Deployment health check, and `targetNamespace: default`.

### Image automation

- `k8s/flux/clusters/bigboy/image-automation.yaml` adds four CRs:
  - `GitRepository/oauth2-server-write` — a second, write-capable source referencing the out-of-band `oauth2-server-git-auth` Secret (the Azure-managed read-only GitRepository cannot be reused for writes).
  - `ImageRepository/oauth2-server` — polls `docker.io/ianlintner068/oauth2-server` every 5m.
  - `ImagePolicy/oauth2-server` — selects the highest semver matching `^[0-9]+\.[0-9]+\.[0-9]+$`; filters out `-mongo`, `-mongo-only`, and `sha-*` variants so they never get promoted to production.
  - `ImageUpdateAutomation/oauth2-server` — commits overlay bumps to `main` with the `flux-image-automation <flux@ianlintner.dev>` identity.
- `k8s/overlays/production/kustomization.yaml` now carries the Setters marker `# {"$imagepolicy": "flux-system:oauth2-server:tag"}` next to the `newTag` line so automation commits land in the right place.

### Runbook

- `docs/flux.md` covers layout, the canonical `az k8s-configuration flux create` command, verification, release workflow, image automation (incl. Secret provisioning and branch-protection tradeoffs), and rollback paths.

## Out-of-band provisioning

The `oauth2-server-git-auth` Secret is not committed — it was created directly in the cluster:

```bash
kubectl -n flux-system create secret generic oauth2-server-git-auth \
  --from-literal=username=x-access-token \
  --from-literal=password="$GITHUB_TOKEN"
```

The PAT needs `repo` (or fine-grained `contents: write`) scope on this repository.

## Activation steps (after merge)

1. From an operator workstation with `az login` done and the `bigboy` kubeconfig loaded, run the `az k8s-configuration flux create` command from `docs/flux.md` §2. This provisions the `FluxConfig` that drives reconciliation.
2. Verify initial sync per `docs/flux.md` §3 (`kubectl -n flux-system get fluxconfig,gitrepository,kustomization`).
3. Once Flux is green, the image-automation controller will reconcile the overlay against the policy. Since the overlay is already pinned to `0.7.0` (the latest published semver), no bump commit is expected until the next release.

## Risks / callouts

- The automation pushes directly to `main`. If branch protection starts requiring PR review, switch `push.branch` on `ImageUpdateAutomation` to a dedicated branch (e.g., `flux-image-updates`) with auto-merge — covered in `docs/flux.md` §5.2.
- The `production-distributed` overlay is intentionally not wired into image automation; opt it in later with the Setters marker if that variant starts tracking releases in lockstep.

## Test plan

- [ ] Operator runs `az k8s-configuration flux create ...` from `docs/flux.md` §2.
- [ ] `kubectl -n flux-system get fluxconfig oauth2-server -o yaml` reports `complianceState: Compliant`.
- [ ] `kubectl -n flux-system get gitrepository,kustomization,imagerepository,imagepolicy,imageupdateautomation | grep oauth2-server` — all READY.
- [ ] `kubectl -n default rollout status deploy/oauth2-server --timeout=5m` succeeds on the `0.7.0` image.
- [ ] Cut a hotfix `0.7.1` (or similar) and confirm an automated `chore(flux): bump oauth2-server image to 0.7.1` commit lands on `main` within ~5m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)