### PR TITLE
fix(caretaker): point default_model at deployed gpt-4.1-mini

### DIFF
--- a/.github/maintainer/config.yml
+++ b/.github/maintainer/config.yml
@@ -133,7 +133,7 @@ fleet_registry:
 llm:
   claude_enabled: auto
   provider: litellm
-  default_model: "azure_ai/gpt-4o"
+  default_model: "azure_ai/gpt-4.1-mini"
   claude_features:
     - ci_log_analysis
     - architectural_review


### PR DESCRIPTION
## Summary

Fixes caretaker bootstrap-check failure in [run 24967977804](https://github.com/ianlintner/rust-oauth2-server/actions/runs/24967977804/job/73106355597).

Two underlying issues:

1. **Missing secrets** — `AZURE_AI_API_KEY` and `AZURE_AI_API_BASE` were never set on this repo, so `caretaker doctor --bootstrap-check` exited 1. Both have now been added as repo secrets pointing at the `lintnerian-7181-resource` Azure AI Foundry resource (matches what the caretaker repo itself uses). For completeness, `AZURE_API_KEY` / `AZURE_API_BASE` were also set.

2. **Wrong model name** — `default_model` was `azure_ai/gpt-4o`, which has no deployment on that resource. Even with the secrets in place, every LLM call would have failed at runtime with `DeploymentNotFound`. This PR switches it to `azure_ai/gpt-4.1-mini`, which is deployed and matches the caretaker repo's own configuration.

## Test plan

- [ ] CI on this branch shows the `Caretaker bootstrap-check` step passes (summary: OK=6 WARN=0 FAIL=0).
- [ ] Next scheduled / dispatched caretaker run completes without `LiteLLM AZURE_AI_*` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)