### PR TITLE
fix(mongo): heal mixed BSON Date/String User timestamps (GitHub callback 500)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4108,6 +4108,7 @@ dependencies = [
  "oauth2-core",
  "oauth2-ports",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/oauth2-core/src/models/user.rs
+++ b/crates/oauth2-core/src/models/user.rs
@@ -15,8 +15,138 @@ pub struct User {
     /// User role: "admin" or "user" (default).
     #[serde(default = "default_role")]
     pub role: String,
+    #[serde(deserialize_with = "dt_tolerant::deserialize")]
     pub created_at: DateTime<Utc>,
+    #[serde(deserialize_with = "dt_tolerant::deserialize")]
     pub updated_at: DateTime<Utc>,
+}
+
+/// Tolerant deserializer for `chrono::DateTime<Utc>` that accepts every shape
+/// MongoDB / BSON might present:
+/// - RFC 3339 string (chrono's native form, what `Collection<User>::insert_one`
+///   writes via chrono's default Serialize)
+/// - BSON Date in binary mode (visited as `i64` millis since epoch)
+/// - BSON Date in extended-JSON v1 (`{"$date": <millis>}`)
+/// - BSON Date in extended-JSON v2 / canonical (`{"$date": {"$numberLong": "<ms>"}}`)
+///
+/// Why: MongoDB documents written via different code paths mix encodings —
+/// fresh `insert_one` writes timestamps as BSON Strings (chrono default),
+/// while historical `$set` updates that used `bson::DateTime` write BSON
+/// Dates. Reading back through chrono's default deserializer fails with
+/// "invalid type: map, expected an RFC 3339 formatted date and time string".
+/// This module heals legacy rows transparently on read.
+mod dt_tolerant {
+    use chrono::{DateTime, TimeZone, Utc};
+    use serde::de::{self, MapAccess, Visitor};
+    use serde::Deserializer;
+    use std::fmt;
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<DateTime<Utc>, D::Error> {
+        d.deserialize_any(DtVisitor)
+    }
+
+    struct DtVisitor;
+
+    impl<'de> Visitor<'de> for DtVisitor {
+        type Value = DateTime<Utc>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("RFC 3339 date string, BSON Date (i64 millis), or extended-JSON {$date: …}")
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            DateTime::parse_from_rfc3339(v)
+                .map(|dt| dt.with_timezone(&Utc))
+                .map_err(de::Error::custom)
+        }
+
+        fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
+            self.visit_str(&v)
+        }
+
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+            Utc.timestamp_millis_opt(v)
+                .single()
+                .ok_or_else(|| de::Error::custom("invalid millis"))
+        }
+
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+            self.visit_i64(v as i64)
+        }
+
+        fn visit_i128<E: de::Error>(self, v: i128) -> Result<Self::Value, E> {
+            self.visit_i64(v as i64)
+        }
+
+        fn visit_u128<E: de::Error>(self, v: u128) -> Result<Self::Value, E> {
+            self.visit_i64(v as i64)
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+            // Look for a `$date` key. Its value is either an i64 (extjson v1)
+            // or a sub-map with `$numberLong` as a string (extjson v2).
+            while let Some(key) = map.next_key::<String>()? {
+                if key == "$date" {
+                    return map.next_value_seed(DateValueSeed);
+                }
+                // Skip unrelated keys (defensive — bson shouldn't produce any).
+                let _: de::IgnoredAny = map.next_value()?;
+            }
+            Err(de::Error::custom("missing $date key in BSON Date object"))
+        }
+    }
+
+    struct DateValueSeed;
+
+    impl<'de> de::DeserializeSeed<'de> for DateValueSeed {
+        type Value = DateTime<Utc>;
+
+        fn deserialize<D: Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
+            d.deserialize_any(DateValueVisitor)
+        }
+    }
+
+    struct DateValueVisitor;
+
+    impl<'de> Visitor<'de> for DateValueVisitor {
+        type Value = DateTime<Utc>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("BSON $date value (i64 millis or {$numberLong: \"<ms>\"})")
+        }
+
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+            Utc.timestamp_millis_opt(v)
+                .single()
+                .ok_or_else(|| de::Error::custom("invalid millis"))
+        }
+
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+            self.visit_i64(v as i64)
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            // ISO-8601 / RFC 3339 form occasionally appears under $date too.
+            DateTime::parse_from_rfc3339(v)
+                .map(|dt| dt.with_timezone(&Utc))
+                .map_err(de::Error::custom)
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+            while let Some(key) = map.next_key::<String>()? {
+                if key == "$numberLong" {
+                    let s: String = map.next_value()?;
+                    let ms: i64 = s.parse().map_err(de::Error::custom)?;
+                    return Utc
+                        .timestamp_millis_opt(ms)
+                        .single()
+                        .ok_or_else(|| de::Error::custom("invalid millis"));
+                }
+                let _: de::IgnoredAny = map.next_value()?;
+            }
+            Err(de::Error::custom("missing $numberLong inside $date"))
+        }
+    }
 }
 
 fn default_role() -> String {
@@ -62,4 +192,65 @@ impl User {
 pub struct UserCredentials {
     pub username: String,
     pub password: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user_json_with_dates(created: &str, updated: &str) -> String {
+        format!(
+            r#"{{
+                "id": "u1",
+                "username": "alice",
+                "password_hash": "x",
+                "email": "a@b.test",
+                "enabled": true,
+                "role": "user",
+                "created_at": {created},
+                "updated_at": {updated}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn deserializes_rfc3339_string_dates() {
+        let json =
+            user_json_with_dates("\"2026-04-27T12:00:00Z\"", "\"2026-04-27T12:00:00+00:00\"");
+        let user: User = serde_json::from_str(&json).expect("RFC 3339 strings should parse");
+        assert_eq!(user.created_at.timestamp(), 1_777_291_200);
+        assert_eq!(user.updated_at.timestamp(), 1_777_291_200);
+    }
+
+    #[test]
+    fn deserializes_bson_extended_json_millis() {
+        // BSON extended JSON v1 form: {"$date": <i64 millis>}
+        let json =
+            user_json_with_dates(r#"{"$date": 1714219200000}"#, r#"{"$date": 1714219200000}"#);
+        let user: User = serde_json::from_str(&json).expect("BSON $date millis form should parse");
+        assert_eq!(user.created_at.timestamp_millis(), 1_714_219_200_000);
+        assert_eq!(user.updated_at.timestamp_millis(), 1_714_219_200_000);
+    }
+
+    #[test]
+    fn deserializes_bson_extended_json_wrapped() {
+        // BSON extended JSON v2 (canonical) form: {"$date": {"$numberLong": "<ms>"}}
+        let json = user_json_with_dates(
+            r#"{"$date": {"$numberLong": "1714219200000"}}"#,
+            r#"{"$date": {"$numberLong": "1714219200000"}}"#,
+        );
+        let user: User =
+            serde_json::from_str(&json).expect("BSON $date+$numberLong form should parse");
+        assert_eq!(user.created_at.timestamp_millis(), 1_714_219_200_000);
+        assert_eq!(user.updated_at.timestamp_millis(), 1_714_219_200_000);
+    }
+
+    #[test]
+    fn mixed_encodings_round_trip() {
+        // Real-world corrupted shape: insert_one wrote String, $set later wrote BSON Date.
+        let json = user_json_with_dates("\"2026-04-27T12:00:00Z\"", r#"{"$date": 1714219200000}"#);
+        let user: User = serde_json::from_str(&json).expect("mixed encodings should parse");
+        assert_eq!(user.created_at.timestamp(), 1_777_291_200);
+        assert_eq!(user.updated_at.timestamp_millis(), 1_714_219_200_000);
+    }
 }

--- a/crates/oauth2-storage-mongo/Cargo.toml
+++ b/crates/oauth2-storage-mongo/Cargo.toml
@@ -16,3 +16,4 @@ chrono = { version = "0.4", features = ["serde"] }
 mongodb = { version = "3", features = ["tracing-unstable"] }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
+tracing = "0.1"

--- a/crates/oauth2-storage-mongo/src/lib.rs
+++ b/crates/oauth2-storage-mongo/src/lib.rs
@@ -181,6 +181,67 @@ impl MongoStorage {
         Ok(())
     }
 
+    /// Heal legacy `users` documents whose `created_at` / `updated_at` were
+    /// written as BSON Date by historical admin update paths. Reading those
+    /// fields through `Collection<User>` fails because chrono's default
+    /// deserializer expects RFC 3339 strings — surfacing as the
+    /// `/auth/callback/github` 500 reported in production. Idempotent: only
+    /// touches documents that still have BSON Date fields.
+    async fn normalize_legacy_user_timestamps(&self) -> Result<(), OAuth2Error> {
+        use futures::TryStreamExt;
+        use mongodb::bson::{Bson, Document};
+
+        // BSON type number 9 = Date. `$type` lets us touch only the rows that
+        // need fixing (cheap on the index-less common case where no rows match).
+        let filter = doc! {
+            "$or": [
+                { "created_at": { "$type": 9 } },
+                { "updated_at": { "$type": 9 } },
+            ]
+        };
+
+        let coll = self.db.collection::<Document>("users");
+        let mut cursor = coll.find(filter).await.map_err(Self::mongo_err_to_oauth)?;
+
+        let mut fixed: u64 = 0;
+        while let Some(doc) = cursor.try_next().await.map_err(Self::mongo_err_to_oauth)? {
+            let id = match doc.get("id").and_then(Bson::as_str) {
+                Some(s) => s.to_string(),
+                None => continue, // pathological doc without id; skip
+            };
+
+            let mut set = Document::new();
+            for field in ["created_at", "updated_at"] {
+                if let Some(Bson::DateTime(bdt)) = doc.get(field) {
+                    // bson 2.x is built without the chrono-0_4 feature in this
+                    // workspace, so go through millis instead of `to_chrono()`.
+                    let ms = bdt.timestamp_millis();
+                    let chrono_dt = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
+                        .ok_or_else(|| {
+                            OAuth2Error::new("server_error", Some("invalid BSON DateTime millis"))
+                        })?;
+                    set.insert(field, chrono_dt.to_rfc3339());
+                }
+            }
+            if set.is_empty() {
+                continue;
+            }
+
+            coll.update_one(doc! { "id": &id }, doc! { "$set": set })
+                .await
+                .map_err(Self::mongo_err_to_oauth)?;
+            fixed += 1;
+        }
+
+        if fixed > 0 {
+            tracing::info!(
+                fixed,
+                "normalized legacy BSON Date timestamps in users collection"
+            );
+        }
+        Ok(())
+    }
+
     fn duplicate_key_error(err: &mongodb::error::Error) -> bool {
         // Canonical server-side message includes "E11000".
         err.to_string().contains("E11000")
@@ -202,7 +263,9 @@ impl Storage for MongoStorage {
             .run_command(doc! { "ping": 1 })
             .await
             .map_err(Self::mongo_err_to_oauth)?;
-        self.ensure_indexes().await
+        self.ensure_indexes().await?;
+        self.normalize_legacy_user_timestamps().await?;
+        Ok(())
     }
 
     async fn save_client(&self, client: &Client) -> Result<(), OAuth2Error> {
@@ -603,7 +666,10 @@ impl Storage for MongoStorage {
     // --- Admin: user management ---
 
     async fn update_user(&self, user: &User) -> Result<(), OAuth2Error> {
-        let updated_at = mongodb::bson::DateTime::from_millis(user.updated_at.timestamp_millis());
+        // Write `updated_at` as an RFC 3339 string to match how `insert_one`
+        // serializes via chrono's default impl. Mixing BSON Date and BSON String
+        // in the same document breaks `Collection<User>::find_one` deserialization.
+        let updated_at = user.updated_at.to_rfc3339();
         self.users
             .update_one(
                 doc! { "id": &user.id },
@@ -632,7 +698,7 @@ impl Storage for MongoStorage {
     }
 
     async fn set_user_enabled(&self, user_id: &str, enabled: bool) -> Result<(), OAuth2Error> {
-        let now = mongodb::bson::DateTime::now();
+        let now = chrono::Utc::now().to_rfc3339();
         self.users
             .update_one(
                 doc! { "id": user_id },
@@ -644,7 +710,7 @@ impl Storage for MongoStorage {
     }
 
     async fn set_user_role(&self, user_id: &str, role: &str) -> Result<(), OAuth2Error> {
-        let now = mongodb::bson::DateTime::now();
+        let now = chrono::Utc::now().to_rfc3339();
         self.users
             .update_one(
                 doc! { "id": user_id },
@@ -660,7 +726,7 @@ impl Storage for MongoStorage {
         user_id: &str,
         password_hash: &str,
     ) -> Result<(), OAuth2Error> {
-        let now = mongodb::bson::DateTime::now();
+        let now = chrono::Utc::now().to_rfc3339();
         self.users
             .update_one(
                 doc! { "id": user_id },
@@ -755,5 +821,31 @@ mod tests {
             doc.contains_key("refresh_token"),
             "refresh_token should be present when Some"
         );
+    }
+
+    /// Reproduces the bug from `/auth/callback/github` where a `User` document
+    /// previously touched by an admin op had `updated_at` written as a BSON
+    /// Date. Pre-fix, deserializing such a document panicked with
+    /// "invalid type: map, expected an RFC 3339 formatted date and time string".
+    /// The tolerant deserializer in `oauth2_core::User` heals it.
+    #[test]
+    fn user_deserializes_with_bson_date_updated_at() {
+        let mut doc = bson::Document::new();
+        doc.insert("id", "u1");
+        doc.insert("username", "github:42");
+        doc.insert("password_hash", "x");
+        doc.insert("email", "a@b.test");
+        doc.insert("enabled", true);
+        doc.insert("role", "user");
+        // Mixed encoding: created_at as String (insert_one path), updated_at
+        // as BSON Date (admin update path) — exactly the corrupted shape.
+        doc.insert("created_at", "2026-04-27T12:00:00Z");
+        doc.insert("updated_at", bson::DateTime::from_millis(1_714_219_200_000));
+
+        let user: User = bson::from_document(doc).expect(
+            "User must deserialize when updated_at is BSON Date — \
+             this reproduces the GitHub callback 500 from production",
+        );
+        assert_eq!(user.updated_at.timestamp_millis(), 1_714_219_200_000);
     }
 }


### PR DESCRIPTION
## Summary

- Fixes `GET /auth/callback/github` returning 500 with `Kind: invalid type: map, expected an RFC 3339 formatted date and time string` for any returning user whose record had been touched by an admin op.
- Root cause: `Collection<User>::insert_one` writes BSON String timestamps (chrono default Serialize → RFC 3339); `update_user` / `set_user_enabled` / `set_user_role` / `set_user_password_hash` overwrote `updated_at` as BSON Date. Mixed encoding broke subsequent reads through chrono's default deserializer.
- Three-part fix scoped to `User`: tolerant `Visitor` on `User.{created_at,updated_at}`, the four admin update sites now write RFC 3339 strings, and `Storage::init()` runs an idempotent `normalize_legacy_user_timestamps()` to heal existing rows.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --locked` (every binary green)
- [x] New unit tests in `oauth2-core` cover RFC 3339 string, BSON Date i64, extjson v1, extjson v2, and a mixed-encoding row
- [x] New `bson::from_document` roundtrip test in `oauth2-storage-mongo` reproduces the production 500 pre-fix and proves the fix
- [ ] (deferred to follow-up PR) Apply same pattern to `Token`, `Client`, `AuthorizationCode`, `DeviceAuthorization`, `AuditEntry`, `Denylist`, `KeySet` — same latent bug shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)