### PR TITLE
fix(k8s): pin production postgres-pvc to managed-premium storage class

### DIFF
--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -9,6 +9,7 @@ commonLabels:
 
 patchesStrategicMerge:
   - observability-patch.yaml
+  - postgres-pvc-patch.yaml
 
 images:
   - name: docker.io/ianlintner068/oauth2-server

--- a/k8s/overlays/production/postgres-pvc-patch.yaml
+++ b/k8s/overlays/production/postgres-pvc-patch.yaml
@@ -1,0 +1,14 @@
+# AKS-specific storage class override for the production PostgreSQL PVC.
+#
+# The base manifest targets `standard`, which matches kind/minikube defaults
+# used in the dev and e2e overlays. On AKS `bigboy` the PVC was originally
+# provisioned against `managed-premium` (an Azure-specific SSD class), and
+# a PVC's `storageClassName` is immutable after binding. Keep this patch in
+# sync with whichever class the bound PV was provisioned against, otherwise
+# Flux reconciliation will fail with a dry-run "spec is immutable" error.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+spec:
+  storageClassName: managed-premium


### PR DESCRIPTION
## Summary

- Production PostgreSQL PVC now patches `storageClassName: managed-premium` so Flux reconciliation matches the bound PV on the `bigboy` AKS cluster.
- Base manifest stays on `standard` for dev/kind/e2e overlays.
- Fixes the Flux `Non-Compliant` state observed immediately after provisioning the `oauth2-server` FluxConfig.

## Background

The `oauth2-server` `FluxConfig` was just created on the `bigboy` AKS cluster and failed its first reconcile with:

```
PersistentVolumeClaim/default/postgres-pvc dry-run failed (Invalid):
PersistentVolumeClaim "postgres-pvc" is invalid: spec: Forbidden:
spec is immutable after creation except resources.requests and
volumeAttributesClassName for bound claims
- "StorageClassName": "managed-premium",
+ "StorageClassName": "standard",
```

The PVC was originally provisioned against `managed-premium` (an Azure-specific SSD class). Kubernetes forbids changing `storageClassName` after a PVC is bound, so the rendered manifest must match the cluster.

## Test plan

- [x] `kubectl kustomize k8s/overlays/production` renders `storageClassName: managed-premium`.
- [ ] After merge, Flux `Kustomization/oauth2-server` reconciles to `Ready=True` (verify with `flux get kustomizations -A` or `az k8s-configuration flux show`).
- [ ] `kubectl get pvc -n default postgres-pvc` continues to show the same bound PV, no rebind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)