### PR TITLE
fix(k8s): replace commonLabels with labels block in production overlay

### DIFF
--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -4,8 +4,12 @@ kind: Kustomization
 bases:
   - ../../base
 
-commonLabels:
-  environment: production
+labels:
+  - pairs:
+      environment: production
+      app.kubernetes.io/instance: production
+    includeSelectors: true
+    includeTemplates: true
 
 patchesStrategicMerge:
   - observability-patch.yaml


### PR DESCRIPTION
## Summary

- Replaces deprecated `commonLabels` with a kustomize v4.1+ `labels` block in the production overlay.
- Fixes Flux reconciliation failure caused by rendered `spec.selector.matchLabels` diverging from the live cluster state.
- Overrides `app.kubernetes.io/instance` from the base value `test` to `production` to match the selector on the bound Deployment.

## Root Cause

`commonLabels` unconditionally injects labels into `spec.selector.matchLabels`. Combined with the base kustomization setting `app.kubernetes.io/instance: test` (with `includeSelectors: true`), the rendered selector was:

```
{app: oauth2-server, instance: test, name: oauth2-server, environment: production}
```

But the live Deployment selector (immutable after creation) is:

```
{app: oauth2-server, instance: production, name: oauth2-server, environment: production}
```

Flux's dry-run caught the mismatch and refused to apply.

## Fix

Switch to `labels` block with both `environment: production` and `app.kubernetes.io/instance: production`, both with `includeSelectors: true`. This overrides the base `test` value and aligns the rendered manifest with the cluster state.

## Test plan

- [x] `kubectl kustomize k8s/overlays/production` renders `matchLabels` matching the live cluster selector exactly.
- [ ] After merge, Flux `Kustomization/oauth2-server` reconciles to `Ready=True`.
- [ ] `kubectl get deployment -n default oauth2-server` continues to serve traffic (no selector change = no pod disruption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)