### PR TITLE
ci(release): rebase-retry on Flux race; assert tag matches Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,20 @@ jobs:
             exit 1
           fi
 
+          # Refuse to publish an image whose tag disagrees with the workspace
+          # Cargo.toml. The canonical release flow (release.yml) bumps
+          # Cargo.toml in the same commit it tags, so a mismatch means the
+          # tag was created outside that flow (e.g. manual gh release create)
+          # and would produce an image labeled X.Y.Z whose binary reports a
+          # different CARGO_PKG_VERSION.
+          cargo_version=$(grep -m1 -E '^version[[:space:]]*=' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if [[ "$cargo_version" != "$version" ]]; then
+            echo "Tag '$ref_name' (-> $version) does not match workspace Cargo.toml version ($cargo_version)." >&2
+            echo "Refusing to publish a versioned image whose binary CARGO_PKG_VERSION would disagree with the image tag." >&2
+            echo "If this is a real release, cut it via the release.yml workflow so Cargo.toml is bumped atomically." >&2
+            exit 1
+          fi
+
           echo "IMAGE_VERSION=$version" >> "$GITHUB_ENV"
 
       - name: Extract metadata (GHCR)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,23 @@ jobs:
 
           git add Cargo.toml Cargo.lock
           git commit -m "chore(release): bump version to ${{ steps.ver.outputs.version }}"
-          git push origin "${{ github.event.repository.default_branch }}"
+
+          # Retry the push to tolerate concurrent activity on the default
+          # branch (e.g. Flux ImageUpdateAutomation pushes a kustomization
+          # bump every ~5 min).
+          branch="${{ github.event.repository.default_branch }}"
+          for attempt in 1 2 3; do
+            if git push origin "$branch"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to push release commit after 3 attempts." >&2
+              exit 1
+            fi
+            echo "Push rejected; rebasing onto origin/$branch and retrying (attempt $((attempt + 1))/3)..." >&2
+            git fetch origin "$branch"
+            git rebase "origin/$branch"
+          done
 
       - name: Capture release commit SHA
         id: commit


### PR DESCRIPTION
## Summary

- **release.yml**: 3-attempt retry loop with `git fetch && git rebase` around the version-bump push, so a concurrent push to `main` (most predictably the Flux ImageUpdateAutomation kustomization bump that lands every ~5 min) doesn't kill the release.
- **ci.yml**: when building on a tag push, assert the tag's `IMAGE_VERSION` matches the workspace `Cargo.toml` version. Refuse to publish otherwise.

## Why

A v0.8.1 release attempt today failed at the bump-commit step:

```
[main af7159e] chore(release): bump version to 0.8.1
 ! [rejected]        main -> main (fetch first)
hint: Updates were rejected because the remote contains work that you do not
hint: have locally.
```

The colliding push was Flux's `chore(flux): bump oauth2-server image to ...0.8.0-mongo` commit. release.yml had no rebase/retry, so it lost the race and bailed without tagging or publishing.

Separately, a `gh release create v0.8.0` earlier today produced a `0.8.0-mongo` Docker image whose binary reports `oauth2_server_app_info{version="0.7.0"}`, because `ci.yml`'s tag-build path uses the tag name as `IMAGE_VERSION` and never checks `Cargo.toml`. The new assertion makes `release.yml` the only path that can publish a versioned image (since it's the only one that bumps `Cargo.toml` atomically with the tag).

## Test plan

- [ ] Re-run `release.yml` for a real version bump and verify it succeeds even with concurrent Flux activity on `main`.
- [ ] Confirm CI on a tag where `Cargo.toml` matches still publishes versioned images.
- [ ] Confirm CI on a hand-created tag (mismatched `Cargo.toml`) fails with the new assertion error rather than publishing a misleading image.
- [ ] Confirm non-tag (push-to-main) CI is unchanged — only `latest*` and `sha-*` images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)