### PR TITLE
fix(observability): app_info version reads workspace root

### DIFF
--- a/crates/oauth2-observability/build.rs
+++ b/crates/oauth2-observability/build.rs
@@ -1,0 +1,69 @@
+// Emits `APP_INFO_VERSION` = the workspace root crate's `[package].version`.
+//
+// The `app_info` Prometheus gauge and the OpenTelemetry `service.version`
+// resource attribute must reflect the *application* version, not the
+// `oauth2-observability` library crate's version. Workspace members are
+// released together but carry their own `version` field in each crate
+// manifest, which drifts because the release workflow only bumps the root
+// `Cargo.toml` — leaving observability's `env!("CARGO_PKG_VERSION")` stale.
+//
+// Reading the workspace root at build time and exposing it as a custom
+// `rustc-env` var keeps the single source of truth (root `[package].version`)
+// without widening the release script's scope.
+
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR is always set for build scripts");
+    let workspace_root: PathBuf = PathBuf::from(&manifest_dir)
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("workspace root resolvable from oauth2-observability crate");
+    let root_cargo_toml = workspace_root.join("Cargo.toml");
+
+    println!("cargo:rerun-if-changed={}", root_cargo_toml.display());
+
+    let text = std::fs::read_to_string(&root_cargo_toml)
+        .unwrap_or_else(|e| panic!("read {}: {e}", root_cargo_toml.display()));
+
+    let version = parse_root_package_version(&text).unwrap_or_else(|| {
+        panic!(
+            "workspace root {} has no [package].version — APP_INFO_VERSION cannot be resolved",
+            root_cargo_toml.display()
+        )
+    });
+
+    println!("cargo:rustc-env=APP_INFO_VERSION={version}");
+}
+
+/// Extract `version = "…"` from the first `[package]` section of the root
+/// `Cargo.toml`. Stops scanning when the next `[section]` header appears, so
+/// versions inside `[dependencies]` or `[workspace.package]` can't be picked
+/// up by accident.
+fn parse_root_package_version(text: &str) -> Option<String> {
+    let mut in_package = false;
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line == "[package]" {
+            in_package = true;
+            continue;
+        }
+        if in_package && line.starts_with('[') && line.ends_with(']') {
+            break;
+        }
+        if in_package {
+            if let Some(rest) = line.strip_prefix("version") {
+                let rest = rest.trim_start();
+                if let Some(rest) = rest.strip_prefix('=') {
+                    let rest = rest.trim().trim_matches('"');
+                    if !rest.is_empty() {
+                        return Some(rest.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/crates/oauth2-observability/src/metrics.rs
+++ b/crates/oauth2-observability/src/metrics.rs
@@ -358,7 +358,11 @@ impl Metrics {
         app_info
             .with_label_values(&[
                 "oauth2-server",
-                env!("CARGO_PKG_VERSION"),
+                // Workspace root version (see build.rs). Using the
+                // observability crate's own `CARGO_PKG_VERSION` would
+                // report the wrong number because release automation
+                // only bumps the root manifest.
+                env!("APP_INFO_VERSION"),
                 option_env!("RUSTC_VERSION").unwrap_or("unknown"),
             ])
             .set(1);

--- a/crates/oauth2-observability/src/telemetry.rs
+++ b/crates/oauth2-observability/src/telemetry.rs
@@ -82,7 +82,7 @@ fn build_resource(service_name: &str) -> Resource {
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+        .unwrap_or_else(|| env!("APP_INFO_VERSION").to_string());
     builder = builder.with_attribute(KeyValue::new("service.version", version));
 
     if let Some(env_name) = std::env::var("DEPLOYMENT_ENVIRONMENT")


### PR DESCRIPTION
## Summary

- `oauth2_server_app_info{version=...}` and OTel `service.version` now source the application version from the **workspace root** `Cargo.toml`, not from the `oauth2-observability` crate's own `[package].version`.
- Fixes a test regression introduced by the `v0.7.0` release: `app_info` kept reporting `0.6.2` because the release script bumps only the root manifest, and the paved-path baseline test (`tests/metrics_paved_path_baseline.rs`) read the root version and failed the comparison.

## Root cause

1. `.github/scripts/bump_cargo_version.py` bumps only the top-level `[package].version`. By design — keeps the script boring and scopable.
2. `crates/oauth2-observability/src/metrics.rs:361` used `env!("CARGO_PKG_VERSION")`, which expands to `oauth2-observability`'s own version — now stale at `0.6.2`.
3. `tests/metrics_paved_path_baseline.rs:64` uses the same macro but resolves to the root crate's `0.7.0`, so the assertion `version="0.7.0"` vs actual `version="0.6.2"` blew up.
4. Because GitHub runs `pull_request` checks on a merge commit of the branch against `main`, every PR opened after the release started failing this test.

## Fix

- New `crates/oauth2-observability/build.rs` reads `../../Cargo.toml`, pulls `[package].version` from the first `[package]` section, and emits `cargo:rustc-env=APP_INFO_VERSION=<ver>`. `rerun-if-changed` points at the root manifest so edits retrigger the build.
- `metrics.rs` and `telemetry.rs` read `env!("APP_INFO_VERSION")` instead of `CARGO_PKG_VERSION`.
- No new runtime deps. Parser is 20-line hand-rolled; avoids pulling `toml` into the build graph.

## Follow-ups

- PR #230 (Flux GitOps) will merge cleanly once this lands — the same test failure was blocking it.
- If the workspace ever moves to `[workspace.package]` inheritance, the build script becomes unnecessary; delete it and revert to `env!("CARGO_PKG_VERSION")`.

## Test plan

- [x] `cargo test --test metrics_paved_path_baseline` — 5/5 pass locally.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [ ] CI full matrix on this branch.
- [ ] Post-deploy: `/metrics` on the cluster reports `oauth2_server_app_info{version="0.7.0",...} 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)