### PR TITLE
feat(compliance): RFC compliance matrix generator + 21-file annotation pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,36 @@ jobs:
       - name: Run tests
         run: cargo test --verbose --all-features --locked
 
+      - name: Compliance test results capture
+        # Re-run only the RFC-tagged compliance tests with stable libtest
+        # pretty output captured to a file. The compliance_report tool then
+        # folds these results into the matrix as real pass/fail/ignored.
+        # The full `Run tests` step above already validated the suite, so
+        # this re-run is fast (compilation cached) and tolerant of failures
+        # (compliance_report itself does not fail the job).
+        run: |
+          mkdir -p target
+          cargo test --no-fail-fast --all-features --locked \
+            --test 'compliance_*' --test 'rfc_compliance' \
+            --test 'rfc8252_native_apps' --test 'rfc9700_*' \
+            --test 'phase2_rfc_compliance' \
+            -- --test-threads=1 \
+            > target/compliance-tests.txt 2>&1 || true
+
+      - name: Generate compliance report (with results)
+        run: cargo run --bin compliance_report -- --results target/compliance-tests.txt
+
+      - name: Upload compliance artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: rfc-compliance-report
+          path: |
+            docs/compliance/RFC_COMPLIANCE.md
+            target/compliance-report.json
+            target/compliance-junit.xml
+            target/compliance-tests.txt
+          if-no-files-found: error
+
   build-binaries:
     name: Build release binaries
     runs-on: ubuntu-latest
@@ -451,6 +481,7 @@ jobs:
   docs:
     name: Build and Deploy Documentation
     runs-on: ubuntu-latest
+    needs: [checks]
     if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     timeout-minutes: 20
     permissions:
@@ -472,6 +503,30 @@ jobs:
 
       - name: Build Rust Docs
         run: cargo doc --no-deps --all-features
+
+      - name: Download compliance artifact (with real test results)
+        # The `checks` job runs the compliance suite and uploads a fresh
+        # docs/compliance/RFC_COMPLIANCE.md (status filled in from libtest
+        # output). Pull it down here so the published docs always reflect
+        # current pass/fail status. Falls back to the committed file if the
+        # artifact is unavailable for any reason.
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        continue-on-error: true
+        with:
+          name: rfc-compliance-report
+          path: target/compliance-artifact
+
+      - name: Apply compliance report to docs tree
+        # If the artifact arrived, copy the fresh Markdown into docs/compliance/
+        # before mkdocs build runs.
+        run: |
+          if [ -f target/compliance-artifact/docs/compliance/RFC_COMPLIANCE.md ]; then
+            cp target/compliance-artifact/docs/compliance/RFC_COMPLIANCE.md \
+               docs/compliance/RFC_COMPLIANCE.md
+            echo "Applied freshly generated compliance matrix from checks job"
+          else
+            echo "No compliance artifact found; using committed RFC_COMPLIANCE.md"
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ __pycache__/
 # Local screenshots + playwright traces (not committed)
 .playwright-mcp/
 admin-*.png
+
+# Claude Code agent worktrees (local only)
+.claude/worktrees/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ oauth2-storage-factory = { path = "crates/oauth2-storage-factory", default-featu
 serde_json = "1.0"
 utoipa = "5.4"
 
+# Used by `src/bin/compliance_report.rs`.
+serde = { version = "1.0", features = ["derive"] }
+
 # Runtime used only by the thin delegating binary (`src/main.rs`).
 actix-rt = "2.9"
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-.PHONY: help kind-observability-up kind-observability-down kind-observability-traffic kind-observability-sync
+.PHONY: help kind-observability-up kind-observability-down kind-observability-traffic kind-observability-sync \
+        compliance-report compliance-report-with-results
 
 help:
 	@echo "Common targets:"
-	@echo "  make kind-observability-up     Bring up KIND cluster + app + in-cluster observability (Grafana/Jaeger port-forwards)"
-	@echo "  make kind-observability-traffic Generate synthetic traffic in the cluster (for dashboards/SLOs)"
-	@echo "  make kind-observability-sync   Sync repo observability assets into the in-cluster kustomize component"
-	@echo "  make kind-observability-down   Delete the KIND cluster used for observability"
+	@echo "  make compliance-report                  Regenerate the RFC compliance matrix (Markdown + JSON + JUnit XML) from source annotations"
+	@echo "  make compliance-report-with-results     As above, but first runs the compliance test suite to fold in real pass/fail status"
+	@echo "  make kind-observability-up              Bring up KIND cluster + app + in-cluster observability (Grafana/Jaeger port-forwards)"
+	@echo "  make kind-observability-traffic         Generate synthetic traffic in the cluster (for dashboards/SLOs)"
+	@echo "  make kind-observability-sync            Sync repo observability assets into the in-cluster kustomize component"
+	@echo "  make kind-observability-down            Delete the KIND cluster used for observability"
 	@echo ""
 	@echo "Useful overrides (env vars):"
 	@echo "  CLUSTER_NAME (default oauth2-observability)"
@@ -13,6 +16,29 @@ help:
 	@echo "  IMAGE_REF    (default docker.io/ianlintner068/oauth2-server:test)"
 	@echo "  SKIP_IMAGE_BUILD=1 (use prebuilt local image tag)"
 	@echo "  RECREATE_CLUSTER=0 (reuse existing cluster)"
+
+# -----------------------------------------------------------------------------
+# RFC compliance reporting
+# -----------------------------------------------------------------------------
+# `make compliance-report` regenerates the matrix from source annotations only
+# (status will be "unknown" because no test results are folded in).
+#
+# `make compliance-report-with-results` runs the relevant test binaries with
+# stable libtest pretty output, captures it, and runs the report generator
+# with `--results`, so the matrix shows real pass/fail/ignored status.
+compliance-report:
+	@cargo run --bin compliance_report
+
+compliance-report-with-results:
+	@mkdir -p target
+	@echo "Running compliance test binaries (this may take a minute)..." >&2
+	@cargo test --no-fail-fast \
+		--test 'compliance_*' --test 'rfc_compliance' \
+		--test 'rfc8252_native_apps' --test 'rfc9700_*' \
+		--test 'phase2_rfc_compliance' \
+		--all-features --locked -- --nocapture --test-threads=1 \
+		> target/compliance-tests.txt 2>&1 || true
+	@cargo run --bin compliance_report -- --results target/compliance-tests.txt
 
 kind-observability-up:
 	@bash scripts/kind_up_observability.sh

--- a/crates/oauth2-server/src/lib.rs
+++ b/crates/oauth2-server/src/lib.rs
@@ -972,6 +972,8 @@ pub async fn run() -> std::io::Result<()> {
         for _ in 0..shard_count {
             let shard = if let Some(ref event_bus) = event_bus {
                 let eb = event_bus.clone();
+                #[allow(clippy::clone_on_copy)]
+                // Option<()> when redis-cache off; real clone otherwise
                 let cache_redis = cache_redis_manager.clone();
                 actix::Actor::create(|ctx| {
                     ctx.set_mailbox_capacity(ACTOR_MAILBOX_CAPACITY);
@@ -987,6 +989,8 @@ pub async fn run() -> std::io::Result<()> {
                     attach_token_cache(actor, &cache_redis)
                 })
             } else {
+                #[allow(clippy::clone_on_copy)]
+                // Option<()> when redis-cache off; real clone otherwise
                 let cache_redis = cache_redis_manager.clone();
                 actix::Actor::create(|ctx| {
                     ctx.set_mailbox_capacity(ACTOR_MAILBOX_CAPACITY);
@@ -1008,6 +1012,7 @@ pub async fn run() -> std::io::Result<()> {
     tracing::info!(shards = shard_count, "TokenActorPool started");
 
     let client_actor = if let Some(ref event_bus) = event_bus {
+        #[allow(clippy::clone_on_copy)] // Option<()> when redis-cache off; real clone otherwise
         let cache_redis = cache_redis_manager.clone();
         actix::Actor::create(|ctx| {
             ctx.set_mailbox_capacity(ACTOR_MAILBOX_CAPACITY);
@@ -1016,6 +1021,7 @@ pub async fn run() -> std::io::Result<()> {
             attach_client_cache(actor, &cache_redis)
         })
     } else {
+        #[allow(clippy::clone_on_copy)] // Option<()> when redis-cache off; real clone otherwise
         let cache_redis = cache_redis_manager.clone();
         actix::Actor::create(|ctx| {
             ctx.set_mailbox_capacity(ACTOR_MAILBOX_CAPACITY);

--- a/docs/compliance/RFC_COMPLIANCE.md
+++ b/docs/compliance/RFC_COMPLIANCE.md
@@ -1,286 +1,374 @@
 # RFC Compliance Matrix
 
-This document tracks which OAuth2/OIDC specification requirements are covered by automated tests.
-Each row maps a specific RFC section to one or more test functions.
-
-**Legend**: ✅ Covered | ⚠️ Partial | ❌ Not Covered
-
----
-
-## RFC 6749 — The OAuth 2.0 Authorization Framework
-
-Test file: [`tests/compliance_rfc6749.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_rfc6749.rs)  
-Supplemental: [`tests/security_http.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/security_http.rs)
-
-| Section | Requirement                                                         | Test Function                                                    | Status |
-| ------- | ------------------------------------------------------------------- | ---------------------------------------------------------------- | ------ |
-| §3.1.2  | Redirect URI must be pre-registered and match exactly               | `rfc6749_s3_1_2_redirect_uri_must_match`                         | ✅     |
-| §4.1.1  | Authorization endpoint requires `response_type=code`                | `rfc6749_s4_1_1_authorize_requires_response_type`                | ✅     |
-| §4.1.1  | Unknown `response_type` is rejected                                 | `rfc6749_s4_1_1_authorize_rejects_unknown_response_type`         | ✅     |
-| §4.1.1  | `client_id` is required                                             | `rfc6749_s4_1_1_authorize_requires_client_id`                    | ✅     |
-| §4.1.1  | Unknown `client_id` is rejected                                     | `rfc6749_s4_1_1_authorize_rejects_unknown_client`                | ✅     |
-| §4.1.2  | Successful authorize redirects with `code`                          | `rfc6749_s4_1_2_authorize_redirects_with_code`                   | ✅     |
-| §4.1.2  | `state` parameter is echoed back verbatim                           | `rfc6749_s4_1_2_state_is_echoed_in_redirect`                     | ✅     |
-| §4.1.3  | Token endpoint validates `grant_type` is present                    | `rfc6749_s4_1_3_token_requires_grant_type`                       | ✅     |
-| §4.1.3  | Unsupported `grant_type` is rejected                                | `rfc6749_s4_1_3_token_rejects_unsupported_grant_type`            | ✅     |
-| §4.1.3  | Code exchange with wrong client is rejected                         | `rfc6749_s4_1_3_token_rejects_wrong_client_for_code`             | ✅     |
-| §4.2    | Implicit grant (`response_type=token`) is rejected                  | `authorize_rejects_implicit_response_type` (security_http.rs)    | ✅     |
-| §4.4.2  | Client credentials flow returns access token                        | `rfc6749_s4_4_2_client_credentials_returns_access_token`         | ✅     |
-| §4.4.3  | Client credentials with invalid secret → `invalid_client`           | `rfc6749_s4_4_3_client_credentials_rejects_invalid_client`       | ✅     |
-| §2.3.1  | Client auth via HTTP Basic header                                   | `rfc6749_s2_3_client_auth_via_basic_header`                      | ✅     |
-| §2.3.1  | Client auth via request body (`client_id` + `client_secret`)        | `rfc6749_s2_3_client_auth_via_post_params`                       | ✅     |
-| §2.3.1  | URL-encoded credentials in Basic auth                               | `token_basic_auth_decodes_url_encoded_secret` (security_http.rs) | ✅     |
-| §5.1    | Token response includes `token_type=bearer` and `access_token`      | `rfc6749_s5_1_token_response_has_required_fields`                | ✅     |
-| §5.2    | Token response has `Cache-Control: no-store` and `Pragma: no-cache` | `rfc6749_s5_2_token_response_no_cache_headers`                   | ✅     |
-| §5.2    | Error response JSON has `error` field                               | `rfc6749_s5_2_error_response_format`                             | ✅     |
-| §10.3   | Authorization code must not be accepted twice                       | `rfc6749_s10_3_authorization_code_single_use`                    | ✅     |
-
----
-
-## RFC 7636 — PKCE (Proof Key for Code Exchange)
-
-Test file: [`tests/compliance_rfc7636.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_rfc7636.rs)
-
-| Section | Requirement                                              | Test Function                                         | Status |
-| ------- | -------------------------------------------------------- | ----------------------------------------------------- | ------ |
-| §4.1    | Authorization code flow requires PKCE                    | `rfc7636_s4_1_pkce_required_for_authorization_code`   | ✅     |
-| §4.2    | `S256` is the only accepted challenge method             | `rfc7636_s4_2_s256_challenge_method_is_accepted`      | ✅     |
-| §4.2    | `plain` challenge method is rejected                     | `rfc7636_s4_2_plain_method_is_rejected`               | ✅     |
-| §4.3    | Valid verifier exchanges code successfully               | `rfc7636_s4_3_valid_verifier_exchanges_code`          | ✅     |
-| §4.3    | Wrong verifier is rejected with `invalid_grant`          | `rfc7636_s4_3_wrong_verifier_is_rejected`             | ✅     |
-| §4.3    | Missing verifier for a PKCE code → `invalid_grant`       | `rfc7636_s4_3_missing_verifier_rejects_pkce_code`     | ✅     |
-| §4.1    | Verifier shorter than 43 chars → `invalid_grant`         | `rfc7636_s4_1_verifier_min_length_43`                 | ✅     |
-| §4.1    | Verifier longer than 128 chars → `invalid_grant`         | `rfc7636_s4_1_verifier_max_length_128`                | ✅     |
-| §4.2    | `code_challenge_method` without `code_challenge` → error | `rfc7636_s4_2_method_without_challenge_rejected`      | ✅     |
-| §4.3    | Sending raw verifier as challenge in exchange → rejected | `rfc7636_s4_3_sending_verifier_as_challenge_rejected` | ✅     |
-
----
-
-## RFC 7662 — OAuth 2.0 Token Introspection
-
-Test file: [`tests/compliance_rfc7662_7009.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_rfc7662_7009.rs)
-
-| Section | Requirement                                 | Test Function                                         | Status |
-| ------- | ------------------------------------------- | ----------------------------------------------------- | ------ |
-| §2      | Valid token introspects with `active: true` | `rfc7662_s2_active_token_returns_true`                | ✅     |
-| §2      | Invalid/unknown token → `active: false`     | `rfc7662_s2_invalid_token_returns_false`              | ✅     |
-| §2      | Revoked token → `active: false`             | `rfc7662_s2_revoked_token_returns_inactive`           | ✅     |
-| §2.1    | Introspect requires client authentication   | `rfc7662_s2_1_introspect_requires_client_auth`        | ✅     |
-| §2.2    | Response contains `scope` field             | `rfc7662_s2_2_introspect_returns_scope`               | ✅     |
-| §2.2    | Response contains `client_id` field         | `rfc7662_s2_2_introspect_returns_client_id`           | ✅     |
-| §2.2    | Response contains `sub` for user tokens     | `rfc7662_s2_2_introspect_returns_sub_for_user_tokens` | ✅     |
-| §2.2    | Response contains `token_type`              | `rfc7662_s2_2_introspect_returns_token_type`          | ✅     |
-
----
-
-## RFC 7009 — OAuth 2.0 Token Revocation
-
-Test file: [`tests/compliance_rfc7662_7009.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_rfc7662_7009.rs)
-
-| Section | Requirement                                            | Test Function                                   | Status |
-| ------- | ------------------------------------------------------ | ----------------------------------------------- | ------ |
-| §2.1    | Revoking a valid token returns 200 OK                  | `rfc7009_s2_1_revoke_valid_token_returns_200`   | ✅     |
-| §2.2    | Revoking an unknown/invalid token still returns 200 OK | `rfc7009_s2_2_revoke_unknown_token_returns_200` | ✅     |
-| §2.1    | Revoke requires client authentication                  | `rfc7009_s2_1_revoke_requires_client_auth`      | ✅     |
-| §2.1    | Revoked token is subsequently inactive                 | `rfc7009_s2_1_revoked_token_becomes_inactive`   | ✅     |
-| §2.2    | Unsupported `token_type_hint` is tolerated             | `rfc7009_s2_2_unsupported_hint_is_tolerated`    | ✅     |
-
----
-
-## RFC 6750 — Bearer Token Usage
-
-Test file: [`tests/compliance_rfc6750.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_rfc6750.rs)
-
-| Section | Requirement                                           | Test Function                                   | Status |
-| ------- | ----------------------------------------------------- | ----------------------------------------------- | ------ |
-| §2.1    | Bearer token in `Authorization` header accepted       | `rfc6750_s2_1_bearer_header_accepted`           | ✅     |
-| §2.1    | Invalid token → 401 with `WWW-Authenticate` header    | `rfc6750_s2_1_invalid_token_returns_401`        | ✅     |
-| §2.1    | Missing token → 401 with `WWW-Authenticate` header    | `rfc6750_s2_1_missing_token_returns_401`        | ✅     |
-| §3.1    | `WWW-Authenticate: Bearer` present on unauthorized    | `rfc6750_s3_1_www_authenticate_header_on_401`   | ✅     |
-| §3.1    | `invalid_token` error code for expired/invalid tokens | `rfc6750_s3_1_error_code_invalid_token`         | ✅     |
-| §2.1    | Token with sufficient scope returns claims            | `rfc6750_s2_1_valid_token_returns_user_claims`  | ✅     |
-| §2.3    | URI query parameter bearer is not supported           | `rfc6750_s2_3_query_param_bearer_not_supported` | ✅     |
-| §2.2    | Form-encoded body bearer is not supported             | `rfc6750_s2_2_form_body_bearer_not_supported`   | ✅     |
-
----
-
-## RFC 8414 — OAuth 2.0 Authorization Server Metadata
-
-Test file: [`tests/compliance_rfc8414.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_rfc8414.rs)
-
-| Section | Requirement                                                                                  | Test Function                                           | Status |
-| ------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ------ |
-| §2      | `/.well-known/openid-configuration` returns 200 JSON                                         | `rfc8414_s2_discovery_endpoint_returns_200`             | ✅     |
-| §2      | Response includes `issuer` matching the server URL                                           | `rfc8414_s2_issuer_is_present_and_matches`              | ✅     |
-| §2      | Response includes `authorization_endpoint`                                                   | `rfc8414_s2_authorization_endpoint_present`             | ✅     |
-| §2      | Response includes `token_endpoint`                                                           | `rfc8414_s2_token_endpoint_present`                     | ✅     |
-| §2      | Response includes `jwks_uri`                                                                 | `rfc8414_s2_jwks_uri_present`                           | ✅     |
-| §2      | `response_types_supported` does not include `token` (implicit)                               | `rfc8414_s2_implicit_not_advertised`                    | ✅     |
-| §2      | `code_challenge_methods_supported` includes `S256` only                                      | `rfc8414_s2_pkce_s256_only_advertised`                  | ✅     |
-| §2      | `grant_types_supported` includes `authorization_code`, `client_credentials`, `refresh_token` | `rfc8414_s2_grant_types_advertised`                     | ✅     |
-| §2      | `introspection_endpoint` and `revocation_endpoint` are present                               | `rfc8414_s2_introspection_revocation_endpoints_present` | ✅     |
-
----
-
-## OpenID Connect Core 1.0
-
-Test file: [`tests/compliance_oidc_core.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_oidc_core.rs)
-
-| Section  | Requirement                                                      | Test Function                                     | Status |
-| -------- | ---------------------------------------------------------------- | ------------------------------------------------- | ------ |
-| §3.1     | Successful OIDC code flow returns `id_token` with `openid` scope | `oidc_core_s3_1_id_token_issued_for_openid_scope` | ✅     |
-| §3.1.3.3 | `id_token` is a valid JWT with three `.`-separated parts         | `oidc_core_s3_1_3_id_token_is_valid_jwt`          | ✅     |
-| §2       | `sub` claim is present and non-empty in `id_token`               | `oidc_core_s2_sub_claim_present`                  | ✅     |
-| §2       | `iss` claim matches the issuer                                   | `oidc_core_s2_iss_claim_matches_issuer`           | ✅     |
-| §2       | `aud` claim contains the `client_id`                             | `oidc_core_s2_aud_claim_contains_client_id`       | ✅     |
-| §2       | `exp` and `iat` claims are present and numeric                   | `oidc_core_s2_exp_and_iat_claims_present`         | ✅     |
-| §3.1.2.1 | `nonce` from authorize request is echoed in `id_token`           | `oidc_core_s3_1_2_1_nonce_echoed_in_id_token`     | ✅     |
-| §5.3     | UserInfo endpoint returns `sub` claim                            | `oidc_core_s5_3_userinfo_returns_sub`             | ✅     |
-| §5.3     | UserInfo endpoint requires Bearer token                          | `oidc_core_s5_3_userinfo_requires_bearer`         | ✅     |
-| §5.3     | UserInfo `sub` matches `sub` in `id_token`                       | `oidc_core_s5_3_userinfo_sub_matches_id_token`    | ✅     |
-| §3.1     | Token without `openid` scope does not include `id_token`         | `oidc_core_s3_1_no_id_token_without_openid_scope` | ✅     |
-
----
-
-## RFC 8628 — OAuth 2.0 Device Authorization Grant
-
-Test file: [`tests/compliance_rfc8628.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_rfc8628.rs)  
-Supplemental: [`tests/device_flow.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/device_flow.rs)
-
-| Section | Requirement                                                                          | Test Function                                               | Status |
-| ------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------- | ------ |
-| §3.1    | Device authorization endpoint returns `device_code`, `user_code`, `verification_uri` | `rfc8628_s3_1_device_authorization_returns_required_fields` | ✅     |
-| §3.1    | `expires_in` and `interval` are present in response                                  | `rfc8628_s3_1_expires_in_and_interval_present`              | ✅     |
-| §3.2    | `authorization_pending` while user has not yet approved                              | `rfc8628_s3_2_returns_authorization_pending`                | ✅     |
-| §3.2    | `slow_down` error is returned when polling too fast                                  | `rfc8628_s3_2_slow_down_on_rapid_polling`                   | ⚠️     |
-| §3.2    | `expired_token` when device code has expired                                         | `rfc8628_s3_2_expired_device_code_returns_error`            | ✅     |
-| §3.5    | Unsupported `grant_type` string → `unsupported_grant_type`                           | `rfc8628_s3_5_unsupported_grant_type`                       | ✅     |
-| §6.1    | Client must be registered for device flow grant type                                 | `rfc8628_s6_1_client_must_support_device_grant`             | ✅     |
-| §3.2    | `access_denied` when user explicitly rejects                                         | `rfc8628_s3_2_access_denied`                                | ⚠️     |
-| §3.1    | `verification_uri_complete` is included when supported                               | `rfc8628_s3_1_verification_uri_complete_present`            | ✅     |
-
-> **Notes**:
->
-> - `slow_down` (⚠️): The server enforces polling intervals via the `interval` field but does not currently track per-device polling rate; this test validates the field is advertised.
-> - `access_denied` (⚠️): Manual user rejection flow is exercised in `tests/device_flow.rs` (happy path); explicit denial is not yet a test case.
-
----
+_This file is generated by `cargo run --bin compliance_report`. Do not edit by hand — re-run the generator to regenerate._
 
 ## Summary
 
-| RFC / Spec | Tests Written | Tests Passing |
-| ---------- | :-----------: | :-----------: |
-| RFC 6749   |      20       |      ✅       |
-| RFC 7636   |      10       |      ✅       |
-| RFC 7662   |       8       |      ✅       |
-| RFC 7009   |       5       |      ✅       |
-| RFC 6750   |       8       |      ✅       |
-| RFC 8414   |       9       |      ✅       |
-| OIDC Core  |      11       |      ✅       |
-| RFC 8628   |       9       |      ⚠️       |
-| RFC 9126   |       5       |      ✅       |
-| RFC 8707   |       1       |      ✅       |
-| RFC 9701   |       3       |      ✅       |
-| RFC 7591   |       6       |      ✅       |
-| RFC 7592   |       3       |      ✅       |
-| RFC 7523   |       4       |      ✅       |
-| Wave 4     |      11       |      ✅       |
-| **Total**  |   **113**     |               |
+- **Total annotated tests:** 189
+- **Passing:** 185
+- **Failing:** 0
+- **Ignored:** 4
+- **Compliance score (passed / passed+failed+ignored):** 97%
 
-_Last updated automatically. Run `cargo test --test compliance_\*` to verify._
+## RFC 6749
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) | MUST | The authorization server MUST support HTTP Basic authentication for clients with a client password. | `rfc6749_s2_3_client_auth_via_basic_header` <br/><sub>tests/compliance_rfc6749.rs:899</sub> |
+| ✅ | [§2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) | MAY | Client credentials MAY be included in the request body using `client_id` and `client_secret` parameters. | `rfc6749_s2_3_client_auth_via_post_params` <br/><sub>tests/compliance_rfc6749.rs:942</sub> |
+| ✅ | [§3.1.2](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2) | MUST | Redirect URI in the authorization request must exactly match a registered redirect URI. | `rfc6749_s3_1_2_redirect_uri_must_match` <br/><sub>tests/compliance_rfc6749.rs:247</sub> |
+| ✅ | [§4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1) | MUST | Authorization requests bearing an unknown `client_id` MUST be rejected. | `rfc6749_s4_1_1_authorize_rejects_unknown_client` <br/><sub>tests/compliance_rfc6749.rs:414</sub> |
+| ✅ | [§4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1) | MUST | Authorization requests with an unsupported `response_type` MUST be rejected with `unsupported_response_type` (or equivalent error). | `rfc6749_s4_1_1_authorize_rejects_unknown_response_type` <br/><sub>tests/compliance_rfc6749.rs:330</sub> |
+| ✅ | [§4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1) | MUST | The authorization request MUST include the `client_id` parameter. | `rfc6749_s4_1_1_authorize_requires_client_id` <br/><sub>tests/compliance_rfc6749.rs:372</sub> |
+| ✅ | [§4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1) | MUST | The authorization request MUST include the `response_type` parameter. | `rfc6749_s4_1_1_authorize_requires_response_type` <br/><sub>tests/compliance_rfc6749.rs:293</sub> |
+| ✅ | [§4.1.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2) | MUST | A successful authorization response MUST be delivered as a redirect to the client's redirect URI with a `code` query parameter. | `rfc6749_s4_1_2_authorize_redirects_with_code` <br/><sub>tests/compliance_rfc6749.rs:463</sub> |
+| ✅ | [§4.1.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2) | MUST | If the client includes a `state` parameter, the authorization server MUST include the exact value received in the response. | `rfc6749_s4_1_2_state_is_echoed_in_redirect` <br/><sub>tests/compliance_rfc6749.rs:522</sub> |
+| ✅ | [§4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3) | MUST | Public clients (`token_endpoint_auth_method=none`) must exchange auth codes via PKCE without a secret. | `public_client_exchanges_code_without_secret` <br/><sub>tests/rfc_compliance.rs:586</sub> |
+| ✅ | [§4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3) | MUST | Public clients presenting a client_secret must be rejected (`invalid_client`). | `public_client_must_not_present_secret` <br/><sub>tests/rfc_compliance.rs:687</sub> |
+| ✅ | [§4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) | MUST | Token requests with an unsupported `grant_type` MUST be rejected with `unsupported_grant_type`. | `rfc6749_s4_1_3_token_rejects_unsupported_grant_type` <br/><sub>tests/compliance_rfc6749.rs:629</sub> |
+| ✅ | [§4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3) | MUST | The authorization server MUST ensure that an authorization code is bound to the client identifier it was issued to. | `rfc6749_s4_1_3_token_rejects_wrong_client_for_code` <br/><sub>tests/compliance_rfc6749.rs:678</sub> |
+| ✅ | [§4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3) | MUST | Token requests MUST include the `grant_type` parameter. | `rfc6749_s4_1_3_token_requires_grant_type` <br/><sub>tests/compliance_rfc6749.rs:584</sub> |
+| ✅ | [§4.4.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.2) | MUST | A successful client credentials grant MUST return an access token in the token response body. | `rfc6749_s4_4_2_client_credentials_returns_access_token` <br/><sub>tests/compliance_rfc6749.rs:805</sub> |
+| ✅ | [§4.4.3](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) | MUST | Invalid client authentication on the token endpoint MUST be rejected with `invalid_client`. | `rfc6749_s4_4_3_client_credentials_rejects_invalid_client` <br/><sub>tests/compliance_rfc6749.rs:851</sub> |
+| ✅ | [§5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1) | MUST | Successful token responses MUST include the `access_token` and `token_type` fields. | `rfc6749_s5_1_token_response_has_required_fields` <br/><sub>tests/compliance_rfc6749.rs:990</sub> |
+| ✅ | [§5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1) | MUST | Token endpoint responses MUST include `Cache-Control: no-store` and `Pragma: no-cache` to prevent caching of sensitive credentials. | `rfc6749_s5_2_token_response_no_cache_headers` <br/><sub>tests/compliance_rfc6749.rs:1046</sub> |
+| ✅ | [§5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) | MUST | Error responses from the token endpoint MUST be JSON objects containing an `error` field. | `rfc6749_s5_2_error_response_format` <br/><sub>tests/compliance_rfc6749.rs:1108</sub> |
+| ✅ | [§10.5](https://datatracker.ietf.org/doc/html/rfc6749#section-10.5) | MUST | Authorization codes MUST be single-use; a second redemption of the same code MUST be rejected. | `rfc6749_s10_3_authorization_code_single_use` <br/><sub>tests/compliance_rfc6749.rs:1160</sub> |
+
+## RFC 6750
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc6750#section-2) | MUST | A token without a resource-owner subject must not be accepted by the userinfo endpoint. | `rfc6750_s2_client_credentials_token_cannot_access_userinfo` <br/><sub>tests/compliance_rfc6750.rs:315</sub> |
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1) | MUST | Bearer token in the Authorization header must be accepted by protected resources. | `rfc6750_s2_1_bearer_in_authorization_header_returns_200` <br/><sub>tests/compliance_rfc6750.rs:132</sub> |
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1) | MUST | A valid Bearer token must enable retrieval of the resource owner's `sub` claim. | `rfc6750_s2_1_userinfo_response_contains_sub` <br/><sub>tests/compliance_rfc6750.rs:165</sub> |
+| ✅ | [§3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1) | MUST | Invalid token error body must contain `error: invalid_token`. | `rfc6750_s3_1_error_body_has_invalid_token_code` <br/><sub>tests/compliance_rfc6750.rs:279</sub> |
+| ✅ | [§3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1) | MUST | Invalid Bearer token must return 401 with WWW-Authenticate including error=invalid_token. | `rfc6750_s3_1_invalid_token_returns_401_with_www_authenticate` <br/><sub>tests/compliance_rfc6750.rs:240</sub> |
+| ✅ | [§3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1) | MUST | Missing Bearer credentials must return 401 with WWW-Authenticate: Bearer. | `rfc6750_s3_1_missing_token_returns_401` <br/><sub>tests/compliance_rfc6750.rs:204</sub> |
+
+## RFC 7009
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc7009#section-2) | MUST | Revoking a token must cascade-revoke the entire token family (security BCP). | `revoke_cascades_to_entire_token_family` <br/><sub>tests/rfc_compliance.rs:1649</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc7009#section-2) | MUST | A revoked token must subsequently be reported as inactive by introspection. | `rfc7009_s2_token_inactive_after_revoke` <br/><sub>tests/compliance_rfc7662_7009.rs:624</sub> |
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1) | MUST | Token revocation endpoint must require client authentication. | `rfc7009_s2_1_revoke_requires_client_auth` <br/><sub>tests/compliance_rfc7662_7009.rs:582</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2) | MUST | Revocation of an unknown token must still return HTTP 200. | `rfc7009_s2_2_revoke_unknown_token_returns_200` <br/><sub>tests/compliance_rfc7662_7009.rs:538</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2) | MUST | Successful token revocation must return HTTP 200. | `rfc7009_s2_2_revoke_valid_token_returns_200` <br/><sub>tests/compliance_rfc7662_7009.rs:496</sub> |
+
+## RFC 7515
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§6](https://datatracker.ietf.org/doc/html/rfc7515#section-6) | MUST | A JWS with `alg: none` and a non-empty signature must be rejected. | `wave2_c1_public_client_jar_rejects_nonempty_signature_with_alg_none` <br/><sub>tests/compliance_wave5.rs:797</sub> |
+
+## RFC 7523
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7523#section-2.2) | MUST | Token endpoint must accept `client_secret_jwt` (HS256 JWT signed with client_secret). | `rfc7523_client_secret_jwt_authentication` <br/><sub>tests/phase2_rfc_compliance.rs:595</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7523#section-2.2) | MUST | A client_secret_jwt assertion signed with the wrong secret must be rejected. | `rfc7523_client_secret_jwt_wrong_secret_fails` <br/><sub>tests/phase2_rfc_compliance.rs:671</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7523#section-2.2) | MUST | Token endpoint must accept `private_key_jwt` (RS256 JWT verified against registered JWKS). | `rfc7523_private_key_jwt_authentication` <br/><sub>tests/phase2_rfc_compliance.rs:748</sub> |
+
+## RFC 7591
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc7591#section-2) | MUST | Dynamic registration must reject public clients requesting the `client_credentials` grant. | `public_client_registration_with_client_credentials_is_rejected` <br/><sub>tests/rfc_compliance.rs:972</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc7591#section-2) | MUST | Dynamic registration must accept `token_endpoint_auth_method=none` for public clients. | `public_client_registration_with_none_auth_method_succeeds` <br/><sub>tests/rfc_compliance.rs:926</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc7591#section-2) | MUST | Registration request must not contain both `jwks` and `jwks_uri`. | `rfc7591_jwks_and_jwks_uri_mutually_exclusive` <br/><sub>tests/phase2_rfc_compliance.rs:1089</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc7591#section-2) | MUST | Registering with `token_endpoint_auth_method=private_key_jwt` must require `jwks` or `jwks_uri`. | `rfc7591_private_key_jwt_requires_jwks` <br/><sub>tests/phase2_rfc_compliance.rs:1022</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc7591#section-2) | MUST | Registration must reject invalid `redirect_uris` (malformed/non-absolute/etc). | `rfc7591_rejects_invalid_redirect_uris` <br/><sub>tests/phase2_rfc_compliance.rs:296</sub> |
+| ✅ | [§3.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.1) | MUST | Registration must default `grant_types`/`response_types` to `authorization_code`/`code` when omitted. | `rfc7591_defaults_grant_and_response_types` <br/><sub>tests/phase2_rfc_compliance.rs:186</sub> |
+| ✅ | [§3.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.1) | MUST | Successful dynamic client registration must return 201 with full client info plus registration_access_token. | `rfc7591_dynamic_registration_success` <br/><sub>tests/phase2_rfc_compliance.rs:100</sub> |
+| ✅ | [§3.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.1) | MUST | Public-client registration must omit `client_secret` from the registration response. | `rfc7591_public_client_no_secret` <br/><sub>tests/phase2_rfc_compliance.rs:238</sub> |
+
+## RFC 7592
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc7592#section-2.1) | MUST | GET on the client configuration endpoint must return the client config when authenticated with the registration access token. | `rfc7592_read_client_configuration` <br/><sub>tests/phase2_rfc_compliance.rs:379</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7592#section-2.2) | MUST | PUT on the client configuration endpoint must update the client metadata. | `rfc7592_update_client_configuration` <br/><sub>tests/phase2_rfc_compliance.rs:451</sub> |
+| ✅ | [§2.3](https://datatracker.ietf.org/doc/html/rfc7592#section-2.3) | MUST | DELETE on the client configuration endpoint must remove the client. | `rfc7592_delete_client` <br/><sub>tests/phase2_rfc_compliance.rs:521</sub> |
+
+## RFC 7636
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§4.1](https://datatracker.ietf.org/doc/html/rfc7636#section-4.1) | MUST | Public clients using authorization_code must include code_challenge in the authorize request. | `rfc7636_s4_1_pkce_required_for_authorization_code` <br/><sub>tests/compliance_rfc7636.rs:190</sub> |
+| ✅ | [§4.1](https://datatracker.ietf.org/doc/html/rfc7636#section-4.1) | MUST | code_verifier longer than 128 characters must be rejected. | `rfc7636_s4_1_verifier_max_length_128` <br/><sub>tests/compliance_rfc7636.rs:291</sub> |
+| ✅ | [§4.1](https://datatracker.ietf.org/doc/html/rfc7636#section-4.1) | MUST | code_verifier shorter than 43 characters must be rejected. | `rfc7636_s4_1_verifier_min_length_43` <br/><sub>tests/compliance_rfc7636.rs:236</sub> |
+| ✅ | [§4.2](https://datatracker.ietf.org/doc/html/rfc7636#section-4.2) | MUST | code_challenge_method without code_challenge must be rejected. | `rfc7636_s4_2_method_without_challenge_rejected` <br/><sub>tests/compliance_rfc7636.rs:457</sub> |
+| ✅ | [§4.2](https://datatracker.ietf.org/doc/html/rfc7636#section-4.2) | MUST | The plain code_challenge_method must be rejected (S256-only enforcement). | `rfc7636_s4_2_plain_method_is_rejected` <br/><sub>tests/compliance_rfc7636.rs:398</sub> |
+| ✅ | [§4.2](https://datatracker.ietf.org/doc/html/rfc7636#section-4.2) | MUST | Servers must support the S256 code_challenge_method. | `rfc7636_s4_2_s256_challenge_method_is_accepted` <br/><sub>tests/compliance_rfc7636.rs:348</sub> |
+| ✅ | [§4.3](https://datatracker.ietf.org/doc/html/rfc7636#section-4.3) | MUST | Missing code_verifier when challenge was registered must yield invalid_grant. | `rfc7636_s4_3_missing_verifier_rejects_pkce_code` <br/><sub>tests/compliance_rfc7636.rs:603</sub> |
+| ✅ | [§4.3](https://datatracker.ietf.org/doc/html/rfc7636#section-4.3) | MUST | Verifier-as-challenge (plain-style) misuse must be rejected when S256 is required. | `rfc7636_s4_3_sending_verifier_as_challenge_rejected` <br/><sub>tests/compliance_rfc7636.rs:657</sub> |
+| ✅ | [§4.3](https://datatracker.ietf.org/doc/html/rfc7636#section-4.3) | MUST | A correct PKCE code_verifier must be accepted at the token endpoint. | `rfc7636_s4_3_valid_verifier_exchanges_code` <br/><sub>tests/compliance_rfc7636.rs:502</sub> |
+| ✅ | [§4.3](https://datatracker.ietf.org/doc/html/rfc7636#section-4.3) | MUST | An incorrect PKCE code_verifier must yield invalid_grant at the token endpoint. | `rfc7636_s4_3_wrong_verifier_is_rejected` <br/><sub>tests/compliance_rfc7636.rs:552</sub> |
+
+## RFC 7662
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc7662#section-2.1) | MUST | Introspection endpoint must accept HTTP Basic client authentication. | `rfc7662_s2_1_introspect_accepts_basic_auth` <br/><sub>tests/compliance_rfc7662_7009.rs:449</sub> |
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc7662#section-2.1) | MUST | Introspection endpoint must require client authentication. | `rfc7662_s2_1_introspect_requires_client_auth` <br/><sub>tests/compliance_rfc7662_7009.rs:294</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2) | MUST | Active introspection response must include `nbf`, `jti`, `aud`, and `iss` claims. | `rfc7662_introspection_includes_nbf_jti_aud_iss` <br/><sub>tests/rfc_compliance.rs:371</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2) | MUST | Introspection response must satisfy `nbf <= iat` for tokens valid from issuance. | `rfc7662_introspection_nbf_le_iat` <br/><sub>tests/rfc_compliance.rs:479</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2) | MUST | Introspection of an active token must yield `active: true`. | `rfc7662_s2_2_introspect_active_token_returns_true` <br/><sub>tests/compliance_rfc7662_7009.rs:207</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2) | MUST | Introspection must report a token belonging to a different client as inactive. | `rfc7662_s2_2_introspect_cross_client_returns_inactive` <br/><sub>tests/compliance_rfc7662_7009.rs:391</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2) | MUST | Introspection must return `active: false` for an invalid or unknown token. | `rfc7662_s2_2_introspect_invalid_token_returns_false` <br/><sub>tests/compliance_rfc7662_7009.rs:251</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2) | MUST | Introspection response for an active token must include scope, client_id, and token_type. | `rfc7662_s2_2_introspect_response_includes_required_fields` <br/><sub>tests/compliance_rfc7662_7009.rs:337</sub> |
+| ✅ | [§5](https://datatracker.ietf.org/doc/html/rfc7662#section-5) | MUST | Anonymous introspection must strip subject identity fields (username, sub) while keeping lifecycle claims. | `rfc9700_anonymous_introspection_strips_username_and_sub` <br/><sub>tests/rfc9700_introspection_pii.rs:28</sub> |
+| ✅ | [§5](https://datatracker.ietf.org/doc/html/rfc7662#section-5) | MUST | Authenticated owner introspection must still return identity claims (sub, client_id) for the token's owner. | `rfc9700_owner_introspection_still_returns_pii` <br/><sub>tests/rfc9700_introspection_pii.rs:169</sub> |
+
+## RFC 8252
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§7.1](https://datatracker.ietf.org/doc/html/rfc8252#section-7.1) | MUST | Claimed/custom URI schemes must match registered redirect URI byte-for-byte. | `rfc8252_custom_scheme_exact_match_only` <br/><sub>tests/rfc8252_native_apps.rs:149</sub> |
+| ✅ | [§7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) | MUST | IPv4 loopback (127.0.0.1) redirect URIs must accept any port at request time. | `rfc8252_ipv4_loopback_any_port_accepted` <br/><sub>tests/rfc8252_native_apps.rs:36</sub> |
+| ✅ | [§7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) | MUST | IPv6 loopback ([::1]) redirect URIs must accept any port at request time. | `rfc8252_ipv6_loopback_any_port_accepted` <br/><sub>tests/rfc8252_native_apps.rs:50</sub> |
+| ✅ | [§7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) | MUST | Loopback exception must still require path equality; only the port is wildcarded. | `rfc8252_loopback_exception_still_requires_path_match` <br/><sub>tests/rfc8252_native_apps.rs:119</sub> |
+| ✅ | [§7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) | MUST | Loopback exception must still require scheme equality (http vs https are distinct). | `rfc8252_loopback_exception_still_requires_scheme_match` <br/><sub>tests/rfc8252_native_apps.rs:134</sub> |
+| ✅ | [§7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) | MUST | IPv4 and IPv6 loopback hosts must be treated as distinct (no cross-family wildcarding). | `rfc8252_loopback_families_do_not_cross` <br/><sub>tests/rfc8252_native_apps.rs:88</sub> |
+| ✅ | [§7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) | MUST | Non-loopback hosts must require exact redirect URI match (no port wildcard). | `rfc8252_non_loopback_host_requires_exact_match` <br/><sub>tests/rfc8252_native_apps.rs:105</sub> |
+| ✅ | [§8.3](https://datatracker.ietf.org/doc/html/rfc8252#section-8.3) | MUST | `localhost` hostname must NOT receive the loopback port-wildcard exception. | `rfc8252_localhost_hostname_does_not_wildcard_port` <br/><sub>tests/rfc8252_native_apps.rs:67</sub> |
+
+## RFC 8414
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) | MUST | Discovery doc must reflect supported client auth methods (incl. client_secret_jwt, private_key_jwt) and registration endpoint. | `rfc8414_discovery_reflects_phase2` <br/><sub>tests/phase2_rfc_compliance.rs:857</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) | MUST | Metadata must include the `authorization_endpoint` field. | `rfc8414_s2_authorization_endpoint_present` <br/><sub>tests/compliance_rfc8414.rs:91</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) | MUST | `code_challenge_methods_supported` must include `S256`. | `rfc8414_s2_code_challenge_methods_includes_s256` <br/><sub>tests/compliance_rfc8414.rs:166</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) | MUST | `grant_types_supported` must include `authorization_code`. | `rfc8414_s2_grant_types_includes_authorization_code` <br/><sub>tests/compliance_rfc8414.rs:243</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) | MUST | The `issuer` metadata value must match the configured issuer URL. | `rfc8414_s2_issuer_matches_configured_value` <br/><sub>tests/compliance_rfc8414.rs:68</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) | MUST | Authorization-server metadata endpoint must return 200 OK. | `rfc8414_s2_metadata_endpoint_returns_200` <br/><sub>tests/compliance_rfc8414.rs:49</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) | MUST | `response_types_supported` must include `code`. | `rfc8414_s2_response_types_includes_code` <br/><sub>tests/compliance_rfc8414.rs:142</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) | MUST | `token_endpoint_auth_methods_supported` must include `client_secret_basic`. | `rfc8414_s2_token_endpoint_auth_methods_include_basic` <br/><sub>tests/compliance_rfc8414.rs:215</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) | MUST | Metadata must include the `token_endpoint` field. | `rfc8414_s2_token_endpoint_present` <br/><sub>tests/compliance_rfc8414.rs:120</sub> |
+| ✅ | [§3](https://datatracker.ietf.org/doc/html/rfc8414#section-3) | MUST | Both `/.well-known/oauth-authorization-server` and `/.well-known/openid-configuration` must serve identical metadata. | `rfc8414_both_well_known_paths_return_same_response` <br/><sub>tests/rfc_compliance.rs:857</sub> |
+| ✅ | [§3](https://datatracker.ietf.org/doc/html/rfc8414#section-3) | MUST | AS metadata must be served at `/.well-known/oauth-authorization-server`. | `rfc8414_oauth_authorization_server_well_known_returns_metadata` <br/><sub>tests/rfc_compliance.rs:792</sub> |
+
+## RFC 8628
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§3.1](https://datatracker.ietf.org/doc/html/rfc8628#section-3.1) | MUST | Device authorization endpoint must accept client_secret_basic credentials. | `rfc8628_s3_1_accepts_client_secret_basic` <br/><sub>tests/compliance_rfc8628.rs:654</sub> |
+| ✅ | [§3.1](https://datatracker.ietf.org/doc/html/rfc8628#section-3.1) | MUST | Device authorization endpoint must reject missing or unknown client_id. | `rfc8628_s3_1_missing_client_id_returns_error` <br/><sub>tests/compliance_rfc8628.rs:235</sub> |
+| ✅ | [§3.1](https://datatracker.ietf.org/doc/html/rfc8628#section-3.1) | MUST | Device authorization response must include device_code, user_code, verification_uri, expires_in. | `rfc8628_s3_1_response_contains_required_fields` <br/><sub>tests/compliance_rfc8628.rs:171</sub> |
+| ✅ | [§3.1](https://datatracker.ietf.org/doc/html/rfc8628#section-3.1) | MUST | A client without device_code grant must receive `unauthorized_client`. | `rfc8628_s3_1_unauthorized_client_is_rejected` <br/><sub>tests/compliance_rfc8628.rs:273</sub> |
+| ✅ | [§3.3](https://datatracker.ietf.org/doc/html/rfc8628#section-3.3) | MUST | Approving a valid user_code at the verification endpoint must return a 2xx response. | `rfc8628_s3_3_approve_returns_success` <br/><sub>tests/compliance_rfc8628.rs:328</sub> |
+| ✅ | [§3.3](https://datatracker.ietf.org/doc/html/rfc8628#section-3.3) | MUST | Denying a valid user_code at the verification endpoint must return a 2xx response. | `rfc8628_s3_3_deny_returns_success` <br/><sub>tests/compliance_rfc8628.rs:395</sub> |
+| ✅ | [§3.4](https://datatracker.ietf.org/doc/html/rfc8628#section-3.4) | MUST | After user approval, token polling must return 200 with an access token. | `rfc8628_s3_4_approved_returns_access_token` <br/><sub>tests/compliance_rfc8628.rs:524</sub> |
+| ✅ | [§3.4](https://datatracker.ietf.org/doc/html/rfc8628#section-3.4) | MUST | Token polling before approval must return 400 with error=authorization_pending. | `rfc8628_s3_4_pending_returns_authorization_pending` <br/><sub>tests/compliance_rfc8628.rs:462</sub> |
+| ✅ | [§3.4](https://datatracker.ietf.org/doc/html/rfc8628#section-3.4) | MUST | Unknown or invalid device_code at the token endpoint must return a 4xx error. | `rfc8628_s3_4_unknown_device_code_returns_error` <br/><sub>tests/compliance_rfc8628.rs:609</sub> |
+
+## RFC 8693
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc8693#section-2.1) | MUST | Discovery metadata must include `urn:ietf:params:oauth:grant-type:token-exchange` in grant_types_supported. | `wave4_rfc8693_token_exchange_grant_type_in_discovery` <br/><sub>tests/compliance_wave4.rs:126</sub> |
+
+## RFC 8705
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc8705#section-2.1) | MUST | `tls_client_auth` must validate the client certificate Subject DN against the registered value. | `test_vector_p_mtls_subject_dn_validation` <br/><sub>tests/rfc9700_compliance.rs:1003</sub> |
+| ✅ | [§3](https://datatracker.ietf.org/doc/html/rfc8705#section-3) | MUST | Discovery metadata must advertise `tls_client_certificate_bound_access_tokens: true`. | `wave4_rfc8705_mtls_advertised_in_discovery` <br/><sub>tests/compliance_wave4.rs:104</sub> |
+
+## RFC 8707
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8707#section-2) | MUST | Token endpoint must accept `resource` parameter and bind it as token audience. | `rfc8707_resource_indicator_accepted_in_client_credentials` <br/><sub>tests/compliance_wave3.rs:376</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc8707#section-2) | MUST | Token request `resource` parameter must populate the issued token's `aud` claim. | `test_vector_m_resource_to_aud_claim` <br/><sub>tests/rfc9700_compliance.rs:860</sub> |
+
+## RFC 9068
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc9068#section-2.1) | MUST | JWT access tokens must use JOSE header `typ: "at+JWT"`. | `rfc9068_access_token_has_typ_at_jwt` <br/><sub>tests/rfc_compliance.rs:225</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc9068#section-2.2) | MUST | Access-token JWT `iss` claim must equal the configured AS issuer URL. | `rfc9068_jwt_iss_matches_configured_issuer` <br/><sub>tests/rfc_compliance.rs:292</sub> |
+
+## RFC 9101
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9101#section-4) | MUST | Authorization endpoint must accept and process the JAR `request` parameter. | `test_vector_q_jar_request_parameter_integration` <br/><sub>tests/rfc9700_compliance.rs:1090</sub> |
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9101#section-4) | MUST | JAR signed via `private_key_jwt` must be verified using the client's resolved JWKS. | `test_vector_r_jar_private_key_jwt_jwks_cache` <br/><sub>tests/rfc9700_compliance.rs:1262</sub> |
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9101#section-4) | MUST | A public-client JAR with a non-`none` `alg` header must be rejected (no signature-bypass). | `wave2_c1_public_client_jar_rejects_non_none_alg_header` <br/><sub>tests/compliance_wave5.rs:736</sub> |
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9101#section-4) | MAY | A confidential client may submit a JAR signed with HS256 derived from client_secret. | `wave5_jar_confidential_client_hs256_succeeds` <br/><sub>tests/compliance_wave5.rs:585</sub> |
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9101#section-4) | MAY | A public client may submit an unsigned (alg=none) JAR via the `request` parameter. | `wave5_jar_public_client_unsigned_succeeds` <br/><sub>tests/compliance_wave5.rs:512</sub> |
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9101#section-4) | MUST | JAR with an invalid / tampered signature must be rejected. | `wave5_jar_tampered_hs256_is_rejected` <br/><sub>tests/compliance_wave5.rs:661</sub> |
+| ✅ | [§9](https://datatracker.ietf.org/doc/html/rfc9101#section-9) | MUST | Discovery must advertise `request_parameter_supported: true`. | `wave5_discovery_request_parameter_supported_is_true` <br/><sub>tests/compliance_wave5.rs:997</sub> |
+
+## RFC 9126
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc9126#section-2.1) | MUST | PAR endpoint must reject confidential clients that do not authenticate. | `rfc9126_par_confidential_client_no_secret_rejected` <br/><sub>tests/compliance_wave3.rs:263</sub> |
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc9126#section-2.1) | MUST | PAR endpoint must accept confidential client authenticated via HTTP Basic. | `rfc9126_par_confidential_client_with_basic_auth_succeeds` <br/><sub>tests/compliance_wave3.rs:312</sub> |
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc9126#section-2.1) | MUST | PAR endpoint must reject requests containing duplicate parameters. | `rfc9126_par_duplicate_param_is_rejected` <br/><sub>tests/compliance_wave3.rs:215</sub> |
+| ✅ | [§2.1](https://datatracker.ietf.org/doc/html/rfc9126#section-2.1) | MUST | PAR endpoint must reject requests missing the `response_type` parameter. | `rfc9126_par_missing_response_type_is_rejected` <br/><sub>tests/compliance_wave3.rs:168</sub> |
+| ✅ | [§2.2](https://datatracker.ietf.org/doc/html/rfc9126#section-2.2) | MUST | PAR endpoint must return 201 with `request_uri` and `expires_in` for valid public-client requests. | `rfc9126_par_public_client_returns_request_uri` <br/><sub>tests/compliance_wave3.rs:108</sub> |
+
+## RFC 9207
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc9207#section-2) | MUST | Authorization response must include the `iss` parameter naming the AS. | `rfc9207_iss_included_in_authorization_response` <br/><sub>tests/rfc_compliance.rs:136</sub> |
+| ✅ | [§2](https://datatracker.ietf.org/doc/html/rfc9207#section-2) | MUST | Authorization response (success or error) must include the `iss` parameter. | `test_vector_e_iss_in_authorization_response` <br/><sub>tests/rfc9700_compliance.rs:341</sub> |
+| ✅ | [§3](https://datatracker.ietf.org/doc/html/rfc9207#section-3) | MUST | Discovery must advertise `authorization_response_iss_parameter_supported: true`. | `discovery_includes_iss_parameter_supported` <br/><sub>tests/rfc_compliance.rs:1814</sub> |
+
+## RFC 9396
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§7](https://datatracker.ietf.org/doc/html/rfc9396#section-7) | MUST | Discovery metadata must advertise `authorization_details_types_supported`. | `wave4_rfc9396_rar_advertised_in_discovery` <br/><sub>tests/compliance_wave4.rs:152</sub> |
+
+## RFC 9449
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9449#section-4) | MUST | DPoP proof with invalid `typ` JOSE header must be rejected with `invalid_dpop_proof`. | `test_vector_n_dpop_invalid_typ` <br/><sub>tests/rfc9700_compliance.rs:944</sub> |
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9449#section-4) | MUST | Replayed DPoP proof (same `jti`) must be rejected with `invalid_dpop_proof`. | `test_vector_o_dpop_jti_replay` <br/><sub>tests/rfc9700_compliance.rs:972</sub> |
+| ✅ | [§5](https://datatracker.ietf.org/doc/html/rfc9449#section-5) | MUST | Discovery metadata must advertise `dpop_signing_alg_values_supported`. | `wave4_rfc9449_dpop_signing_alg_values_supported_advertised` <br/><sub>tests/compliance_wave4.rs:75</sub> |
+
+## RFC 9470
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9470#section-4) | MUST | Discovery metadata must advertise `acr_values_supported`. | `wave4_rfc9470_acr_values_supported_advertised` <br/><sub>tests/compliance_wave4.rs:175</sub> |
+
+## RFC 9700
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2.1.1](https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.1) | MUST | Authorization-code replay must cascade-revoke every access/refresh token issued from the original exchange. | `rfc9700_authorization_code_replay_revokes_issued_tokens` <br/><sub>tests/rfc9700_code_replay.rs:54</sub> |
+| ✅ | [§2.1.1](https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.1) | MUST | PKCE `plain` method must be rejected; only S256 is acceptable. | `test_vector_a_plain_pkce_rejected` <br/><sub>tests/rfc9700_compliance.rs:158</sub> |
+| ✅ | [§2.1.1](https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.1) | MUST | Public clients must supply PKCE on the authorization-code flow. | `test_vector_b_public_client_missing_pkce` <br/><sub>tests/rfc9700_compliance.rs:229</sub> |
+| ⚠️ | [§2.1.5](https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.5) | MUST | Authorization-code replay must revoke the entire issued token family. _(ignored: Awaits bead 6.1: token family revocation on code replay)_ | `test_vector_c_authorization_code_replay` <br/><sub>tests/rfc9700_compliance.rs:306</sub> |
+| ⚠️ | [§2.1.5](https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.5) | MUST | Replaying a rotated refresh token must revoke the entire token family. _(ignored: Awaits bead 6.1: token family revocation on refresh replay)_ | `test_vector_d_refresh_token_replay` <br/><sub>tests/rfc9700_compliance.rs:324</sub> |
+| ✅ | [§2.3](https://datatracker.ietf.org/doc/html/rfc9700#section-2.3) | MUST | Token endpoint responses must include `Cache-Control: no-store`. | `test_vector_i_token_cache_control_no_store` <br/><sub>tests/rfc9700_compliance.rs:621</sub> |
+| ✅ | [§2.4](https://datatracker.ietf.org/doc/html/rfc9700#section-2.4) | MUST | Resource Owner Password Credentials grant must be disabled (`unsupported_grant_type`). | `wave2_c3_password_grant_is_rejected` <br/><sub>tests/compliance_wave5.rs:867</sub> |
+| ✅ | [§2.5](https://datatracker.ietf.org/doc/html/rfc9700#section-2.5) | SHOULD | Rate-limit buckets must be keyed per client_id so one client's exhaustion does not affect others. | `invalid_client_buckets_are_isolated_per_client_id` <br/><sub>tests/rfc9700_rate_limit.rs:180</sub> |
+| ✅ | [§2.5](https://datatracker.ietf.org/doc/html/rfc9700#section-2.5) | MUST | Without a configured rate limiter, the token endpoint must still respond 401 `invalid_client` to bad credentials. | `invalid_client_no_limiter_returns_401` <br/><sub>tests/rfc9700_rate_limit.rs:140</sub> |
+| ✅ | [§2.5](https://datatracker.ietf.org/doc/html/rfc9700#section-2.5) | SHOULD | Token endpoint must rate-limit repeated `invalid_client` failures and return 429 when the budget is exhausted. | `invalid_client_rate_limit_returns_429_after_budget_exhausted` <br/><sub>tests/rfc9700_rate_limit.rs:76</sub> |
+| ✅ | [§2.5](https://datatracker.ietf.org/doc/html/rfc9700#section-2.5) | MUST | Replayed JWT client-assertion (same client_id + jti within exp window) must be rejected with `invalid_client`. | `rfc9700_client_secret_jwt_replay_is_rejected` <br/><sub>tests/rfc9700_jti_replay.rs:27</sub> |
+| ✅ | [§2.5](https://datatracker.ietf.org/doc/html/rfc9700#section-2.5) | MUST | A new (client_id, jti) pair from the same client must still be accepted. | `rfc9700_fresh_jti_from_same_client_is_accepted` <br/><sub>tests/rfc9700_jti_replay.rs:175</sub> |
+| ⚠️ | [§2.5](https://datatracker.ietf.org/doc/html/rfc9700#section-2.5) | MUST | A replayed client assertion (same `jti` within exp window) must be rejected. _(ignored: Awaits bead 6.5: JWT client-assertion jti replay store)_ | `test_vector_l_client_assertion_jti_replay` <br/><sub>tests/rfc9700_compliance.rs:843</sub> |
+| ✅ | [§2.5](https://datatracker.ietf.org/doc/html/rfc9700#section-2.5) | SHOULD | Successful token issuance must not consume the `invalid_client` rate-limit bucket. | `valid_requests_do_not_deplete_invalid_client_bucket` <br/><sub>tests/rfc9700_rate_limit.rs:288</sub> |
+| ✅ | [§2.6](https://datatracker.ietf.org/doc/html/rfc9700#section-2.6) | MAY | HTTPS-enforcement middleware must be a no-op when explicitly disabled. | `disabled_by_default_passes_plain_http_through` <br/><sub>tests/rfc9700_https_enforcement.rs:19</sub> |
+| ✅ | [§2.6](https://datatracker.ietf.org/doc/html/rfc9700#section-2.6) | MUST | Plain-HTTP requests must be redirected (308) to the corresponding HTTPS URL when enforcement is on. | `enforced_plain_http_is_redirected_308_to_https` <br/><sub>tests/rfc9700_https_enforcement.rs:45</sub> |
+| ✅ | [§2.6](https://datatracker.ietf.org/doc/html/rfc9700#section-2.6) | MUST | HTTPS-enforcement must accept TLS-terminated upstream traffic via trusted X-Forwarded-Proto. | `trusted_forwarded_proto_https_passes_through` <br/><sub>tests/rfc9700_https_enforcement.rs:96</sub> |
+| ✅ | [§2.6](https://datatracker.ietf.org/doc/html/rfc9700#section-2.6) | MUST | Untrusted X-Forwarded-Proto must not bypass HTTPS enforcement (anti-spoof). | `untrusted_forwarded_proto_header_is_ignored` <br/><sub>tests/rfc9700_https_enforcement.rs:131</sub> |
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9700#section-4) | MUST | Discovery doc must satisfy RFC 9700 BCP constraints (S256-only, no password, no implicit, iss param). | `test_vector_k_discovery_json_constraints` <br/><sub>tests/rfc9700_compliance.rs:781</sub> |
+| ✅ | [§4.1](https://datatracker.ietf.org/doc/html/rfc9700#section-4.1) | MUST | redirect_uri must be matched byte-for-byte; trailing-slash differences must be rejected. | `test_vector_f_redirect_uri_trailing_slash` <br/><sub>tests/rfc9700_compliance.rs:445</sub> |
+| ✅ | [§4.1](https://datatracker.ietf.org/doc/html/rfc9700#section-4.1) | MUST | redirect_uri carrying additional query parameters must be rejected. | `test_vector_g_redirect_uri_extra_query_param` <br/><sub>tests/rfc9700_compliance.rs:524</sub> |
+| ✅ | [§4.7](https://datatracker.ietf.org/doc/html/rfc9700#section-4.7) | MAY | Default `require_state=false` must allow authorize requests without a `state` parameter. | `require_state_off_accepts_missing_state` <br/><sub>tests/rfc9700_require_state.rs:151</sub> |
+| ✅ | [§4.7](https://datatracker.ietf.org/doc/html/rfc9700#section-4.7) | MUST | `require_state=true` must accept authorize requests when `state` is provided. | `require_state_on_accepts_present_state` <br/><sub>tests/rfc9700_require_state.rs:183</sub> |
+| ✅ | [§4.7](https://datatracker.ietf.org/doc/html/rfc9700#section-4.7) | MUST | `require_state=true` must reject authorize requests missing a `state` parameter. | `require_state_on_rejects_missing_state` <br/><sub>tests/rfc9700_require_state.rs:167</sub> |
+| ⚠️ | [§4.11](https://datatracker.ietf.org/doc/html/rfc9700#section-4.11) | SHOULD | Login form POST handler should redirect with 303 See Other (not 302). _(ignored: Awaits bead 6.7: 302 → 303 See Other for login redirects)_ | `test_vector_h_login_redirect_303` <br/><sub>tests/rfc9700_compliance.rs:604</sub> |
+| ✅ | [§4.12](https://datatracker.ietf.org/doc/html/rfc9700#section-4.12) | MUST | /authorize and /consent must set X-Frame-Options: DENY or CSP frame-ancestors 'none'. | `test_vector_j_authorize_security_headers` <br/><sub>tests/rfc9700_compliance.rs:689</sub> |
+
+## RFC 9701
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9701#section-4) | MUST | Introspection must return a signed JWT response when `Accept: application/token-introspection+jwt`. | `rfc9701_jwt_accept_header_returns_jwt_introspection_response` <br/><sub>tests/compliance_wave3.rs:442</sub> |
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9701#section-4) | MUST | JWT introspection payload must include a `token_introspection` claim with standard fields. | `rfc9701_jwt_payload_contains_token_introspection_claim` <br/><sub>tests/compliance_wave3.rs:604</sub> |
+| ✅ | [§4](https://datatracker.ietf.org/doc/html/rfc9701#section-4) | MUST | Introspection without special Accept must return the standard JSON response. | `rfc9701_standard_accept_returns_json_introspection_response` <br/><sub>tests/compliance_wave3.rs:531</sub> |
+
+## RFC 9728
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§3](https://datatracker.ietf.org/doc/html/rfc9728#section-3) | MUST | Protected resource metadata must include an `authorization_servers` array. | `wave4_rfc9728_protected_resource_metadata_has_authorization_servers` <br/><sub>tests/compliance_wave4.rs:238</sub> |
+| ✅ | [§3](https://datatracker.ietf.org/doc/html/rfc9728#section-3) | MUST | Protected resource metadata must include a `resource` field. | `wave4_rfc9728_protected_resource_metadata_has_resource_field` <br/><sub>tests/compliance_wave4.rs:216</sub> |
+| ✅ | [§3](https://datatracker.ietf.org/doc/html/rfc9728#section-3) | MUST | /.well-known/oauth-protected-resource must return 200. | `wave4_rfc9728_protected_resource_metadata_returns_200` <br/><sub>tests/compliance_wave4.rs:195</sub> |
+
+## OpenID Connect Back-Channel Logout 1.0
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2.1](https://openid.net/specs/openid-connect-backchannel-1_0.html#ClientMetadata) | MUST | Dynamic client registration must accept `backchannel_logout_uri` and `backchannel_logout_session_required`. | `wave6_client_registration_includes_logout_fields` <br/><sub>tests/compliance_wave6.rs:586</sub> |
+
+## OpenID Connect Core 1.0
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) | MUST | id_token `aud` claim must contain the requesting RP's client_id. | `oidc_core_s3_1_id_token_aud_matches_client` <br/><sub>tests/compliance_oidc_core.rs:409</sub> |
+| ✅ | [§2](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) | MUST | id_token must have `iat` and `exp` NumericDate claims with `exp` > `iat`. | `oidc_core_s3_1_id_token_has_iat_and_exp` <br/><sub>tests/compliance_oidc_core.rs:455</sub> |
+| ✅ | [§2](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) | MUST | id_token `iss` claim must match the configured issuer value exactly. | `oidc_core_s3_1_id_token_iss_matches_config` <br/><sub>tests/compliance_oidc_core.rs:368</sub> |
+| ✅ | [§2](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) | MUST | id_token must contain a `sub` claim identifying the end-user. | `oidc_core_s3_1_id_token_sub_claim_present` <br/><sub>tests/compliance_oidc_core.rs:329</sub> |
+| ✅ | [§3.1](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) | MUST | id_token must be a compact-serialised JWT (header.payload.signature). | `oidc_core_s3_1_id_token_is_valid_jwt` <br/><sub>tests/compliance_oidc_core.rs:289</sub> |
+| ✅ | [§3.1](https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse) | MUST | Token response without `openid` scope must not include an id_token. | `oidc_core_s3_1_no_id_token_without_openid_scope` <br/><sub>tests/compliance_oidc_core.rs:543</sub> |
+| ✅ | [§3.1](https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse) | MUST | Authorization-code flow with `openid` scope must include an id_token in the token response. | `oidc_core_s3_1_openid_scope_triggers_id_token` <br/><sub>tests/compliance_oidc_core.rs:251</sub> |
+| ✅ | [§3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) | MUST | `max_age=0` must force re-authentication when auth_time is unavailable or stale. | `max_age_zero_forces_reauthentication` <br/><sub>tests/rfc_compliance.rs:1490</sub> |
+| ✅ | [§3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) | MUST | A nonce in the authorization request must be echoed verbatim in the id_token. | `oidc_core_s3_1_2_1_nonce_echoed_in_id_token` <br/><sub>tests/compliance_oidc_core.rs:497</sub> |
+| ✅ | [§3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) | MUST | `prompt=login` must force re-authentication even when an active session exists. | `prompt_login_forces_reauthentication` <br/><sub>tests/rfc_compliance.rs:1407</sub> |
+| ✅ | [§3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) | MUST | `prompt=none` without an active session must return a `login_required` error redirect. | `prompt_none_without_session_returns_login_required` <br/><sub>tests/rfc_compliance.rs:1324</sub> |
+| ✅ | [§3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) | MUST | `prompt=consent` must proceed to authorization (auto-approve in test harness). | `wave6_prompt_consent_proceeds_after_auto_approve` <br/><sub>tests/compliance_wave6.rs:454</sub> |
+| ✅ | [§3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) | MUST | `prompt=select_account` must force account selection / re-authentication. | `wave6_prompt_select_account_forces_reauth` <br/><sub>tests/compliance_wave6.rs:521</sub> |
+| ✅ | [§3.3](https://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth) | MUST | Hybrid `code id_token` flow must return both `code` and `id_token` in the response fragment. | `wave5_hybrid_code_id_token_delivers_both_in_fragment` <br/><sub>tests/compliance_wave5.rs:370</sub> |
+| ✅ | [§3.3](https://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth) | MUST | Hybrid `code id_token` without `openid` scope must not return an id_token. | `wave5_hybrid_no_openid_scope_omits_id_token` <br/><sub>tests/compliance_wave5.rs:441</sub> |
+| ✅ | [§5.3](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) | MUST | UserInfo endpoint must return 401 with WWW-Authenticate: Bearer when token is missing. | `oidc_core_userinfo_s5_3_missing_token_returns_401` <br/><sub>tests/compliance_oidc_core.rs:632</sub> |
+| ✅ | [§5.3](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) | MUST | UserInfo response with a valid token must include the `sub` claim. | `oidc_core_userinfo_s5_3_sub_claim_present` <br/><sub>tests/compliance_oidc_core.rs:585</sub> |
+| ✅ | [§5.4](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) | MUST | UserInfo must return profile claims (e.g. preferred_username) when `profile` scope is granted. | `userinfo_returns_real_claims_for_auth_code_flow` <br/><sub>tests/rfc_compliance.rs:1146</sub> |
+| ✅ | [§5.4](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) | MUST | UserInfo must return the `email` claim when the access token has the `email` scope. | `userinfo_returns_real_email_when_email_scope_requested` <br/><sub>tests/rfc_compliance.rs:1022</sub> |
+| ✅ | [§5.5](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter) | MUST | Discovery `claims_supported` must advertise `acr` and `auth_time` to indicate Claims Request support. | `wave4_oidc_claims_request_acr_auth_time_in_claims_supported` <br/><sub>tests/compliance_wave4.rs:311</sub> |
+
+## OpenID Connect Discovery 1.0
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§3](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) | MUST | OIDC discovery metadata must include `userinfo_endpoint`. | `rfc8414_s2_userinfo_endpoint_present` <br/><sub>tests/compliance_rfc8414.rs:192</sub> |
+| ✅ | [§3](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) | MUST | Discovery `response_modes_supported` must include `fragment`. | `wave5_discovery_response_modes_includes_fragment` <br/><sub>tests/compliance_wave5.rs:963</sub> |
+| ✅ | [§3](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) | MUST | Discovery `response_types_supported` must include `code id_token` for hybrid flow. | `wave5_discovery_response_types_includes_code_id_token` <br/><sub>tests/compliance_wave5.rs:932</sub> |
+
+## OpenID Connect Front-Channel Logout 1.0
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§3](https://openid.net/specs/openid-connect-frontchannel-1_0.html#RPLogout) | MUST | Logout endpoint must render front-channel logout iframes for clients with `frontchannel_logout_uri`. | `wave6_logout_renders_frontchannel_iframes` <br/><sub>tests/compliance_wave6.rs:317</sub> |
+
+## OAuth 2.0 Multiple Response Type Encoding Practices
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes) | MUST | `response_mode=fragment` must encode authorization response in URL fragment. | `wave5_response_mode_fragment_delivers_code_in_fragment` <br/><sub>tests/compliance_wave5.rs:247</sub> |
+| ✅ | [§2](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes) | MUST | An unsupported `response_mode` value must produce `invalid_request`. | `wave5_unsupported_response_mode_is_rejected` <br/><sub>tests/compliance_wave5.rs:321</sub> |
+
+## OpenID Connect Dynamic Client Registration 1.0
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§2](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata) | MUST | Registration must accept and round-trip OIDC client metadata (contacts, *_uri fields, response_types). | `oidc_metadata_preserved_in_registration` <br/><sub>tests/phase2_rfc_compliance.rs:933</sub> |
+
+## OpenID Connect RP-Initiated Logout 1.0
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§3](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout) | MUST | Logout endpoint must reject `id_token_hint` whose `aud` does not match a registered client. | `logout_with_invalid_aud_id_token_hint_returns_error` <br/><sub>tests/rfc_compliance.rs:1578</sub> |
+| ✅ | [§3](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout) | MUST | Logout must accept post_logout_redirect_uri only when registered in post_logout_redirect_uris. | `wave6_logout_accepts_registered_post_logout_redirect_uri` <br/><sub>tests/compliance_wave6.rs:368</sub> |
+| ✅ | [§3](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout) | MUST | Logout must reject unregistered post_logout_redirect_uri values. | `wave6_logout_rejects_unregistered_post_logout_redirect_uri` <br/><sub>tests/compliance_wave6.rs:408</sub> |
+| ✅ | [§3](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout) | SHOULD | Logout endpoint must accept a simple GET (no id_token_hint, no redirect) and return 200. | `wave6_simple_logout_returns_ok` <br/><sub>tests/compliance_wave6.rs:651</sub> |
+
+## OpenID Connect Session Management 1.0
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§3](https://openid.net/specs/openid-connect-session-1_0.html#OPiframe) | MUST | check_session_iframe must return HTML with a postMessage handler. | `wave6_check_session_iframe_returns_html` <br/><sub>tests/compliance_wave6.rs:266</sub> |
+| ✅ | [§4](https://openid.net/specs/openid-connect-session-1_0.html#OPMetadata) | MUST | Discovery must advertise `check_session_iframe` for OIDC Session Management. | `wave6_discovery_includes_session_management_fields` <br/><sub>tests/compliance_wave6.rs:211</sub> |
+
+## OAuth 2.0 Token Status List (draft-ietf-oauth-status-list)
+
+| Status | Section | Level | Requirement | Test |
+|---|---|---|---|---|
+| ✅ | [§5](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-status-list) | MUST | Token Status List discovery endpoint must return 200. | `wave4_token_status_list_returns_200` <br/><sub>tests/compliance_wave4.rs:267</sub> |
+| ✅ | [§5](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-status-list) | MUST | Token Status List response must be valid JSON. | `wave4_token_status_list_returns_valid_json` <br/><sub>tests/compliance_wave4.rs:288</sub> |
 
 ---
 
-## RFC 9126 — Pushed Authorization Requests (PAR)
-
-Test file: [`tests/compliance_wave3.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_wave3.rs)
-
-| Section | Requirement | Test Function | Status |
-| ------- | ----------- | ------------- | ------ |
-| §2.2 | Public client with valid params receives `request_uri` and `expires_in: 60` | `rfc9126_par_public_client_returns_request_uri` | ✅ |
-| §2.1 | PAR request missing `response_type` is rejected | `rfc9126_par_missing_response_type_is_rejected` | ✅ |
-| §2.1 | PAR request with duplicate parameters is rejected | `rfc9126_par_duplicate_param_is_rejected` | ✅ |
-| §2.1 | Confidential client sending PAR without authentication is rejected | `rfc9126_par_confidential_client_no_secret_rejected` | ✅ |
-| §2.1 | Confidential client with valid Basic auth succeeds | `rfc9126_par_confidential_client_with_basic_auth_succeeds` | ✅ |
-
----
-
-## RFC 8707 — Resource Indicators for OAuth 2.0
-
-Test file: [`tests/compliance_wave3.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_wave3.rs)
-
-| Section | Requirement | Test Function | Status |
-| ------- | ----------- | ------------- | ------ |
-| §2 | `resource` parameter in client_credentials request is accepted and echoed in token `aud` | `rfc8707_resource_indicator_accepted_in_client_credentials` | ✅ |
-
----
-
-## RFC 9701 — JWT Response for OAuth Token Introspection
-
-Test file: [`tests/compliance_wave3.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_wave3.rs)
-
-| Section | Requirement | Test Function | Status |
-| ------- | ----------- | ------------- | ------ |
-| §4 | `Accept: application/token-introspection+jwt` triggers JWT response with matching `Content-Type` | `rfc9701_jwt_accept_header_returns_jwt_introspection_response` | ✅ |
-| §4 | Without the `Accept` header, introspection returns standard JSON | `rfc9701_standard_accept_returns_json_introspection_response` | ✅ |
-| §4 | JWT payload contains `token_introspection` claim with `active`, `scope`, `client_id` | `rfc9701_jwt_payload_contains_token_introspection_claim` | ✅ |
-
----
-
-## RFC 7591 — OAuth 2.0 Dynamic Client Registration
-
-Test file: [`tests/phase2_rfc_compliance.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/phase2_rfc_compliance.rs)
-
-| Section | Requirement | Test Function | Status |
-| ------- | ----------- | ------------- | ------ |
-| §3.1 | Dynamic registration returns `client_id` and `registration_access_token` | `rfc7591_dynamic_registration_success` | ✅ |
-| §3.2 | Defaults for `grant_types` and `response_types` are applied when omitted | `rfc7591_defaults_grant_and_response_types` | ✅ |
-| §2 | Public client registered with `token_endpoint_auth_method: none` | `rfc7591_public_client_no_secret` | ✅ |
-| §3.1 | Registration with invalid `redirect_uris` is rejected | `rfc7591_rejects_invalid_redirect_uris` | ✅ |
-| §3.2 | `jwks` and `jwks_uri` are mutually exclusive | `rfc7591_jwks_and_jwks_uri_mutually_exclusive` | ✅ |
-| §3.2 | `private_key_jwt` registration requires `jwks` or `jwks_uri` | `rfc7591_private_key_jwt_requires_jwks` | ✅ |
-
----
-
-## RFC 7592 — OAuth 2.0 Dynamic Client Registration Management
-
-Test file: [`tests/phase2_rfc_compliance.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/phase2_rfc_compliance.rs)
-
-| Section | Requirement | Test Function | Status |
-| ------- | ----------- | ------------- | ------ |
-| §2 | `GET /connect/register/{id}` returns client configuration | `rfc7592_read_client_configuration` | ✅ |
-| §2 | `PUT /connect/register/{id}` updates client metadata | `rfc7592_update_client_configuration` | ✅ |
-| §2 | `DELETE /connect/register/{id}` removes the client | `rfc7592_delete_client` | ✅ |
-
----
-
-## RFC 7523 — JSON Web Token (JWT) Profile for Client Authentication
-
-Test file: [`tests/phase2_rfc_compliance.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/phase2_rfc_compliance.rs)
-
-| Section | Requirement | Test Function | Status |
-| ------- | ----------- | ------------- | ------ |
-| §2.2 | `client_secret_jwt` assertion with correct HMAC secret succeeds | `rfc7523_client_secret_jwt_authentication` | ✅ |
-| §2.2 | `client_secret_jwt` assertion with wrong secret fails | `rfc7523_client_secret_jwt_wrong_secret_fails` | ✅ |
-| §2.2 | `private_key_jwt` assertion with RSA key pair succeeds | `rfc7523_private_key_jwt_authentication` | ✅ |
-| §2 | OIDC registration metadata is preserved after registration | `oidc_metadata_preserved_in_registration` | ✅ |
-
----
-
-## Wave 4 — DPoP, mTLS, Token Exchange, RAR, Step-Up, Protected Resource Metadata
-
-Test file: [`tests/compliance_wave4.rs`](https://github.com/ianlintner/rust-oauth2-server/blob/main/tests/compliance_wave4.rs)
-
-| Feature | RFC | Requirement | Test Function | Status |
-| ------- | --- | ----------- | ------------- | ------ |
-| DPoP | RFC 9449 | Discovery advertises `dpop_signing_alg_values_supported` including `ES256` | `wave4_rfc9449_dpop_signing_alg_values_supported_advertised` | ✅ |
-| mTLS | RFC 8705 | Discovery advertises `tls_client_certificate_bound_access_tokens: true` | `wave4_rfc8705_mtls_advertised_in_discovery` | ✅ |
-| Token Exchange | RFC 8693 | Discovery includes `urn:ietf:params:oauth:grant-type:token-exchange` in `grant_types_supported` | `wave4_rfc8693_token_exchange_grant_type_in_discovery` | ✅ |
-| RAR | RFC 9396 | Discovery advertises `authorization_details_types_supported` | `wave4_rfc9396_rar_advertised_in_discovery` | ✅ |
-| Step-Up Auth | RFC 9470 | Discovery advertises `acr_values_supported` | `wave4_rfc9470_acr_values_supported_advertised` | ✅ |
-| Protected Resource Metadata | RFC 9728 | `/.well-known/oauth-protected-resource` returns 200 | `wave4_rfc9728_protected_resource_metadata_returns_200` | ✅ |
-| Protected Resource Metadata | RFC 9728 | Response includes `resource` field | `wave4_rfc9728_protected_resource_metadata_has_resource_field` | ✅ |
-| Protected Resource Metadata | RFC 9728 | Response includes `authorization_servers` field | `wave4_rfc9728_protected_resource_metadata_has_authorization_servers` | ✅ |
-| Token Status List | Draft | `/.well-known/oauth-authorization-server/status` returns 200 | `wave4_token_status_list_returns_200` | ✅ |
-| Token Status List | Draft | Response is valid JSON | `wave4_token_status_list_returns_valid_json` | ✅ |
-| OIDC Claims Request | OIDC Core §5.5 | Discovery advertises `acr` and `auth_time` in `claims_supported` | `wave4_oidc_claims_request_acr_auth_time_in_claims_supported` | ✅ |
+Legend:  ✅ passing test &middot; ❌ failing test &middot; ⚠️ ignored / pending &middot; · status unknown (no test results provided)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,3 +75,5 @@ nav:
       - Extending: development/extending.md
       - Testing: development/testing.md
       - Contributing: development/contributing.md
+  - Compliance:
+      - RFC matrix: compliance/RFC_COMPLIANCE.md

--- a/src/bin/compliance_report.rs
+++ b/src/bin/compliance_report.rs
@@ -1,0 +1,956 @@
+//! Compliance report generator for the RFC test suite.
+//!
+//! Walks `tests/compliance_*.rs`, parses structured `@rfc / @section /
+//! @requirement / @level / @url` doc-comment annotations on each
+//! `#[actix_web::test]` (or `#[test]`), optionally folds in runtime
+//! pass/fail/ignored status from a `cargo test --message-format=json`
+//! transcript, and emits three reports:
+//!
+//! * `docs/compliance/RFC_COMPLIANCE.md`     — published to the docs site
+//! * `target/compliance-report.json`         — machine-readable artifact
+//! * `target/compliance-junit.xml`           — JUnit XML for CI integrations
+//!
+//! Usage
+//! -----
+//! ```text
+//! # Just regenerate Markdown / JSON / JUnit from source annotations:
+//! cargo run --bin compliance_report
+//!
+//! # Fold in real test results:
+//! cargo test --tests --no-fail-fast -- -Z unstable-options \
+//!     --format json --report-time | tee target/compliance-tests.jsonl
+//! cargo run --bin compliance_report -- --results target/compliance-tests.jsonl
+//!
+//! # Stable Rust alternative (libtest-mimic / test harness):
+//! CARGO_TERM_COLOR=never cargo test --tests --no-fail-fast \
+//!     -- --format=json -Zunstable-options 2> /dev/null \
+//!     > target/compliance-tests.jsonl || true
+//! cargo run --bin compliance_report -- --results target/compliance-tests.jsonl
+//! ```
+//!
+//! Design notes
+//! ------------
+//! Pure stdlib + `serde_json` — no `syn`, `regex`, or proc-macro deps.
+//! Annotation extraction is line-oriented and tolerant of formatting
+//! variations (leading whitespace, indented `///`).
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+// -----------------------------------------------------------------------------
+// Data model
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct Annotation {
+    /// Function name as written in source (e.g. `rfc6749_s4_1_1_authorize_requires_response_type`).
+    test_name: String,
+    /// Source file relative to repo root (e.g. `tests/compliance_rfc6749.rs`).
+    source_file: String,
+    /// 1-indexed line number of the `fn` declaration.
+    source_line: usize,
+    /// Cargo test target name (e.g. `compliance_rfc6749`). Used to build the
+    /// fully qualified test path that libtest reports in JSON output.
+    test_target: String,
+    /// RFC number (e.g. `"6749"`).
+    rfc: String,
+    /// Section within the RFC (e.g. `"4.1.1"`).
+    section: String,
+    /// Plain-language requirement string (one line).
+    requirement: String,
+    /// RFC 2119 keyword: `"MUST" | "SHOULD" | "MAY"` (uppercase).
+    level: String,
+    /// Direct link to the relevant RFC section.
+    url: String,
+    /// `true` if the test is gated with `#[ignore]`. Reason captured separately.
+    ignored: bool,
+    /// Reason from `#[ignore = "..."]`, if any.
+    ignore_reason: Option<String>,
+    /// Resolved status from cargo test JSON (`"passed"`, `"failed"`,
+    /// `"ignored"`, or `"unknown"` when no results file was provided).
+    status: String,
+}
+
+#[derive(Default)]
+struct ResultsMap {
+    /// `compliance_rfc6749::rfc6749_s4_1_1_authorize_requires_response_type` ->
+    /// `"ok" | "failed" | "ignored"`.
+    by_full_name: BTreeMap<String, String>,
+}
+
+// -----------------------------------------------------------------------------
+// Source parsing
+// -----------------------------------------------------------------------------
+
+/// Parse a single test file and return all annotated test functions.
+///
+/// Annotations are recognised when at least `@rfc` and `@section` tags are
+/// present in the contiguous `///` comment block immediately above the
+/// `#[actix_web::test]` / `#[test]` attribute on a `fn` declaration.
+fn parse_source_file(path: &Path) -> Vec<Annotation> {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+
+    let source_file = path
+        .strip_prefix(repo_root())
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    let test_target = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string();
+
+    let mut out = Vec::new();
+    let mut doc_buffer: Vec<String> = Vec::new();
+    let mut saw_test_attr = false;
+    let mut ignored = false;
+    let mut ignore_reason: Option<String> = None;
+
+    for (idx, raw_line) in contents.lines().enumerate() {
+        let trimmed = raw_line.trim_start();
+
+        if let Some(rest) = trimmed.strip_prefix("///") {
+            // Inside a doc-comment block: accumulate.
+            doc_buffer.push(rest.trim_start().to_string());
+            continue;
+        }
+
+        if trimmed.starts_with("#[") {
+            // Attribute line. Track #[test] / #[actix_web::test] / #[ignore].
+            if trimmed.starts_with("#[test]")
+                || trimmed.starts_with("#[actix_web::test]")
+                || trimmed.starts_with("#[tokio::test")
+            {
+                saw_test_attr = true;
+            }
+            if trimmed.starts_with("#[ignore") {
+                ignored = true;
+                if let Some(eq_pos) = trimmed.find('=') {
+                    let after_eq = &trimmed[eq_pos + 1..];
+                    if let Some(start) = after_eq.find('"') {
+                        if let Some(end_rel) = after_eq[start + 1..].find('"') {
+                            ignore_reason =
+                                Some(after_eq[start + 1..start + 1 + end_rel].to_string());
+                        }
+                    }
+                }
+            }
+            continue;
+        }
+
+        if trimmed.starts_with("fn ") || trimmed.starts_with("async fn ") {
+            if saw_test_attr {
+                if let Some(name) = extract_fn_name(trimmed) {
+                    if let Some(ann) = build_annotation(
+                        &doc_buffer,
+                        name,
+                        idx + 1,
+                        &source_file,
+                        &test_target,
+                        ignored,
+                        ignore_reason.clone(),
+                    ) {
+                        out.push(ann);
+                    }
+                }
+            }
+            // Reset for next item regardless of whether we matched.
+            doc_buffer.clear();
+            saw_test_attr = false;
+            ignored = false;
+            ignore_reason = None;
+            continue;
+        }
+
+        // Any other non-blank line breaks the doc-buffer association.
+        if !trimmed.is_empty() {
+            doc_buffer.clear();
+            saw_test_attr = false;
+            ignored = false;
+            ignore_reason = None;
+        }
+    }
+
+    out
+}
+
+fn extract_fn_name(line: &str) -> Option<String> {
+    // Strip leading "async fn " or "fn " and read identifier up to '('.
+    let after_keyword = if let Some(rest) = line.strip_prefix("async fn ") {
+        rest
+    } else if let Some(rest) = line.strip_prefix("fn ") {
+        rest
+    } else {
+        return None;
+    };
+    let name: String = after_keyword
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+fn build_annotation(
+    doc_buffer: &[String],
+    fn_name: String,
+    fn_line: usize,
+    source_file: &str,
+    test_target: &str,
+    ignored: bool,
+    ignore_reason: Option<String>,
+) -> Option<Annotation> {
+    let mut rfc = None;
+    let mut section = None;
+    let mut requirement = None;
+    let mut level = None;
+    let mut url = None;
+
+    for line in doc_buffer {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix('@') else {
+            continue;
+        };
+        let (key, value) = match rest.split_once(char::is_whitespace) {
+            Some(pair) => pair,
+            None => continue,
+        };
+        let value = value.trim().to_string();
+        match key {
+            "rfc" => rfc = Some(value),
+            "section" => section = Some(value),
+            "requirement" => requirement = Some(value),
+            "level" => level = Some(value.to_uppercase()),
+            "url" => url = Some(value),
+            _ => {}
+        }
+    }
+
+    // Require at minimum @rfc + @section, otherwise this isn't a tagged test.
+    let rfc = rfc?;
+    let section = section?;
+
+    Some(Annotation {
+        test_name: fn_name,
+        source_file: source_file.to_string(),
+        source_line: fn_line,
+        test_target: test_target.to_string(),
+        rfc,
+        section,
+        requirement: requirement.unwrap_or_default(),
+        level: level.unwrap_or_else(|| "MUST".to_string()),
+        url: url.unwrap_or_default(),
+        ignored,
+        ignore_reason,
+        // Filled in later when results are folded in.
+        status: "unknown".to_string(),
+    })
+}
+
+// -----------------------------------------------------------------------------
+// Cargo test JSON parsing
+// -----------------------------------------------------------------------------
+
+fn parse_results_file(path: &Path) -> ResultsMap {
+    let mut map = ResultsMap::default();
+    let Ok(contents) = fs::read_to_string(path) else {
+        eprintln!(
+            "warning: could not read results file {} — falling back to status=unknown",
+            path.display()
+        );
+        return map;
+    };
+    // Heuristically detect format: nightly libtest emits JSONL, stable emits
+    // pretty text lines (`test <name> ... ok`). We parse whichever appears.
+    let looks_like_json = contents
+        .lines()
+        .find(|l| !l.trim().is_empty())
+        .map(|l| l.trim_start().starts_with('{'))
+        .unwrap_or(false);
+
+    if looks_like_json {
+        parse_results_jsonl(&contents, &mut map);
+    } else {
+        parse_results_pretty(&contents, &mut map);
+    }
+    map
+}
+
+fn parse_results_jsonl(contents: &str, map: &mut ResultsMap) {
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // libtest JSON event:  {"type":"test","event":"ok","name":"<crate>::<fn>"}
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if json.get("type").and_then(|v| v.as_str()) != Some("test") {
+            continue;
+        }
+        let Some(name) = json.get("name").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(event) = json.get("event").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let status = match event {
+            "ok" => "passed",
+            "failed" => "failed",
+            "ignored" => "ignored",
+            _ => continue,
+        };
+        map.by_full_name
+            .insert(name.to_string(), status.to_string());
+    }
+}
+
+/// Parse stable libtest "pretty" format:
+///
+/// ```text
+/// test rfc6749_s4_1_1_authorize_requires_response_type ... ok
+/// test some::other::test ... FAILED
+/// test foo ... ignored
+/// ```
+///
+/// Tests that print to stdout while running can interleave their output
+/// between `test <name> ... ` and the trailing status token, splitting the
+/// status onto a later line:
+///
+/// ```text
+/// test test_vector_q_jar_request_parameter ... interleaved stdout
+/// ok
+/// ```
+///
+/// We track a `pending_name` for any `test <name> ... ` line whose suffix
+/// did NOT contain a recognised status token, and resolve it on the next
+/// bare `ok|FAILED|ignored` line.
+///
+/// Test names lack the crate prefix in stable pretty output (e.g.
+/// `rfc6749_s4_1_1_…` instead of `compliance_rfc6749::rfc6749_s4_1_1_…`),
+/// so we record them under the bare name and reconcile downstream.
+fn parse_results_pretty(contents: &str, map: &mut ResultsMap) {
+    let mut pending_name: Option<String> = None;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+
+        // Resolve a previously deferred status if this line is a bare token.
+        if let Some(name) = pending_name.take() {
+            let token = trimmed
+                .split_whitespace()
+                .next()
+                .unwrap_or("")
+                .trim_end_matches(',');
+            if let Some(status) = match_status_token(token) {
+                map.by_full_name.insert(name, status.to_string());
+                continue;
+            }
+            // Otherwise drop the pending name; the test output is malformed
+            // for our purposes and the test will surface as `unknown`.
+        }
+
+        let Some(rest) = trimmed.strip_prefix("test ") else {
+            continue;
+        };
+        let Some((name, after)) = rest.split_once(" ... ") else {
+            continue;
+        };
+        // `after` may look like "ok", "FAILED", "ignored", "ok (1.23s)",
+        // or — when the test wrote to stdout mid-run — arbitrary user
+        // output with the real status on a later line.
+        let status_token = after
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .trim_end_matches(',');
+        match match_status_token(status_token) {
+            Some(status) => {
+                map.by_full_name
+                    .insert(name.trim().to_string(), status.to_string());
+            }
+            None => {
+                // Defer until we see a bare ok/FAILED/ignored on a later line.
+                pending_name = Some(name.trim().to_string());
+            }
+        }
+    }
+}
+
+fn match_status_token(token: &str) -> Option<&'static str> {
+    match token.to_ascii_lowercase().as_str() {
+        "ok" => Some("passed"),
+        "failed" => Some("failed"),
+        "ignored" => Some("ignored"),
+        _ => None,
+    }
+}
+
+fn fill_status(annotations: &mut [Annotation], results: &ResultsMap) {
+    for ann in annotations.iter_mut() {
+        // Nightly libtest JSON reports `<target>::<fn_name>`; stable pretty
+        // output uses just `<fn_name>`. Try both.
+        let qualified = format!("{}::{}", ann.test_target, ann.test_name);
+        if let Some(s) = results.by_full_name.get(&qualified) {
+            ann.status.clone_from(s);
+        } else if let Some(s) = results.by_full_name.get(&ann.test_name) {
+            ann.status.clone_from(s);
+        } else if ann.ignored {
+            // No results entry — fall back to attribute-only status.
+            ann.status = "ignored".to_string();
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Output: Markdown
+// -----------------------------------------------------------------------------
+
+fn render_markdown(annotations: &[Annotation], have_results: bool) -> String {
+    let mut grouped: BTreeMap<String, Vec<&Annotation>> = BTreeMap::new();
+    for ann in annotations {
+        grouped.entry(ann.rfc.clone()).or_default().push(ann);
+    }
+    // Sort RFC groups: numeric RFCs ascending → OIDC specs (alpha) → drafts (alpha) → other.
+    let mut rfc_order: Vec<String> = grouped.keys().cloned().collect();
+    rfc_order.sort_by_key(|a| rfc_sort_key(a));
+
+    let mut out = String::new();
+    out.push_str("# RFC Compliance Matrix\n\n");
+    out.push_str(
+        "_This file is generated by `cargo run --bin compliance_report`. \
+         Do not edit by hand — re-run the generator to regenerate._\n\n",
+    );
+
+    // Top-level summary
+    let total = annotations.len();
+    let passed = annotations.iter().filter(|a| a.status == "passed").count();
+    let failed = annotations.iter().filter(|a| a.status == "failed").count();
+    let ignored = annotations.iter().filter(|a| a.status == "ignored").count();
+    let unknown = annotations.iter().filter(|a| a.status == "unknown").count();
+
+    out.push_str("## Summary\n\n");
+    out.push_str(&format!("- **Total annotated tests:** {total}\n"));
+    if have_results {
+        out.push_str(&format!("- **Passing:** {passed}\n"));
+        out.push_str(&format!("- **Failing:** {failed}\n"));
+        out.push_str(&format!("- **Ignored:** {ignored}\n"));
+        if unknown > 0 {
+            out.push_str(&format!("- **Unknown (no result reported):** {unknown}\n"));
+        }
+        let denom = (passed + failed + ignored).max(1);
+        let score = (passed * 100) / denom;
+        out.push_str(&format!(
+            "- **Compliance score (passed / passed+failed+ignored):** {score}%\n"
+        ));
+    } else {
+        out.push_str("- _Run with `--results <jsonl>` to fold in `cargo test` outcomes._\n");
+    }
+    out.push('\n');
+
+    // Per-RFC tables
+    for rfc in &rfc_order {
+        let entries = &grouped[rfc];
+        out.push_str(&format!("## {}\n\n", rfc_heading(rfc)));
+        out.push_str("| Status | Section | Level | Requirement | Test |\n");
+        out.push_str("|---|---|---|---|---|\n");
+        let mut sorted = entries.clone();
+        sorted.sort_by(|a, b| {
+            section_sort_key(&a.section)
+                .cmp(&section_sort_key(&b.section))
+                .then(a.test_name.cmp(&b.test_name))
+        });
+        for ann in sorted {
+            let status_emoji = match ann.status.as_str() {
+                "passed" => "✅",
+                "failed" => "❌",
+                "ignored" => "⚠️",
+                _ => "·",
+            };
+            let section_link = if ann.url.is_empty() {
+                format!("§{}", ann.section)
+            } else {
+                format!("[§{}]({})", ann.section, ann.url)
+            };
+            // Render test name as bare code with file location appended.
+            // Avoids broken relative links under `mkdocs strict: true` while
+            // staying useful when reading the file directly on GitHub.
+            let test_link = format!(
+                "`{}` <br/><sub>{}:{}</sub>",
+                ann.test_name, ann.source_file, ann.source_line
+            );
+            let level = if ann.level.is_empty() {
+                "—".to_string()
+            } else {
+                ann.level.clone()
+            };
+            let mut req = escape_md_table_cell(&ann.requirement);
+            if ann.ignored {
+                if let Some(reason) = &ann.ignore_reason {
+                    req.push_str(&format!(" _(ignored: {})_", escape_md_table_cell(reason)));
+                } else {
+                    req.push_str(" _(ignored)_");
+                }
+            }
+            out.push_str(&format!(
+                "| {status_emoji} | {section_link} | {level} | {req} | {test_link} |\n"
+            ));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("---\n\n");
+    out.push_str(
+        "Legend:  \
+         ✅ passing test &middot; \
+         ❌ failing test &middot; \
+         ⚠️ ignored / pending &middot; \
+         · status unknown (no test results provided)\n",
+    );
+    out
+}
+
+fn escape_md_table_cell(s: &str) -> String {
+    s.replace('|', "\\|").replace('\n', " ")
+}
+
+/// Sort RFC group keys: numeric RFCs ascending, then OIDC specs (alpha),
+/// then drafts (alpha), then anything else (alpha). Numeric keys parse into
+/// `(0, n, "")`, OIDC keys into `(1, 0, name)`, drafts into `(2, 0, name)`,
+/// other strings into `(3, 0, name)`.
+fn rfc_sort_key(rfc: &str) -> (u8, u32, String) {
+    if let Ok(n) = rfc.parse::<u32>() {
+        return (0, n, String::new());
+    }
+    let lower = rfc.to_ascii_lowercase();
+    if lower.starts_with("oidc-") {
+        (1, 0, lower)
+    } else if lower.starts_with("draft-") {
+        (2, 0, lower)
+    } else {
+        (3, 0, lower)
+    }
+}
+
+/// Render a friendly per-group heading. Numeric keys become `RFC <n>`;
+/// known OIDC family keys get a human label; drafts and unknown strings
+/// fall back to a verbatim rendering.
+fn rfc_heading(rfc: &str) -> String {
+    if rfc.parse::<u32>().is_ok() {
+        return format!("RFC {rfc}");
+    }
+    match rfc {
+        "oidc-core-1.0" => "OpenID Connect Core 1.0".to_string(),
+        "oidc-discovery-1.0" => "OpenID Connect Discovery 1.0".to_string(),
+        "oidc-session-1.0" => "OpenID Connect Session Management 1.0".to_string(),
+        "oidc-frontchannel-1.0" => "OpenID Connect Front-Channel Logout 1.0".to_string(),
+        "oidc-backchannel-1.0" => "OpenID Connect Back-Channel Logout 1.0".to_string(),
+        "oidc-rpinit-1.0" => "OpenID Connect RP-Initiated Logout 1.0".to_string(),
+        "oidc-mrt-1.0" => "OAuth 2.0 Multiple Response Type Encoding Practices".to_string(),
+        "oidc-registration-1.0" => "OpenID Connect Dynamic Client Registration 1.0".to_string(),
+        "draft-ietf-oauth-status-list" => {
+            "OAuth 2.0 Token Status List (draft-ietf-oauth-status-list)".to_string()
+        }
+        other => other.to_string(),
+    }
+}
+
+/// Sort sections numerically: `4.1.1` before `4.1.2` before `10.5`.
+fn section_sort_key(s: &str) -> Vec<u32> {
+    s.split('.')
+        .map(|part| {
+            part.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+        })
+        .map(|num| num.parse::<u32>().unwrap_or(u32::MAX))
+        .collect()
+}
+
+// -----------------------------------------------------------------------------
+// Output: JSON
+// -----------------------------------------------------------------------------
+
+#[derive(serde::Serialize)]
+struct JsonReport<'a> {
+    schema_version: u32,
+    generated_at: String,
+    have_results: bool,
+    summary: JsonSummary,
+    annotations: &'a [Annotation],
+}
+
+#[derive(serde::Serialize)]
+struct JsonSummary {
+    total: usize,
+    passed: usize,
+    failed: usize,
+    ignored: usize,
+    unknown: usize,
+    by_rfc: BTreeMap<String, RfcSummary>,
+}
+
+#[derive(serde::Serialize)]
+struct RfcSummary {
+    total: usize,
+    passed: usize,
+    failed: usize,
+    ignored: usize,
+    unknown: usize,
+}
+
+fn build_json_report<'a>(annotations: &'a [Annotation], have_results: bool) -> JsonReport<'a> {
+    let mut by_rfc: BTreeMap<String, RfcSummary> = BTreeMap::new();
+    for ann in annotations {
+        let entry = by_rfc.entry(ann.rfc.clone()).or_insert(RfcSummary {
+            total: 0,
+            passed: 0,
+            failed: 0,
+            ignored: 0,
+            unknown: 0,
+        });
+        entry.total += 1;
+        match ann.status.as_str() {
+            "passed" => entry.passed += 1,
+            "failed" => entry.failed += 1,
+            "ignored" => entry.ignored += 1,
+            _ => entry.unknown += 1,
+        }
+    }
+
+    let summary = JsonSummary {
+        total: annotations.len(),
+        passed: annotations.iter().filter(|a| a.status == "passed").count(),
+        failed: annotations.iter().filter(|a| a.status == "failed").count(),
+        ignored: annotations.iter().filter(|a| a.status == "ignored").count(),
+        unknown: annotations.iter().filter(|a| a.status == "unknown").count(),
+        by_rfc,
+    };
+
+    // Use a fixed-shape RFC3339 date string without pulling in `chrono`.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let generated_at = format!("unix:{now}");
+
+    JsonReport {
+        schema_version: 1,
+        generated_at,
+        have_results,
+        summary,
+        annotations,
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Output: JUnit XML
+// -----------------------------------------------------------------------------
+
+fn render_junit(annotations: &[Annotation]) -> String {
+    let mut by_rfc: BTreeMap<String, Vec<&Annotation>> = BTreeMap::new();
+    for ann in annotations {
+        by_rfc.entry(ann.rfc.clone()).or_default().push(ann);
+    }
+
+    let mut out = String::new();
+    out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str("<testsuites name=\"rfc-compliance\">\n");
+    let mut rfc_order: Vec<String> = by_rfc.keys().cloned().collect();
+    rfc_order.sort_by_key(|a| rfc_sort_key(a));
+    for rfc in &rfc_order {
+        let tests = &by_rfc[rfc];
+        let total = tests.len();
+        let failures = tests.iter().filter(|a| a.status == "failed").count();
+        let skipped = tests.iter().filter(|a| a.status == "ignored").count();
+        let suite_name = rfc_heading(rfc);
+        out.push_str(&format!(
+            "  <testsuite name=\"{}\" tests=\"{total}\" failures=\"{failures}\" skipped=\"{skipped}\">\n",
+            xml_escape(&suite_name),
+        ));
+        for ann in tests {
+            // For numeric RFCs: `rfc6749.section_4_1_1`. For named specs:
+            // `oidc-core-1.0.section_3_1_2_1`.
+            let classname_prefix = if ann.rfc.parse::<u32>().is_ok() {
+                format!("rfc{}", ann.rfc)
+            } else {
+                ann.rfc.clone()
+            };
+            let classname = format!(
+                "{}.section_{}",
+                classname_prefix,
+                ann.section.replace('.', "_")
+            );
+            out.push_str(&format!(
+                "    <testcase classname=\"{}\" name=\"{}\">\n",
+                xml_escape(&classname),
+                xml_escape(&ann.test_name)
+            ));
+            match ann.status.as_str() {
+                "failed" => {
+                    out.push_str(&format!(
+                        "      <failure message=\"{}\">{}</failure>\n",
+                        xml_escape(&format!(
+                            "RFC {} §{} failing: {}",
+                            ann.rfc, ann.section, ann.requirement
+                        )),
+                        xml_escape(&ann.url),
+                    ));
+                }
+                "ignored" => {
+                    let msg = ann
+                        .ignore_reason
+                        .as_deref()
+                        .unwrap_or("test marked #[ignore]");
+                    out.push_str(&format!(
+                        "      <skipped message=\"{}\"/>\n",
+                        xml_escape(msg)
+                    ));
+                }
+                "unknown" => {
+                    out.push_str(
+                        "      <skipped message=\"no test results provided to compliance_report\"/>\n",
+                    );
+                }
+                _ => {}
+            }
+            // Embed the RFC link as system-out for downstream tooling.
+            if !ann.url.is_empty() {
+                out.push_str(&format!(
+                    "      <system-out>{}</system-out>\n",
+                    xml_escape(&ann.url)
+                ));
+            }
+            out.push_str("    </testcase>\n");
+        }
+        out.push_str("  </testsuite>\n");
+    }
+    out.push_str("</testsuites>\n");
+    out
+}
+
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+// -----------------------------------------------------------------------------
+// Filesystem helpers
+// -----------------------------------------------------------------------------
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is set when running via cargo. Falls back to CWD.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn discover_test_files(tests_dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(tests_dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        // Anything that *might* contain RFC annotations. The parser ignores
+        // files with no @rfc/@section tags, so this is a cheap pre-filter.
+        if !name.ends_with(".rs") {
+            continue;
+        }
+        // Anything that *might* contain RFC annotations. The parser ignores
+        // files with no @rfc/@section tags, so this is a cheap pre-filter.
+        // Patterns: `compliance_*.rs`, `rfc*.rs` (e.g. `rfc8252_native_apps.rs`),
+        // `rfc_compliance.rs`, and `phase*_rfc_compliance.rs`.
+        let is_compliance_like = name.starts_with("compliance_")
+            || name.starts_with("rfc")
+            || name == "rfc_compliance.rs"
+            || (name.starts_with("phase") && name.contains("_rfc_"));
+        if is_compliance_like {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
+fn write_file(path: &Path, contents: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut f = fs::File::create(path)?;
+    f.write_all(contents.as_bytes())?;
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Entry point
+// -----------------------------------------------------------------------------
+
+struct Args {
+    results: Option<PathBuf>,
+    markdown_out: PathBuf,
+    json_out: PathBuf,
+    junit_out: PathBuf,
+}
+
+fn parse_args() -> Args {
+    let root = repo_root();
+    let mut results = None;
+    let mut markdown_out = root.join("docs/compliance/RFC_COMPLIANCE.md");
+    let mut json_out = root.join("target/compliance-report.json");
+    let mut junit_out = root.join("target/compliance-junit.xml");
+
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--results" => {
+                i += 1;
+                if let Some(v) = argv.get(i) {
+                    results = Some(PathBuf::from(v));
+                }
+            }
+            "--markdown" => {
+                i += 1;
+                if let Some(v) = argv.get(i) {
+                    markdown_out = PathBuf::from(v);
+                }
+            }
+            "--json" => {
+                i += 1;
+                if let Some(v) = argv.get(i) {
+                    json_out = PathBuf::from(v);
+                }
+            }
+            "--junit" => {
+                i += 1;
+                if let Some(v) = argv.get(i) {
+                    junit_out = PathBuf::from(v);
+                }
+            }
+            "--help" | "-h" => {
+                print_help();
+                std::process::exit(0);
+            }
+            _ => {
+                eprintln!("warning: unknown argument: {}", argv[i]);
+            }
+        }
+        i += 1;
+    }
+
+    Args {
+        results,
+        markdown_out,
+        json_out,
+        junit_out,
+    }
+}
+
+fn print_help() {
+    println!(
+        "compliance_report — generate RFC compliance reports from annotated tests\n\n\
+         USAGE:\n    \
+         cargo run --bin compliance_report -- [OPTIONS]\n\n\
+         OPTIONS:\n    \
+         --results <FILE>     libtest JSONL output from `cargo test --format json`\n    \
+         --markdown <PATH>    Markdown output (default: docs/compliance/RFC_COMPLIANCE.md)\n    \
+         --json <PATH>        JSON output     (default: target/compliance-report.json)\n    \
+         --junit <PATH>       JUnit XML       (default: target/compliance-junit.xml)\n    \
+         --help               Show this help"
+    );
+}
+
+fn main() -> ExitCode {
+    let args = parse_args();
+    let root = repo_root();
+    let tests_dir = root.join("tests");
+
+    let files = discover_test_files(&tests_dir);
+    if files.is_empty() {
+        eprintln!(
+            "error: no candidate test files found in {}",
+            tests_dir.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let mut annotations: Vec<Annotation> = Vec::new();
+    for path in &files {
+        annotations.extend(parse_source_file(path));
+    }
+
+    let have_results = args.results.is_some();
+    if let Some(results_path) = &args.results {
+        let results = parse_results_file(results_path);
+        fill_status(&mut annotations, &results);
+    } else {
+        // No results file: pre-mark `#[ignore]`d tests as ignored, leave others unknown.
+        for ann in annotations.iter_mut() {
+            if ann.ignored {
+                ann.status = "ignored".to_string();
+            }
+        }
+    }
+
+    if annotations.is_empty() {
+        eprintln!(
+            "error: scanned {} files but found zero `@rfc`-tagged tests",
+            files.len()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let md = render_markdown(&annotations, have_results);
+    let json_report = build_json_report(&annotations, have_results);
+    let json = serde_json::to_string_pretty(&json_report).expect("serialize JSON report");
+    let xml = render_junit(&annotations);
+
+    if let Err(e) = write_file(&args.markdown_out, &md) {
+        eprintln!("error writing {}: {e}", args.markdown_out.display());
+        return ExitCode::FAILURE;
+    }
+    if let Err(e) = write_file(&args.json_out, &json) {
+        eprintln!("error writing {}: {e}", args.json_out.display());
+        return ExitCode::FAILURE;
+    }
+    if let Err(e) = write_file(&args.junit_out, &xml) {
+        eprintln!("error writing {}: {e}", args.junit_out.display());
+        return ExitCode::FAILURE;
+    }
+
+    println!(
+        "compliance_report: {} annotated tests across {} files",
+        annotations.len(),
+        files.len()
+    );
+    println!("  markdown -> {}", args.markdown_out.display());
+    println!("  json     -> {}", args.json_out.display());
+    println!("  junit    -> {}", args.junit_out.display());
+
+    ExitCode::SUCCESS
+}

--- a/src/bin/compliance_report.rs
+++ b/src/bin/compliance_report.rs
@@ -183,12 +183,9 @@ fn parse_source_file(path: &Path) -> Vec<Annotation> {
 
 fn extract_fn_name(line: &str) -> Option<String> {
     // Strip leading "async fn " or "fn " and read identifier up to '('.
-    let after_keyword = if let Some(rest) = line.strip_prefix("async fn ") {
-        rest
-    } else if let Some(rest) = line.strip_prefix("fn ") {
-        rest
-    } else {
-        return None;
+    let after_keyword = match line.strip_prefix("async fn ") {
+        Some(rest) => rest,
+        None => line.strip_prefix("fn ")?,
     };
     let name: String = after_keyword
         .chars()

--- a/tests/compliance_oidc_core.rs
+++ b/tests/compliance_oidc_core.rs
@@ -241,6 +241,12 @@ macro_rules! do_oidc_flow {
 
 /// OIDC Core §3.1: Including `openid` in the scope of an authorization code
 /// grant MUST result in an `id_token` field in the token response.
+///
+/// @rfc oidc-core-1.0
+/// @section 3.1
+/// @requirement Authorization-code flow with `openid` scope must include an id_token in the token response.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse
 #[actix_web::test]
 async fn oidc_core_s3_1_openid_scope_triggers_id_token() {
     let client = Client::new(
@@ -273,6 +279,12 @@ async fn oidc_core_s3_1_openid_scope_triggers_id_token() {
 
 /// OIDC Core §3.1: The `id_token` MUST be a compact-serialised JWT with
 /// exactly three dot-separated components (header.payload.signature).
+///
+/// @rfc oidc-core-1.0
+/// @section 3.1
+/// @requirement id_token must be a compact-serialised JWT (header.payload.signature).
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 #[actix_web::test]
 async fn oidc_core_s3_1_id_token_is_valid_jwt() {
     let client = Client::new(
@@ -307,6 +319,12 @@ async fn oidc_core_s3_1_id_token_is_valid_jwt() {
 
 /// OIDC Core §2: The `sub` (subject) claim MUST be present in the id_token
 /// and MUST identify the authenticated end-user.
+///
+/// @rfc oidc-core-1.0
+/// @section 2
+/// @requirement id_token must contain a `sub` claim identifying the end-user.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 #[actix_web::test]
 async fn oidc_core_s3_1_id_token_sub_claim_present() {
     let client = Client::new(
@@ -340,6 +358,12 @@ async fn oidc_core_s3_1_id_token_sub_claim_present() {
 
 /// OIDC Core §2: The `iss` (issuer) claim MUST be present and MUST exactly
 /// match the issuer value from the server configuration.
+///
+/// @rfc oidc-core-1.0
+/// @section 2
+/// @requirement id_token `iss` claim must match the configured issuer value exactly.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 #[actix_web::test]
 async fn oidc_core_s3_1_id_token_iss_matches_config() {
     let client = Client::new(
@@ -375,6 +399,12 @@ async fn oidc_core_s3_1_id_token_iss_matches_config() {
 
 /// OIDC Core §2: The `aud` (audience) claim MUST contain the `client_id` of
 /// the relying party that requested the id_token.
+///
+/// @rfc oidc-core-1.0
+/// @section 2
+/// @requirement id_token `aud` claim must contain the requesting RP's client_id.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 #[actix_web::test]
 async fn oidc_core_s3_1_id_token_aud_matches_client() {
     let client = Client::new(
@@ -415,6 +445,12 @@ async fn oidc_core_s3_1_id_token_aud_matches_client() {
 
 /// OIDC Core §2: The `iat` (issued-at) and `exp` (expiration) claims MUST be
 /// present as integer NumericDate values, with `exp` strictly after `iat`.
+///
+/// @rfc oidc-core-1.0
+/// @section 2
+/// @requirement id_token must have `iat` and `exp` NumericDate claims with `exp` > `iat`.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 #[actix_web::test]
 async fn oidc_core_s3_1_id_token_has_iat_and_exp() {
     let client = Client::new(
@@ -451,6 +487,12 @@ async fn oidc_core_s3_1_id_token_has_iat_and_exp() {
 
 /// OIDC Core §3.1.2.1: When a `nonce` is provided in the authorization
 /// request, it MUST be present verbatim in the id_token claims.
+///
+/// @rfc oidc-core-1.0
+/// @section 3.1.2.1
+/// @requirement A nonce in the authorization request must be echoed verbatim in the id_token.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 #[actix_web::test]
 async fn oidc_core_s3_1_2_1_nonce_echoed_in_id_token() {
     let client = Client::new(
@@ -491,6 +533,12 @@ async fn oidc_core_s3_1_2_1_nonce_echoed_in_id_token() {
 
 /// OIDC Core §3.1: When `openid` is absent from the scope, the token
 /// response MUST NOT include an `id_token` field.
+///
+/// @rfc oidc-core-1.0
+/// @section 3.1
+/// @requirement Token response without `openid` scope must not include an id_token.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse
 #[actix_web::test]
 async fn oidc_core_s3_1_no_id_token_without_openid_scope() {
     let client = Client::new(
@@ -527,6 +575,12 @@ async fn oidc_core_s3_1_no_id_token_without_openid_scope() {
 
 /// OIDC Core §5.3: A valid Bearer access token MUST return a JSON body
 /// containing the `sub` claim that identifies the authenticated end-user.
+///
+/// @rfc oidc-core-1.0
+/// @section 5.3
+/// @requirement UserInfo response with a valid token must include the `sub` claim.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
 #[actix_web::test]
 async fn oidc_core_userinfo_s5_3_sub_claim_present() {
     let client = Client::new(
@@ -568,6 +622,12 @@ async fn oidc_core_userinfo_s5_3_sub_claim_present() {
 
 /// OIDC Core §5.3: The UserInfo endpoint MUST return HTTP 401 with a
 /// `WWW-Authenticate: Bearer` header when no access token is provided.
+///
+/// @rfc oidc-core-1.0
+/// @section 5.3
+/// @requirement UserInfo endpoint must return 401 with WWW-Authenticate: Bearer when token is missing.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
 #[actix_web::test]
 async fn oidc_core_userinfo_s5_3_missing_token_returns_401() {
     let client = Client::new(

--- a/tests/compliance_rfc6749.rs
+++ b/tests/compliance_rfc6749.rs
@@ -2,6 +2,28 @@
 //!
 //! Compliance tests that map directly to RFC 6749 sections.
 //! See docs/compliance/RFC_COMPLIANCE.md for the full matrix.
+//!
+//! # Compliance metadata format
+//!
+//! Each `#[actix_web::test]` in this file is annotated with a structured
+//! block of doc-comment tags consumed by `cargo run --bin compliance_report`
+//! to produce the published compliance matrix. Format:
+//!
+//! ```text
+//! /// RFC 6749 §3.1.2: <human-readable prose explaining what is checked>
+//! ///
+//! /// @rfc 6749
+//! /// @section 3.1.2
+//! /// @requirement <one-line normative requirement under test>
+//! /// @level MUST              # RFC 2119 keyword: MUST | SHOULD | MAY
+//! /// @url https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2
+//! ```
+//!
+//! Tags must appear on contiguous `///` lines immediately preceding the
+//! `#[actix_web::test]` (or `#[test]`) attribute. The extractor pairs them
+//! with the test's runtime status (passed / failed / ignored) from
+//! `cargo test --message-format=json` to produce Markdown, JSON, and JUnit
+//! XML reports.
 
 use actix::{Actor, Addr};
 use actix_session::{storage::CookieSessionStore, Session, SessionMiddleware};
@@ -215,6 +237,12 @@ macro_rules! plain_app {
 
 /// RFC 6749 §3.1.2: The redirect URI provided at the authorization endpoint
 /// must exactly match the one registered for the client.
+///
+/// @rfc 6749
+/// @section 3.1.2
+/// @requirement Redirect URI in the authorization request must exactly match a registered redirect URI.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2
 #[actix_web::test]
 async fn rfc6749_s3_1_2_redirect_uri_must_match() {
     let client = Client::new(
@@ -255,6 +283,12 @@ async fn rfc6749_s3_1_2_redirect_uri_must_match() {
 // ---------------------------------------------------------------------------
 
 /// RFC 6749 §4.1.1: `response_type` is a required parameter.
+///
+/// @rfc 6749
+/// @section 4.1.1
+/// @requirement The authorization request MUST include the `response_type` parameter.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
 #[actix_web::test]
 async fn rfc6749_s4_1_1_authorize_requires_response_type() {
     let client = Client::new(
@@ -286,6 +320,12 @@ async fn rfc6749_s4_1_1_authorize_requires_response_type() {
 }
 
 /// RFC 6749 §4.1.1: Unsupported `response_type` values must be rejected.
+///
+/// @rfc 6749
+/// @section 4.1.1
+/// @requirement Authorization requests with an unsupported `response_type` MUST be rejected with `unsupported_response_type` (or equivalent error).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
 #[actix_web::test]
 async fn rfc6749_s4_1_1_authorize_rejects_unknown_response_type() {
     let client = Client::new(
@@ -322,6 +362,12 @@ async fn rfc6749_s4_1_1_authorize_rejects_unknown_response_type() {
 }
 
 /// RFC 6749 §4.1.1: `client_id` is a required parameter.
+///
+/// @rfc 6749
+/// @section 4.1.1
+/// @requirement The authorization request MUST include the `client_id` parameter.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
 #[actix_web::test]
 async fn rfc6749_s4_1_1_authorize_requires_client_id() {
     let client = Client::new(
@@ -358,6 +404,12 @@ async fn rfc6749_s4_1_1_authorize_requires_client_id() {
 }
 
 /// RFC 6749 §4.1.1: An unknown `client_id` must be rejected.
+///
+/// @rfc 6749
+/// @section 4.1.1
+/// @requirement Authorization requests bearing an unknown `client_id` MUST be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
 #[actix_web::test]
 async fn rfc6749_s4_1_1_authorize_rejects_unknown_client() {
     let client = Client::new(
@@ -401,6 +453,12 @@ async fn rfc6749_s4_1_1_authorize_rejects_unknown_client() {
 
 /// RFC 6749 §4.1.2: Successful authorization returns a 302 redirect containing
 /// the `code` query parameter.
+///
+/// @rfc 6749
+/// @section 4.1.2
+/// @requirement A successful authorization response MUST be delivered as a redirect to the client's redirect URI with a `code` query parameter.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2
 #[actix_web::test]
 async fn rfc6749_s4_1_2_authorize_redirects_with_code() {
     let client = Client::new(
@@ -454,6 +512,12 @@ async fn rfc6749_s4_1_2_authorize_redirects_with_code() {
 
 /// RFC 6749 §4.1.2: The `state` parameter, when present, must be included
 /// verbatim in the redirect response.
+///
+/// @rfc 6749
+/// @section 4.1.2
+/// @requirement If the client includes a `state` parameter, the authorization server MUST include the exact value received in the response.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2
 #[actix_web::test]
 async fn rfc6749_s4_1_2_state_is_echoed_in_redirect() {
     let client = Client::new(
@@ -510,6 +574,12 @@ async fn rfc6749_s4_1_2_state_is_echoed_in_redirect() {
 // ---------------------------------------------------------------------------
 
 /// RFC 6749 §4.1.3: `grant_type` is a required parameter.
+///
+/// @rfc 6749
+/// @section 4.1.3
+/// @requirement Token requests MUST include the `grant_type` parameter.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
 #[actix_web::test]
 async fn rfc6749_s4_1_3_token_requires_grant_type() {
     let client = Client::new(
@@ -549,6 +619,12 @@ async fn rfc6749_s4_1_3_token_requires_grant_type() {
 }
 
 /// RFC 6749 §4.1.3: Unsupported `grant_type` values must be rejected.
+///
+/// @rfc 6749
+/// @section 4.1.3
+/// @requirement Token requests with an unsupported `grant_type` MUST be rejected with `unsupported_grant_type`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
 #[actix_web::test]
 async fn rfc6749_s4_1_3_token_rejects_unsupported_grant_type() {
     let client = Client::new(
@@ -592,6 +668,12 @@ async fn rfc6749_s4_1_3_token_rejects_unsupported_grant_type() {
 
 /// RFC 6749 §4.1.3: A client must not be able to exchange a code that was
 /// issued to a different client.
+///
+/// @rfc 6749
+/// @section 4.1.3
+/// @requirement The authorization server MUST ensure that an authorization code is bound to the client identifier it was issued to.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
 #[actix_web::test]
 async fn rfc6749_s4_1_3_token_rejects_wrong_client_for_code() {
     let client_a = Client::new(
@@ -713,6 +795,12 @@ async fn rfc6749_s4_1_3_token_rejects_wrong_client_for_code() {
 // ---------------------------------------------------------------------------
 
 /// RFC 6749 §4.4.2: Successful client credentials grant returns an access token.
+///
+/// @rfc 6749
+/// @section 4.4.2
+/// @requirement A successful client credentials grant MUST return an access token in the token response body.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.2
 #[actix_web::test]
 async fn rfc6749_s4_4_2_client_credentials_returns_access_token() {
     let client = Client::new(
@@ -753,6 +841,12 @@ async fn rfc6749_s4_4_2_client_credentials_returns_access_token() {
 }
 
 /// RFC 6749 §4.4.3: Invalid client credentials → `invalid_client` (401).
+///
+/// @rfc 6749
+/// @section 4.4.3
+/// @requirement Invalid client authentication on the token endpoint MUST be rejected with `invalid_client`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
 #[actix_web::test]
 async fn rfc6749_s4_4_3_client_credentials_rejects_invalid_client() {
     let client = Client::new(
@@ -795,6 +889,12 @@ async fn rfc6749_s4_4_3_client_credentials_rejects_invalid_client() {
 
 /// RFC 6749 §2.3.1: Client credentials may be sent in an HTTP Basic
 /// Authorization header.
+///
+/// @rfc 6749
+/// @section 2.3.1
+/// @requirement The authorization server MUST support HTTP Basic authentication for clients with a client password.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
 #[actix_web::test]
 async fn rfc6749_s2_3_client_auth_via_basic_header() {
     let client = Client::new(
@@ -832,6 +932,12 @@ async fn rfc6749_s2_3_client_auth_via_basic_header() {
 
 /// RFC 6749 §2.3.1: Client credentials may also be sent as request body
 /// parameters (`client_id` + `client_secret`).
+///
+/// @rfc 6749
+/// @section 2.3.1
+/// @requirement Client credentials MAY be included in the request body using `client_id` and `client_secret` parameters.
+/// @level MAY
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
 #[actix_web::test]
 async fn rfc6749_s2_3_client_auth_via_post_params() {
     let client = Client::new(
@@ -874,6 +980,12 @@ async fn rfc6749_s2_3_client_auth_via_post_params() {
 
 /// RFC 6749 §5.1: Successful token response must include `token_type` (bearer)
 /// and a non-empty `access_token`.
+///
+/// @rfc 6749
+/// @section 5.1
+/// @requirement Successful token responses MUST include the `access_token` and `token_type` fields.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
 #[actix_web::test]
 async fn rfc6749_s5_1_token_response_has_required_fields() {
     let client = Client::new(
@@ -924,6 +1036,12 @@ async fn rfc6749_s5_1_token_response_has_required_fields() {
 
 /// RFC 6749 §5.2: Token response must include `Cache-Control: no-store` and
 /// `Pragma: no-cache` to prevent caching of sensitive tokens.
+///
+/// @rfc 6749
+/// @section 5.1
+/// @requirement Token endpoint responses MUST include `Cache-Control: no-store` and `Pragma: no-cache` to prevent caching of sensitive credentials.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
 #[actix_web::test]
 async fn rfc6749_s5_2_token_response_no_cache_headers() {
     let client = Client::new(
@@ -980,6 +1098,12 @@ async fn rfc6749_s5_2_token_response_no_cache_headers() {
 
 /// RFC 6749 §5.2: Error responses must be JSON objects with at minimum
 /// an `error` string field.
+///
+/// @rfc 6749
+/// @section 5.2
+/// @requirement Error responses from the token endpoint MUST be JSON objects containing an `error` field.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
 #[actix_web::test]
 async fn rfc6749_s5_2_error_response_format() {
     let client = Client::new(
@@ -1026,6 +1150,12 @@ async fn rfc6749_s5_2_error_response_format() {
 
 /// RFC 6749 §10.3: An authorization code must only be usable once.
 /// A second exchange with the same code must fail.
+///
+/// @rfc 6749
+/// @section 10.5
+/// @requirement Authorization codes MUST be single-use; a second redemption of the same code MUST be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-10.5
 #[actix_web::test]
 async fn rfc6749_s10_3_authorization_code_single_use() {
     let client = Client::new(

--- a/tests/compliance_rfc6750.rs
+++ b/tests/compliance_rfc6750.rs
@@ -122,6 +122,12 @@ macro_rules! app {
 
 /// RFC 6750 §2.1: Bearer token in the `Authorization` header must be accepted
 /// and return the resource owner's claims.
+///
+/// @rfc 6750
+/// @section 2.1
+/// @requirement Bearer token in the Authorization header must be accepted by protected resources.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
 #[actix_web::test]
 async fn rfc6750_s2_1_bearer_in_authorization_header_returns_200() {
     let client = Client::new(
@@ -149,6 +155,12 @@ async fn rfc6750_s2_1_bearer_in_authorization_header_returns_200() {
 }
 
 /// RFC 6750 §2.1: The userinfo response must include the `sub` claim.
+///
+/// @rfc 6750
+/// @section 2.1
+/// @requirement A valid Bearer token must enable retrieval of the resource owner's `sub` claim.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
 #[actix_web::test]
 async fn rfc6750_s2_1_userinfo_response_contains_sub() {
     let client = Client::new(
@@ -182,6 +194,12 @@ async fn rfc6750_s2_1_userinfo_response_contains_sub() {
 
 /// RFC 6750 §3.1: A request without an `Authorization` header must return
 /// 401 Unauthorized with a `WWW-Authenticate: Bearer` header.
+///
+/// @rfc 6750
+/// @section 3.1
+/// @requirement Missing Bearer credentials must return 401 with WWW-Authenticate: Bearer.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
 #[actix_web::test]
 async fn rfc6750_s3_1_missing_token_returns_401() {
     let client = Client::new(
@@ -212,6 +230,12 @@ async fn rfc6750_s3_1_missing_token_returns_401() {
 
 /// RFC 6750 §3.1: A request presenting an invalid / garbage Bearer token must
 /// return 401 with a `WWW-Authenticate: Bearer error="invalid_token"` header.
+///
+/// @rfc 6750
+/// @section 3.1
+/// @requirement Invalid Bearer token must return 401 with WWW-Authenticate including error=invalid_token.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
 #[actix_web::test]
 async fn rfc6750_s3_1_invalid_token_returns_401_with_www_authenticate() {
     let client = Client::new(
@@ -245,6 +269,12 @@ async fn rfc6750_s3_1_invalid_token_returns_401_with_www_authenticate() {
 
 /// RFC 6750 §3.1: The error body for an invalid token must include an `error`
 /// field set to `invalid_token`.
+///
+/// @rfc 6750
+/// @section 3.1
+/// @requirement Invalid token error body must contain `error: invalid_token`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
 #[actix_web::test]
 async fn rfc6750_s3_1_error_body_has_invalid_token_code() {
     let client = Client::new(
@@ -275,6 +305,12 @@ async fn rfc6750_s3_1_error_body_has_invalid_token_code() {
 /// RFC 6750 §2.3: A client credentials token (no user context) must not grant
 /// access to the userinfo endpoint — the resource server returns 401 because
 /// the token represents a client, not a resource owner.
+///
+/// @rfc 6750
+/// @section 2
+/// @requirement A token without a resource-owner subject must not be accepted by the userinfo endpoint.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6750#section-2
 #[actix_web::test]
 async fn rfc6750_s2_client_credentials_token_cannot_access_userinfo() {
     let client = Client::new(

--- a/tests/compliance_rfc7636.rs
+++ b/tests/compliance_rfc7636.rs
@@ -180,6 +180,12 @@ macro_rules! app {
 
 /// RFC 7636 §4.1 + §4.3: PKCE is required for public authorization-code
 /// clients; an authorize request without a code_challenge must be rejected.
+///
+/// @rfc 7636
+/// @section 4.1
+/// @requirement Public clients using authorization_code must include code_challenge in the authorize request.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
 #[actix_web::test]
 async fn rfc7636_s4_1_pkce_required_for_authorization_code() {
     let client = Client::new(
@@ -220,6 +226,12 @@ async fn rfc7636_s4_1_pkce_required_for_authorization_code() {
 
 /// RFC 7636 §4.1: `code_verifier` minimum length is 43 characters (ASCII
 /// unreserved characters).  Shorter verifiers must be rejected at token exchange.
+///
+/// @rfc 7636
+/// @section 4.1
+/// @requirement code_verifier shorter than 43 characters must be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
 #[actix_web::test]
 async fn rfc7636_s4_1_verifier_min_length_43() {
     let client = Client::new(
@@ -269,6 +281,12 @@ async fn rfc7636_s4_1_verifier_min_length_43() {
 
 /// RFC 7636 §4.1: `code_verifier` maximum length is 128 characters.
 /// Verifiers exceeding this limit must be rejected.
+///
+/// @rfc 7636
+/// @section 4.1
+/// @requirement code_verifier longer than 128 characters must be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
 #[actix_web::test]
 async fn rfc7636_s4_1_verifier_max_length_128() {
     let client = Client::new(
@@ -320,6 +338,12 @@ async fn rfc7636_s4_1_verifier_max_length_128() {
 // ---------------------------------------------------------------------------
 
 /// RFC 7636 §4.2: The `S256` code challenge method must be accepted.
+///
+/// @rfc 7636
+/// @section 4.2
+/// @requirement Servers must support the S256 code_challenge_method.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
 #[actix_web::test]
 async fn rfc7636_s4_2_s256_challenge_method_is_accepted() {
     let client = Client::new(
@@ -364,6 +388,12 @@ async fn rfc7636_s4_2_s256_challenge_method_is_accepted() {
 
 /// RFC 7636 §4.2: The `plain` code challenge method must NOT be accepted
 /// (this server enforces S256-only per best practice).
+///
+/// @rfc 7636
+/// @section 4.2
+/// @requirement The plain code_challenge_method must be rejected (S256-only enforcement).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
 #[actix_web::test]
 async fn rfc7636_s4_2_plain_method_is_rejected() {
     let client = Client::new(
@@ -417,6 +447,12 @@ async fn rfc7636_s4_2_plain_method_is_rejected() {
 
 /// RFC 7636 §4.2: Providing a `code_challenge_method` without a
 /// `code_challenge` must be rejected.
+///
+/// @rfc 7636
+/// @section 4.2
+/// @requirement code_challenge_method without code_challenge must be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
 #[actix_web::test]
 async fn rfc7636_s4_2_method_without_challenge_rejected() {
     let client = Client::new(
@@ -456,6 +492,12 @@ async fn rfc7636_s4_2_method_without_challenge_rejected() {
 // ---------------------------------------------------------------------------
 
 /// RFC 7636 §4.3: Exchanging a code with the correct verifier must succeed.
+///
+/// @rfc 7636
+/// @section 4.3
+/// @requirement A correct PKCE code_verifier must be accepted at the token endpoint.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7636#section-4.3
 #[actix_web::test]
 async fn rfc7636_s4_3_valid_verifier_exchanges_code() {
     let client = Client::new(
@@ -500,6 +542,12 @@ async fn rfc7636_s4_3_valid_verifier_exchanges_code() {
 
 /// RFC 7636 §4.3: Exchanging a code with a wrong verifier must return
 /// `invalid_grant`.
+///
+/// @rfc 7636
+/// @section 4.3
+/// @requirement An incorrect PKCE code_verifier must yield invalid_grant at the token endpoint.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7636#section-4.3
 #[actix_web::test]
 async fn rfc7636_s4_3_wrong_verifier_is_rejected() {
     let client = Client::new(
@@ -545,6 +593,12 @@ async fn rfc7636_s4_3_wrong_verifier_is_rejected() {
 
 /// RFC 7636 §4.3: Missing verifier when a challenge was registered must
 /// return `invalid_grant`.
+///
+/// @rfc 7636
+/// @section 4.3
+/// @requirement Missing code_verifier when challenge was registered must yield invalid_grant.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7636#section-4.3
 #[actix_web::test]
 async fn rfc7636_s4_3_missing_verifier_rejects_pkce_code() {
     let client = Client::new(
@@ -593,6 +647,12 @@ async fn rfc7636_s4_3_missing_verifier_rejects_pkce_code() {
 
 /// RFC 7636 §4.3: Sending the verifier *value* as the challenge (i.e.,
 /// `challenge == verifier` instead of `challenge == S256(verifier)`) must fail.
+///
+/// @rfc 7636
+/// @section 4.3
+/// @requirement Verifier-as-challenge (plain-style) misuse must be rejected when S256 is required.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7636#section-4.3
 #[actix_web::test]
 async fn rfc7636_s4_3_sending_verifier_as_challenge_rejected() {
     let client = Client::new(

--- a/tests/compliance_rfc7662_7009.rs
+++ b/tests/compliance_rfc7662_7009.rs
@@ -197,6 +197,12 @@ macro_rules! app {
 // ---------------------------------------------------------------------------
 
 /// RFC 7662 §2.2: Introspection of an active token must return `active: true`.
+///
+/// @rfc 7662
+/// @section 2.2
+/// @requirement Introspection of an active token must yield `active: true`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
 #[actix_web::test]
 async fn rfc7662_s2_2_introspect_active_token_returns_true() {
     let client = Client::new(
@@ -235,6 +241,12 @@ async fn rfc7662_s2_2_introspect_active_token_returns_true() {
 
 /// RFC 7662 §2.2: Introspection must return `active: false` for an unknown or
 /// garbage token string.
+///
+/// @rfc 7662
+/// @section 2.2
+/// @requirement Introspection must return `active: false` for an invalid or unknown token.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
 #[actix_web::test]
 async fn rfc7662_s2_2_introspect_invalid_token_returns_false() {
     let client = Client::new(
@@ -272,6 +284,12 @@ async fn rfc7662_s2_2_introspect_invalid_token_returns_false() {
 
 /// RFC 7662 §2.1: The introspect endpoint must require client authentication
 /// (when public introspection is disabled).
+///
+/// @rfc 7662
+/// @section 2.1
+/// @requirement Introspection endpoint must require client authentication.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7662#section-2.1
 #[actix_web::test]
 async fn rfc7662_s2_1_introspect_requires_client_auth() {
     let client = Client::new(
@@ -309,6 +327,12 @@ async fn rfc7662_s2_1_introspect_requires_client_auth() {
 
 /// RFC 7662 §2.2: Introspection response must include `scope`, `client_id`,
 /// and `token_type` fields for an active token.
+///
+/// @rfc 7662
+/// @section 2.2
+/// @requirement Introspection response for an active token must include scope, client_id, and token_type.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
 #[actix_web::test]
 async fn rfc7662_s2_2_introspect_response_includes_required_fields() {
     let client = Client::new(
@@ -357,6 +381,12 @@ async fn rfc7662_s2_2_introspect_response_includes_required_fields() {
 
 /// RFC 7662 §2.2: Introspection must return `active: false` for a token that
 /// belongs to a different client (cross-client isolation).
+///
+/// @rfc 7662
+/// @section 2.2
+/// @requirement Introspection must report a token belonging to a different client as inactive.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
 #[actix_web::test]
 async fn rfc7662_s2_2_introspect_cross_client_returns_inactive() {
     let client_a = Client::new(
@@ -409,6 +439,12 @@ async fn rfc7662_s2_2_introspect_cross_client_returns_inactive() {
 }
 
 /// RFC 7662 §2.1: Introspect endpoint must accept client auth via Basic header.
+///
+/// @rfc 7662
+/// @section 2.1
+/// @requirement Introspection endpoint must accept HTTP Basic client authentication.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7662#section-2.1
 #[actix_web::test]
 async fn rfc7662_s2_1_introspect_accepts_basic_auth() {
     let client = Client::new(
@@ -450,6 +486,12 @@ async fn rfc7662_s2_1_introspect_accepts_basic_auth() {
 // ---------------------------------------------------------------------------
 
 /// RFC 7009 §2.2: Successful revocation must return 200 OK.
+///
+/// @rfc 7009
+/// @section 2.2
+/// @requirement Successful token revocation must return HTTP 200.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7009#section-2.2
 #[actix_web::test]
 async fn rfc7009_s2_2_revoke_valid_token_returns_200() {
     let client = Client::new(
@@ -486,6 +528,12 @@ async fn rfc7009_s2_2_revoke_valid_token_returns_200() {
 
 /// RFC 7009 §2.2: Revocation of an unknown (never-issued) token must also
 /// return 200 OK per the spec ("error-free" behavior for unknown tokens).
+///
+/// @rfc 7009
+/// @section 2.2
+/// @requirement Revocation of an unknown token must still return HTTP 200.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7009#section-2.2
 #[actix_web::test]
 async fn rfc7009_s2_2_revoke_unknown_token_returns_200() {
     let client = Client::new(
@@ -524,6 +572,12 @@ async fn rfc7009_s2_2_revoke_unknown_token_returns_200() {
 }
 
 /// RFC 7009 §2.1: Token revocation must require client authentication.
+///
+/// @rfc 7009
+/// @section 2.1
+/// @requirement Token revocation endpoint must require client authentication.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7009#section-2.1
 #[actix_web::test]
 async fn rfc7009_s2_1_revoke_requires_client_auth() {
     let client = Client::new(
@@ -560,6 +614,12 @@ async fn rfc7009_s2_1_revoke_requires_client_auth() {
 
 /// RFC 7009 §2 + RFC 7662 §2.2: After revocation, introspecting the token
 /// must return `active: false`.
+///
+/// @rfc 7009
+/// @section 2
+/// @requirement A revoked token must subsequently be reported as inactive by introspection.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7009#section-2
 #[actix_web::test]
 async fn rfc7009_s2_token_inactive_after_revoke() {
     let client = Client::new(

--- a/tests/compliance_rfc8414.rs
+++ b/tests/compliance_rfc8414.rs
@@ -39,6 +39,12 @@ macro_rules! app {
 // ---------------------------------------------------------------------------
 
 /// RFC 8414 §2: `GET /.well-known/openid-configuration` must return 200 OK.
+///
+/// @rfc 8414
+/// @section 2
+/// @requirement Authorization-server metadata endpoint must return 200 OK.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-2
 #[actix_web::test]
 async fn rfc8414_s2_metadata_endpoint_returns_200() {
     let app = app!(oidc_config());
@@ -52,6 +58,12 @@ async fn rfc8414_s2_metadata_endpoint_returns_200() {
 
 /// RFC 8414 §2: The `issuer` field in the metadata must exactly match the
 /// configured issuer identifier.
+///
+/// @rfc 8414
+/// @section 2
+/// @requirement The `issuer` metadata value must match the configured issuer URL.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-2
 #[actix_web::test]
 async fn rfc8414_s2_issuer_matches_configured_value() {
     let app = app!(oidc_config());
@@ -69,6 +81,12 @@ async fn rfc8414_s2_issuer_matches_configured_value() {
 }
 
 /// RFC 8414 §2: The metadata document must include `authorization_endpoint`.
+///
+/// @rfc 8414
+/// @section 2
+/// @requirement Metadata must include the `authorization_endpoint` field.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-2
 #[actix_web::test]
 async fn rfc8414_s2_authorization_endpoint_present() {
     let app = app!(oidc_config());
@@ -92,6 +110,12 @@ async fn rfc8414_s2_authorization_endpoint_present() {
 }
 
 /// RFC 8414 §2: The metadata document must include `token_endpoint`.
+///
+/// @rfc 8414
+/// @section 2
+/// @requirement Metadata must include the `token_endpoint` field.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-2
 #[actix_web::test]
 async fn rfc8414_s2_token_endpoint_present() {
     let app = app!(oidc_config());
@@ -108,6 +132,12 @@ async fn rfc8414_s2_token_endpoint_present() {
 }
 
 /// RFC 8414 §2: `response_types_supported` must include `"code"`.
+///
+/// @rfc 8414
+/// @section 2
+/// @requirement `response_types_supported` must include `code`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-2
 #[actix_web::test]
 async fn rfc8414_s2_response_types_includes_code() {
     let app = app!(oidc_config());
@@ -126,6 +156,12 @@ async fn rfc8414_s2_response_types_includes_code() {
 
 /// RFC 8414 §2 / RFC 7636 §4: `code_challenge_methods_supported` must include
 /// `"S256"`.
+///
+/// @rfc 8414
+/// @section 2
+/// @requirement `code_challenge_methods_supported` must include `S256`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-2
 #[actix_web::test]
 async fn rfc8414_s2_code_challenge_methods_includes_s256() {
     let app = app!(oidc_config());
@@ -146,6 +182,12 @@ async fn rfc8414_s2_code_challenge_methods_includes_s256() {
 }
 
 /// OIDC Discovery §3: The metadata must include a `userinfo_endpoint`.
+///
+/// @rfc oidc-discovery-1.0
+/// @section 3
+/// @requirement OIDC discovery metadata must include `userinfo_endpoint`.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
 #[actix_web::test]
 async fn rfc8414_s2_userinfo_endpoint_present() {
     let app = app!(oidc_config());
@@ -163,6 +205,12 @@ async fn rfc8414_s2_userinfo_endpoint_present() {
 
 /// RFC 8414 §2: `token_endpoint_auth_methods_supported` must include
 /// `"client_secret_basic"`.
+///
+/// @rfc 8414
+/// @section 2
+/// @requirement `token_endpoint_auth_methods_supported` must include `client_secret_basic`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-2
 #[actix_web::test]
 async fn rfc8414_s2_token_endpoint_auth_methods_include_basic() {
     let app = app!(oidc_config());
@@ -185,6 +233,12 @@ async fn rfc8414_s2_token_endpoint_auth_methods_include_basic() {
 }
 
 /// RFC 8414 §2: `grant_types_supported` must include `"authorization_code"`.
+///
+/// @rfc 8414
+/// @section 2
+/// @requirement `grant_types_supported` must include `authorization_code`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-2
 #[actix_web::test]
 async fn rfc8414_s2_grant_types_includes_authorization_code() {
     let app = app!(oidc_config());

--- a/tests/compliance_rfc8628.rs
+++ b/tests/compliance_rfc8628.rs
@@ -161,6 +161,12 @@ macro_rules! device_app {
 /// RFC 8628 §3.1: A valid device authorization request MUST return a JSON
 /// body containing `device_code`, `user_code`, `verification_uri`, and
 /// `expires_in`.
+///
+/// @rfc 8628
+/// @section 3.1
+/// @requirement Device authorization response must include device_code, user_code, verification_uri, expires_in.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8628#section-3.1
 #[actix_web::test]
 async fn rfc8628_s3_1_response_contains_required_fields() {
     let (token_actor, client_actor, auth_actor, storage, jwt_secret, metrics, oidc_config) =
@@ -219,6 +225,12 @@ async fn rfc8628_s3_1_response_contains_required_fields() {
 }
 
 /// RFC 8628 §3.1: A missing or unknown `client_id` MUST return an error.
+///
+/// @rfc 8628
+/// @section 3.1
+/// @requirement Device authorization endpoint must reject missing or unknown client_id.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8628#section-3.1
 #[actix_web::test]
 async fn rfc8628_s3_1_missing_client_id_returns_error() {
     let (token_actor, client_actor, auth_actor, storage, jwt_secret, metrics, oidc_config) =
@@ -251,6 +263,12 @@ async fn rfc8628_s3_1_missing_client_id_returns_error() {
 
 /// RFC 8628 §3.1: A client that is not authorized to use the device_code
 /// grant type MUST receive an `unauthorized_client` error.
+///
+/// @rfc 8628
+/// @section 3.1
+/// @requirement A client without device_code grant must receive `unauthorized_client`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8628#section-3.1
 #[actix_web::test]
 async fn rfc8628_s3_1_unauthorized_client_is_rejected() {
     let non_device_client = Client::new(
@@ -300,6 +318,12 @@ async fn rfc8628_s3_1_unauthorized_client_is_rejected() {
 
 /// RFC 8628 §3.3: A user who approves a valid `user_code` MUST receive a
 /// successful (2xx) response from the verification endpoint.
+///
+/// @rfc 8628
+/// @section 3.3
+/// @requirement Approving a valid user_code at the verification endpoint must return a 2xx response.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8628#section-3.3
 #[actix_web::test]
 async fn rfc8628_s3_3_approve_returns_success() {
     let (token_actor, client_actor, auth_actor, storage, jwt_secret, metrics, oidc_config) =
@@ -361,6 +385,12 @@ async fn rfc8628_s3_3_approve_returns_success() {
 
 /// RFC 8628 §3.3: A user who denies a valid `user_code` MUST receive a
 /// successful (2xx) response from the verification endpoint.
+///
+/// @rfc 8628
+/// @section 3.3
+/// @requirement Denying a valid user_code at the verification endpoint must return a 2xx response.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8628#section-3.3
 #[actix_web::test]
 async fn rfc8628_s3_3_deny_returns_success() {
     let (token_actor, client_actor, auth_actor, storage, jwt_secret, metrics, oidc_config) =
@@ -422,6 +452,12 @@ async fn rfc8628_s3_3_deny_returns_success() {
 
 /// RFC 8628 §3.4: Polling before the user approves MUST return a 400 with
 /// `error=authorization_pending`.
+///
+/// @rfc 8628
+/// @section 3.4
+/// @requirement Token polling before approval must return 400 with error=authorization_pending.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8628#section-3.4
 #[actix_web::test]
 async fn rfc8628_s3_4_pending_returns_authorization_pending() {
     let (token_actor, client_actor, auth_actor, storage, jwt_secret, metrics, oidc_config) =
@@ -478,6 +514,12 @@ async fn rfc8628_s3_4_pending_returns_authorization_pending() {
 
 /// RFC 8628 §3.4: After the user approves, polling MUST return 200 with a
 /// valid access token.
+///
+/// @rfc 8628
+/// @section 3.4
+/// @requirement After user approval, token polling must return 200 with an access token.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8628#section-3.4
 #[actix_web::test]
 async fn rfc8628_s3_4_approved_returns_access_token() {
     let (token_actor, client_actor, auth_actor, storage, jwt_secret, metrics, oidc_config) =
@@ -557,6 +599,12 @@ async fn rfc8628_s3_4_approved_returns_access_token() {
 
 /// RFC 8628 §3.4: An unknown or invalid `device_code` MUST return a 4xx
 /// error (not a 200 or 5xx).
+///
+/// @rfc 8628
+/// @section 3.4
+/// @requirement Unknown or invalid device_code at the token endpoint must return a 4xx error.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8628#section-3.4
 #[actix_web::test]
 async fn rfc8628_s3_4_unknown_device_code_returns_error() {
     let (token_actor, client_actor, auth_actor, storage, jwt_secret, metrics, oidc_config) =
@@ -596,6 +644,12 @@ async fn rfc8628_s3_4_unknown_device_code_returns_error() {
 /// `/device_authorization` using `client_secret_basic` — the handler must
 /// accept credentials from the `Authorization` header when the form body
 /// omits `client_id`/`client_secret`.
+///
+/// @rfc 8628
+/// @section 3.1
+/// @requirement Device authorization endpoint must accept client_secret_basic credentials.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8628#section-3.1
 #[actix_web::test]
 async fn rfc8628_s3_1_accepts_client_secret_basic() {
     use base64::{engine::general_purpose::STANDARD, Engine};

--- a/tests/compliance_wave3.rs
+++ b/tests/compliance_wave3.rs
@@ -98,6 +98,12 @@ async fn setup_context(
 
 /// RFC 9126 §2.2: A public client (no secret) POSTing valid params to /oauth/par
 /// must receive 201 Created with `request_uri` and `expires_in: 60`.
+///
+/// @rfc 9126
+/// @section 2.2
+/// @requirement PAR endpoint must return 201 with `request_uri` and `expires_in` for valid public-client requests.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9126#section-2.2
 #[actix_web::test]
 async fn rfc9126_par_public_client_returns_request_uri() {
     // Build a public client (token_endpoint_auth_method = "none").
@@ -152,6 +158,12 @@ async fn rfc9126_par_public_client_returns_request_uri() {
 }
 
 /// RFC 9126 §2.1: PAR request without `response_type` must be rejected.
+///
+/// @rfc 9126
+/// @section 2.1
+/// @requirement PAR endpoint must reject requests missing the `response_type` parameter.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9126#section-2.1
 #[actix_web::test]
 async fn rfc9126_par_missing_response_type_is_rejected() {
     let mut client = Client::new(
@@ -193,6 +205,12 @@ async fn rfc9126_par_missing_response_type_is_rejected() {
 }
 
 /// RFC 9126 §2.1: PAR request with duplicate parameters must be rejected.
+///
+/// @rfc 9126
+/// @section 2.1
+/// @requirement PAR endpoint must reject requests containing duplicate parameters.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9126#section-2.1
 #[actix_web::test]
 async fn rfc9126_par_duplicate_param_is_rejected() {
     let mut client = Client::new(
@@ -235,6 +253,12 @@ async fn rfc9126_par_duplicate_param_is_rejected() {
 }
 
 /// RFC 9126 §2.1: Confidential client sending PAR without authentication must be rejected.
+///
+/// @rfc 9126
+/// @section 2.1
+/// @requirement PAR endpoint must reject confidential clients that do not authenticate.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9126#section-2.1
 #[actix_web::test]
 async fn rfc9126_par_confidential_client_no_secret_rejected() {
     // Confidential client (default token_endpoint_auth_method = "client_secret_basic").
@@ -278,6 +302,12 @@ async fn rfc9126_par_confidential_client_no_secret_rejected() {
 }
 
 /// RFC 9126 §2.1: Confidential client with valid Basic auth succeeds.
+///
+/// @rfc 9126
+/// @section 2.1
+/// @requirement PAR endpoint must accept confidential client authenticated via HTTP Basic.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9126#section-2.1
 #[actix_web::test]
 async fn rfc9126_par_confidential_client_with_basic_auth_succeeds() {
     let client = Client::new(
@@ -336,6 +366,12 @@ async fn rfc9126_par_confidential_client_with_basic_auth_succeeds() {
 /// RFC 8707 §2: A `resource` parameter in a client_credentials request must be
 /// accepted. The token must be issued successfully (the server records the
 /// audience for later use).
+///
+/// @rfc 8707
+/// @section 2
+/// @requirement Token endpoint must accept `resource` parameter and bind it as token audience.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8707#section-2
 #[actix_web::test]
 async fn rfc8707_resource_indicator_accepted_in_client_credentials() {
     let client = Client::new(
@@ -396,6 +432,12 @@ async fn rfc8707_resource_indicator_accepted_in_client_credentials() {
 /// the introspection endpoint must return a signed JWT with
 /// `Content-Type: application/token-introspection+jwt` and
 /// JOSE header `typ: "token-introspection+jwt"`.
+///
+/// @rfc 9701
+/// @section 4
+/// @requirement Introspection must return a signed JWT response when `Accept: application/token-introspection+jwt`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9701#section-4
 #[actix_web::test]
 async fn rfc9701_jwt_accept_header_returns_jwt_introspection_response() {
     let client = Client::new(
@@ -479,6 +521,12 @@ async fn rfc9701_jwt_accept_header_returns_jwt_introspection_response() {
 
 /// RFC 9701 §4: When no special Accept header is sent, the introspection endpoint
 /// must still return the standard JSON response.
+///
+/// @rfc 9701
+/// @section 4
+/// @requirement Introspection without special Accept must return the standard JSON response.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9701#section-4
 #[actix_web::test]
 async fn rfc9701_standard_accept_returns_json_introspection_response() {
     let client = Client::new(
@@ -546,6 +594,12 @@ async fn rfc9701_standard_accept_returns_json_introspection_response() {
 
 /// RFC 9701 §4: The JWT payload must contain a `token_introspection` claim
 /// with the standard introspection fields (active, scope, client_id).
+///
+/// @rfc 9701
+/// @section 4
+/// @requirement JWT introspection payload must include a `token_introspection` claim with standard fields.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9701#section-4
 #[actix_web::test]
 async fn rfc9701_jwt_payload_contains_token_introspection_claim() {
     let client = Client::new(

--- a/tests/compliance_wave4.rs
+++ b/tests/compliance_wave4.rs
@@ -65,6 +65,12 @@ async fn discovery_body(oidc_config: OidcConfig) -> Value {
 // ---------------------------------------------------------------------------
 
 /// RFC 9449 §5: Discovery document MUST advertise `dpop_signing_alg_values_supported`.
+///
+/// @rfc 9449
+/// @section 5
+/// @requirement Discovery metadata must advertise `dpop_signing_alg_values_supported`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9449#section-5
 #[actix_web::test]
 async fn wave4_rfc9449_dpop_signing_alg_values_supported_advertised() {
     let body = discovery_body(oidc_config()).await;
@@ -88,6 +94,12 @@ async fn wave4_rfc9449_dpop_signing_alg_values_supported_advertised() {
 
 /// RFC 8705 §3: Discovery document MUST advertise
 /// `tls_client_certificate_bound_access_tokens: true`.
+///
+/// @rfc 8705
+/// @section 3
+/// @requirement Discovery metadata must advertise `tls_client_certificate_bound_access_tokens: true`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8705#section-3
 #[actix_web::test]
 async fn wave4_rfc8705_mtls_advertised_in_discovery() {
     let body = discovery_body(oidc_config()).await;
@@ -104,6 +116,12 @@ async fn wave4_rfc8705_mtls_advertised_in_discovery() {
 
 /// RFC 8693 §2.1: Token Exchange grant type MUST appear in
 /// `grant_types_supported`.
+///
+/// @rfc 8693
+/// @section 2.1
+/// @requirement Discovery metadata must include `urn:ietf:params:oauth:grant-type:token-exchange` in grant_types_supported.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8693#section-2.1
 #[actix_web::test]
 async fn wave4_rfc8693_token_exchange_grant_type_in_discovery() {
     let body = discovery_body(oidc_config()).await;
@@ -124,6 +142,12 @@ async fn wave4_rfc8693_token_exchange_grant_type_in_discovery() {
 
 /// RFC 9396 §7: Discovery document MUST advertise
 /// `authorization_details_types_supported`.
+///
+/// @rfc 9396
+/// @section 7
+/// @requirement Discovery metadata must advertise `authorization_details_types_supported`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9396#section-7
 #[actix_web::test]
 async fn wave4_rfc9396_rar_advertised_in_discovery() {
     let body = discovery_body(oidc_config()).await;
@@ -141,6 +165,12 @@ async fn wave4_rfc9396_rar_advertised_in_discovery() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9470 §4: Discovery document MUST advertise `acr_values_supported`.
+///
+/// @rfc 9470
+/// @section 4
+/// @requirement Discovery metadata must advertise `acr_values_supported`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9470#section-4
 #[actix_web::test]
 async fn wave4_rfc9470_acr_values_supported_advertised() {
     let body = discovery_body(oidc_config()).await;
@@ -155,6 +185,12 @@ async fn wave4_rfc9470_acr_values_supported_advertised() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9728 §3: GET /.well-known/oauth-protected-resource MUST return 200.
+///
+/// @rfc 9728
+/// @section 3
+/// @requirement /.well-known/oauth-protected-resource must return 200.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9728#section-3
 #[actix_web::test]
 async fn wave4_rfc9728_protected_resource_metadata_returns_200() {
     let app = discovery_app!(oidc_config());
@@ -170,6 +206,12 @@ async fn wave4_rfc9728_protected_resource_metadata_returns_200() {
 }
 
 /// RFC 9728 §3: Protected resource metadata MUST include a `resource` field.
+///
+/// @rfc 9728
+/// @section 3
+/// @requirement Protected resource metadata must include a `resource` field.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9728#section-3
 #[actix_web::test]
 async fn wave4_rfc9728_protected_resource_metadata_has_resource_field() {
     let app = discovery_app!(oidc_config());
@@ -186,6 +228,12 @@ async fn wave4_rfc9728_protected_resource_metadata_has_resource_field() {
 
 /// RFC 9728 §3: Protected resource metadata MUST include
 /// `authorization_servers`.
+///
+/// @rfc 9728
+/// @section 3
+/// @requirement Protected resource metadata must include an `authorization_servers` array.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9728#section-3
 #[actix_web::test]
 async fn wave4_rfc9728_protected_resource_metadata_has_authorization_servers() {
     let app = discovery_app!(oidc_config());
@@ -209,6 +257,12 @@ async fn wave4_rfc9728_protected_resource_metadata_has_authorization_servers() {
 
 /// Token Status List: GET /.well-known/oauth-authorization-server/status MUST
 /// return 200.
+///
+/// @rfc draft-ietf-oauth-status-list
+/// @section 5
+/// @requirement Token Status List discovery endpoint must return 200.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/draft-ietf-oauth-status-list
 #[actix_web::test]
 async fn wave4_token_status_list_returns_200() {
     let app = discovery_app!(oidc_config());
@@ -224,6 +278,12 @@ async fn wave4_token_status_list_returns_200() {
 }
 
 /// Token Status List: Response must be valid JSON.
+///
+/// @rfc draft-ietf-oauth-status-list
+/// @section 5
+/// @requirement Token Status List response must be valid JSON.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/draft-ietf-oauth-status-list
 #[actix_web::test]
 async fn wave4_token_status_list_returns_valid_json() {
     let app = discovery_app!(oidc_config());
@@ -241,6 +301,12 @@ async fn wave4_token_status_list_returns_valid_json() {
 
 /// OIDC Core §5.5: Discovery document MUST include `acr` and `auth_time` in
 /// `claims_supported` to advertise support for Claims Request parameter.
+///
+/// @rfc oidc-core-1.0
+/// @section 5.5
+/// @requirement Discovery `claims_supported` must advertise `acr` and `auth_time` to indicate Claims Request support.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
 #[actix_web::test]
 async fn wave4_oidc_claims_request_acr_auth_time_in_claims_supported() {
     let body = discovery_body(oidc_config()).await;

--- a/tests/compliance_wave5.rs
+++ b/tests/compliance_wave5.rs
@@ -237,6 +237,12 @@ macro_rules! discovery_app {
 
 /// OIDC Multiple Response Types §2: `response_mode=fragment` must deliver the
 /// authorization code in the URL fragment rather than the query string.
+///
+/// @rfc oidc-mrt-1.0
+/// @section 2
+/// @requirement `response_mode=fragment` must encode authorization response in URL fragment.
+/// @level MUST
+/// @url https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes
 #[actix_web::test]
 async fn wave5_response_mode_fragment_delivers_code_in_fragment() {
     let client = Client::new(
@@ -305,6 +311,12 @@ async fn wave5_response_mode_fragment_delivers_code_in_fragment() {
 }
 
 /// An unsupported response_mode must be rejected with an invalid_request error.
+///
+/// @rfc oidc-mrt-1.0
+/// @section 2
+/// @requirement An unsupported `response_mode` value must produce `invalid_request`.
+/// @level MUST
+/// @url https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes
 #[actix_web::test]
 async fn wave5_unsupported_response_mode_is_rejected() {
     let client = Client::new(
@@ -348,6 +360,12 @@ async fn wave5_unsupported_response_mode_is_rejected() {
 
 /// OIDC Core §3.3: A `code id_token` hybrid request must return both an
 /// authorization code and an id_token in the fragment.
+///
+/// @rfc oidc-core-1.0
+/// @section 3.3
+/// @requirement Hybrid `code id_token` flow must return both `code` and `id_token` in the response fragment.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth
 #[actix_web::test]
 async fn wave5_hybrid_code_id_token_delivers_both_in_fragment() {
     let client = Client::new(
@@ -413,6 +431,12 @@ async fn wave5_hybrid_code_id_token_delivers_both_in_fragment() {
 
 /// OIDC Core §3.3: When scope does NOT include "openid", a `code id_token`
 /// request must NOT include an id_token in the response (no openid scope → no id_token).
+///
+/// @rfc oidc-core-1.0
+/// @section 3.3
+/// @requirement Hybrid `code id_token` without `openid` scope must not return an id_token.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth
 #[actix_web::test]
 async fn wave5_hybrid_no_openid_scope_omits_id_token() {
     let client = Client::new(
@@ -478,6 +502,12 @@ async fn wave5_hybrid_no_openid_scope_omits_id_token() {
 
 /// RFC 9101 §4: A public client (token_endpoint_auth_method=none) may send an
 /// unsigned (alg=none) JAR.  The JWT payload claims override the query parameters.
+///
+/// @rfc 9101
+/// @section 4
+/// @requirement A public client may submit an unsigned (alg=none) JAR via the `request` parameter.
+/// @level MAY
+/// @url https://datatracker.ietf.org/doc/html/rfc9101#section-4
 #[actix_web::test]
 async fn wave5_jar_public_client_unsigned_succeeds() {
     let mut client = Client::new(
@@ -545,6 +575,12 @@ async fn wave5_jar_public_client_unsigned_succeeds() {
 /// RFC 9101 §4: A confidential client may sign the JAR with HS256 using its
 /// client_secret.  The payload claims must include `iss` (= client_id), `exp`,
 /// and `aud` (= authorization endpoint URL).
+///
+/// @rfc 9101
+/// @section 4
+/// @requirement A confidential client may submit a JAR signed with HS256 derived from client_secret.
+/// @level MAY
+/// @url https://datatracker.ietf.org/doc/html/rfc9101#section-4
 #[actix_web::test]
 async fn wave5_jar_confidential_client_hs256_succeeds() {
     let client_secret = "secret_jar_hs256";
@@ -615,6 +651,12 @@ async fn wave5_jar_confidential_client_hs256_succeeds() {
 }
 
 /// RFC 9101 §4: A JAR with a tampered / wrong signature must be rejected.
+///
+/// @rfc 9101
+/// @section 4
+/// @requirement JAR with an invalid / tampered signature must be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9101#section-4
 #[actix_web::test]
 async fn wave5_jar_tampered_hs256_is_rejected() {
     let client = Client::new(
@@ -684,6 +726,12 @@ fn make_jar_with_header_and_sig(header_json: &str, claims: Value, signature: &st
 /// `alg: "HS256"` (or any non-`none` algorithm).  Before the fix, the server
 /// would blindly base64-decode the payload without inspecting the header or
 /// signature — a signature-bypass primitive.
+///
+/// @rfc 9101
+/// @section 4
+/// @requirement A public-client JAR with a non-`none` `alg` header must be rejected (no signature-bypass).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9101#section-4
 #[actix_web::test]
 async fn wave2_c1_public_client_jar_rejects_non_none_alg_header() {
     let mut client = Client::new(
@@ -739,6 +787,12 @@ async fn wave2_c1_public_client_jar_rejects_non_none_alg_header() {
 
 /// C1: A public client JAR whose header says `alg: "none"` but carries a
 /// non-empty signature must also be rejected (RFC 7515 §6).
+///
+/// @rfc 7515
+/// @section 6
+/// @requirement A JWS with `alg: none` and a non-empty signature must be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7515#section-6
 #[actix_web::test]
 async fn wave2_c1_public_client_jar_rejects_nonempty_signature_with_alg_none() {
     let mut client = Client::new(
@@ -803,6 +857,12 @@ async fn wave2_c1_public_client_jar_rejects_nonempty_signature_with_alg_none() {
 /// §4.3) is disabled per OAuth 2.0 Security BCP.  Token endpoint must reject
 /// `grant_type=password` with `unsupported_grant_type` regardless of client
 /// authentication state.
+///
+/// @rfc 9700
+/// @section 2.4
+/// @requirement Resource Owner Password Credentials grant must be disabled (`unsupported_grant_type`).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.4
 #[actix_web::test]
 async fn wave2_c3_password_grant_is_rejected() {
     use std::sync::Arc;
@@ -862,6 +922,12 @@ async fn wave2_c3_password_grant_is_rejected() {
 // ---------------------------------------------------------------------------
 
 /// Discovery must advertise `code id_token` as a supported response type.
+///
+/// @rfc oidc-discovery-1.0
+/// @section 3
+/// @requirement Discovery `response_types_supported` must include `code id_token` for hybrid flow.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
 #[actix_web::test]
 async fn wave5_discovery_response_types_includes_code_id_token() {
     let app = discovery_app!(oidc_config());
@@ -887,6 +953,12 @@ async fn wave5_discovery_response_types_includes_code_id_token() {
 }
 
 /// Discovery must advertise `fragment` as a supported response mode.
+///
+/// @rfc oidc-discovery-1.0
+/// @section 3
+/// @requirement Discovery `response_modes_supported` must include `fragment`.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
 #[actix_web::test]
 async fn wave5_discovery_response_modes_includes_fragment() {
     let app = discovery_app!(oidc_config());
@@ -915,6 +987,12 @@ async fn wave5_discovery_response_modes_includes_fragment() {
 }
 
 /// Discovery must advertise `request_parameter_supported: true` (RFC 9101).
+///
+/// @rfc 9101
+/// @section 9
+/// @requirement Discovery must advertise `request_parameter_supported: true`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9101#section-9
 #[actix_web::test]
 async fn wave5_discovery_request_parameter_supported_is_true() {
     let app = discovery_app!(oidc_config());

--- a/tests/compliance_wave6.rs
+++ b/tests/compliance_wave6.rs
@@ -201,6 +201,12 @@ macro_rules! logout_app {
 // ---------------------------------------------------------------------------
 
 /// OIDC Session Management 1.0: check_session_iframe must be advertised.
+///
+/// @rfc oidc-session-1.0
+/// @section 4
+/// @requirement Discovery must advertise `check_session_iframe` for OIDC Session Management.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-session-1_0.html#OPMetadata
 #[actix_web::test]
 async fn wave6_discovery_includes_session_management_fields() {
     let oidc = oidc_config();
@@ -250,6 +256,12 @@ async fn wave6_discovery_includes_session_management_fields() {
 
 /// OIDC Session Management 1.0 §3: check_session_iframe must return HTML
 /// with a postMessage handler.
+///
+/// @rfc oidc-session-1.0
+/// @section 3
+/// @requirement check_session_iframe must return HTML with a postMessage handler.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-session-1_0.html#OPiframe
 #[actix_web::test]
 async fn wave6_check_session_iframe_returns_html() {
     let oidc = oidc_config();
@@ -295,6 +307,12 @@ async fn wave6_check_session_iframe_returns_html() {
 
 /// OIDC Front-Channel Logout 1.0 §3: When a client has frontchannel_logout_uri
 /// registered, the logout endpoint must render an HTML page with iframes.
+///
+/// @rfc oidc-frontchannel-1.0
+/// @section 3
+/// @requirement Logout endpoint must render front-channel logout iframes for clients with `frontchannel_logout_uri`.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-frontchannel-1_0.html#RPLogout
 #[actix_web::test]
 async fn wave6_logout_renders_frontchannel_iframes() {
     let client = frontchannel_client();
@@ -340,6 +358,12 @@ async fn wave6_logout_renders_frontchannel_iframes() {
 
 /// OIDC RP-Initiated Logout: post_logout_redirect_uri must be checked against
 /// post_logout_redirect_uris (not just redirect_uris).
+///
+/// @rfc oidc-rpinit-1.0
+/// @section 3
+/// @requirement Logout must accept post_logout_redirect_uri only when registered in post_logout_redirect_uris.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
 #[actix_web::test]
 async fn wave6_logout_accepts_registered_post_logout_redirect_uri() {
     let client = backchannel_client();
@@ -374,6 +398,12 @@ async fn wave6_logout_accepts_registered_post_logout_redirect_uri() {
 }
 
 /// OIDC RP-Initiated Logout: unregistered post_logout_redirect_uri must be rejected.
+///
+/// @rfc oidc-rpinit-1.0
+/// @section 3
+/// @requirement Logout must reject unregistered post_logout_redirect_uri values.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
 #[actix_web::test]
 async fn wave6_logout_rejects_unregistered_post_logout_redirect_uri() {
     let client = backchannel_client();
@@ -414,6 +444,12 @@ async fn wave6_logout_rejects_unregistered_post_logout_redirect_uri() {
 // ---------------------------------------------------------------------------
 
 /// OIDC Core §3.1.2.1: prompt=consent should proceed normally (auto-approve).
+///
+/// @rfc oidc-core-1.0
+/// @section 3.1.2.1
+/// @requirement `prompt=consent` must proceed to authorization (auto-approve in test harness).
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 #[actix_web::test]
 async fn wave6_prompt_consent_proceeds_after_auto_approve() {
     let mut client = Client::new(
@@ -475,6 +511,12 @@ async fn wave6_prompt_consent_proceeds_after_auto_approve() {
 
 /// OIDC Core §3.1.2.1: prompt=select_account forces re-authentication
 /// (single-account server treats it as prompt=login).
+///
+/// @rfc oidc-core-1.0
+/// @section 3.1.2.1
+/// @requirement `prompt=select_account` must force account selection / re-authentication.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 #[actix_web::test]
 async fn wave6_prompt_select_account_forces_reauth() {
     let client = Client::new(
@@ -534,6 +576,12 @@ async fn wave6_prompt_select_account_forces_reauth() {
 
 /// OIDC Back-Channel Logout 1.0 §2.1: Dynamic client registration must
 /// accept backchannel_logout_uri and backchannel_logout_session_required.
+///
+/// @rfc oidc-backchannel-1.0
+/// @section 2.1
+/// @requirement Dynamic client registration must accept `backchannel_logout_uri` and `backchannel_logout_session_required`.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-backchannel-1_0.html#ClientMetadata
 #[actix_web::test]
 async fn wave6_client_registration_includes_logout_fields() {
     let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
@@ -593,6 +641,12 @@ async fn wave6_client_registration_includes_logout_fields() {
 }
 
 /// OIDC RP-Initiated Logout: simple logout without id_token_hint or redirect returns 200.
+///
+/// @rfc oidc-rpinit-1.0
+/// @section 3
+/// @requirement Logout endpoint must accept a simple GET (no id_token_hint, no redirect) and return 200.
+/// @level SHOULD
+/// @url https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
 #[actix_web::test]
 async fn wave6_simple_logout_returns_ok() {
     let client = Client::new(

--- a/tests/phase2_rfc_compliance.rs
+++ b/tests/phase2_rfc_compliance.rs
@@ -90,6 +90,12 @@ async fn setup_phase2_context(
 
 /// RFC 7591 §3.1: successful dynamic registration returns a 201 with full
 /// client information response including registration_access_token.
+///
+/// @rfc 7591
+/// @section 3.1
+/// @requirement Successful dynamic client registration must return 201 with full client info plus registration_access_token.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7591#section-3.1
 #[actix_web::test]
 async fn rfc7591_dynamic_registration_success() {
     const ISSUER: &str = "https://auth.example.com";
@@ -170,6 +176,12 @@ async fn rfc7591_dynamic_registration_success() {
 
 /// RFC 7591 §3.1: defaults — when `grant_types` and `response_types` are
 /// omitted, the server MUST default to `authorization_code` / `code`.
+///
+/// @rfc 7591
+/// @section 3.1
+/// @requirement Registration must default `grant_types`/`response_types` to `authorization_code`/`code` when omitted.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7591#section-3.1
 #[actix_web::test]
 async fn rfc7591_defaults_grant_and_response_types() {
     const ISSUER: &str = "https://auth.example.com";
@@ -216,6 +228,12 @@ async fn rfc7591_defaults_grant_and_response_types() {
 
 /// RFC 7591 §3.1: public client registration (token_endpoint_auth_method=none)
 /// must NOT return a client_secret.
+///
+/// @rfc 7591
+/// @section 3.1
+/// @requirement Public-client registration must omit `client_secret` from the registration response.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7591#section-3.1
 #[actix_web::test]
 async fn rfc7591_public_client_no_secret() {
     const ISSUER: &str = "https://auth.example.com";
@@ -268,6 +286,12 @@ async fn rfc7591_public_client_no_secret() {
 }
 
 /// RFC 7591: registration rejects invalid redirect_uris.
+///
+/// @rfc 7591
+/// @section 2
+/// @requirement Registration must reject invalid `redirect_uris` (malformed/non-absolute/etc).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7591#section-2
 #[actix_web::test]
 async fn rfc7591_rejects_invalid_redirect_uris() {
     const ISSUER: &str = "https://auth.example.com";
@@ -345,6 +369,12 @@ macro_rules! register_test_client {
 
 /// RFC 7592 §2.1: GET /connect/register/{client_id} with a valid
 /// registration_access_token returns the client configuration.
+///
+/// @rfc 7592
+/// @section 2.1
+/// @requirement GET on the client configuration endpoint must return the client config when authenticated with the registration access token.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7592#section-2.1
 #[actix_web::test]
 async fn rfc7592_read_client_configuration() {
     const ISSUER: &str = "https://auth.example.com";
@@ -411,6 +441,12 @@ async fn rfc7592_read_client_configuration() {
 }
 
 /// RFC 7592 §2.2: PUT /connect/register/{client_id} updates the client.
+///
+/// @rfc 7592
+/// @section 2.2
+/// @requirement PUT on the client configuration endpoint must update the client metadata.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7592#section-2.2
 #[actix_web::test]
 async fn rfc7592_update_client_configuration() {
     const ISSUER: &str = "https://auth.example.com";
@@ -475,6 +511,12 @@ async fn rfc7592_update_client_configuration() {
 }
 
 /// RFC 7592 §2.3: DELETE /connect/register/{client_id} deletes the client.
+///
+/// @rfc 7592
+/// @section 2.3
+/// @requirement DELETE on the client configuration endpoint must remove the client.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7592#section-2.3
 #[actix_web::test]
 async fn rfc7592_delete_client() {
     const ISSUER: &str = "https://auth.example.com";
@@ -543,6 +585,12 @@ async fn rfc7592_delete_client() {
 
 /// RFC 7523 §2.2 — client_secret_jwt: token endpoint authenticates client
 /// using an HS256 JWT signed with the client's secret.
+///
+/// @rfc 7523
+/// @section 2.2
+/// @requirement Token endpoint must accept `client_secret_jwt` (HS256 JWT signed with client_secret).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7523#section-2.2
 #[actix_web::test]
 async fn rfc7523_client_secret_jwt_authentication() {
     const ISSUER: &str = "https://auth.example.com";
@@ -613,6 +661,12 @@ async fn rfc7523_client_secret_jwt_authentication() {
 }
 
 /// RFC 7523: client_secret_jwt with wrong secret must fail.
+///
+/// @rfc 7523
+/// @section 2.2
+/// @requirement A client_secret_jwt assertion signed with the wrong secret must be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7523#section-2.2
 #[actix_web::test]
 async fn rfc7523_client_secret_jwt_wrong_secret_fails() {
     const ISSUER: &str = "https://auth.example.com";
@@ -684,6 +738,12 @@ async fn rfc7523_client_secret_jwt_wrong_secret_fails() {
 /// RFC 7523 §2.2 — private_key_jwt: token endpoint authenticates client
 /// using an RS256 JWT signed with the client's private key, verified against
 /// the registered JWKS.
+///
+/// @rfc 7523
+/// @section 2.2
+/// @requirement Token endpoint must accept `private_key_jwt` (RS256 JWT verified against registered JWKS).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7523#section-2.2
 #[actix_web::test]
 async fn rfc7523_private_key_jwt_authentication() {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
@@ -787,6 +847,12 @@ async fn rfc7523_private_key_jwt_authentication() {
 
 /// RFC 8414 §2: the discovery document MUST reflect the new auth methods
 /// and registration endpoint.
+///
+/// @rfc 8414
+/// @section 2
+/// @requirement Discovery doc must reflect supported client auth methods (incl. client_secret_jwt, private_key_jwt) and registration endpoint.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-2
 #[actix_web::test]
 async fn rfc8414_discovery_reflects_phase2() {
     const ISSUER: &str = "https://auth.example.com";
@@ -857,6 +923,12 @@ async fn rfc8414_discovery_reflects_phase2() {
 /// OIDC Core: client registration should accept and preserve full OIDC
 /// metadata fields (contacts, logo_uri, client_uri, policy_uri, tos_uri,
 /// response_types).
+///
+/// @rfc oidc-registration-1.0
+/// @section 2
+/// @requirement Registration must accept and round-trip OIDC client metadata (contacts, *_uri fields, response_types).
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
 #[actix_web::test]
 async fn oidc_metadata_preserved_in_registration() {
     const ISSUER: &str = "https://auth.example.com";
@@ -940,6 +1012,12 @@ async fn oidc_metadata_preserved_in_registration() {
 }
 
 /// RFC 7591: private_key_jwt registration requires jwks or jwks_uri.
+///
+/// @rfc 7591
+/// @section 2
+/// @requirement Registering with `token_endpoint_auth_method=private_key_jwt` must require `jwks` or `jwks_uri`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7591#section-2
 #[actix_web::test]
 async fn rfc7591_private_key_jwt_requires_jwks() {
     const ISSUER: &str = "https://auth.example.com";
@@ -1001,6 +1079,12 @@ async fn rfc7591_private_key_jwt_requires_jwks() {
 }
 
 /// RFC 7591 §2: jwks and jwks_uri MUST NOT both be present.
+///
+/// @rfc 7591
+/// @section 2
+/// @requirement Registration request must not contain both `jwks` and `jwks_uri`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7591#section-2
 #[actix_web::test]
 async fn rfc7591_jwks_and_jwks_uri_mutually_exclusive() {
     const ISSUER: &str = "https://auth.example.com";

--- a/tests/rfc8252_native_apps.rs
+++ b/tests/rfc8252_native_apps.rs
@@ -26,6 +26,12 @@ fn client_registered_for(redirect: &str) -> Client {
 
 /// §7.3 — registered `127.0.0.1:3000`, request arrives on a different
 /// ephemeral port. Must be accepted.
+///
+/// @rfc 8252
+/// @section 7.3
+/// @requirement IPv4 loopback (127.0.0.1) redirect URIs must accept any port at request time.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
 #[test]
 fn rfc8252_ipv4_loopback_any_port_accepted() {
     let c = client_registered_for("http://127.0.0.1:3000/cb");
@@ -34,6 +40,12 @@ fn rfc8252_ipv4_loopback_any_port_accepted() {
 }
 
 /// §7.3 — same for IPv6 literal.
+///
+/// @rfc 8252
+/// @section 7.3
+/// @requirement IPv6 loopback ([::1]) redirect URIs must accept any port at request time.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
 #[test]
 fn rfc8252_ipv6_loopback_any_port_accepted() {
     let c = client_registered_for("http://[::1]:3000/cb");
@@ -45,6 +57,12 @@ fn rfc8252_ipv6_loopback_any_port_accepted() {
 /// requests `http://localhost:4000/cb` is rejected; the same client
 /// requesting the literal registered URI is still accepted via the
 /// exact-match fast path.
+///
+/// @rfc 8252
+/// @section 8.3
+/// @requirement `localhost` hostname must NOT receive the loopback port-wildcard exception.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8252#section-8.3
 #[test]
 fn rfc8252_localhost_hostname_does_not_wildcard_port() {
     let c = client_registered_for("http://localhost:3000/cb");
@@ -60,6 +78,12 @@ fn rfc8252_localhost_hostname_does_not_wildcard_port() {
 
 /// IPv4-registered clients MUST NOT be able to redirect to `[::1]` and
 /// vice versa. Each loopback family is treated as a distinct host.
+///
+/// @rfc 8252
+/// @section 7.3
+/// @requirement IPv4 and IPv6 loopback hosts must be treated as distinct (no cross-family wildcarding).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
 #[test]
 fn rfc8252_loopback_families_do_not_cross() {
     let v4 = client_registered_for("http://127.0.0.1:3000/cb");
@@ -71,6 +95,12 @@ fn rfc8252_loopback_families_do_not_cross() {
 /// The loopback exception is scoped to loopback hosts only. A client
 /// registered for `http://example.com/cb` MUST NOT benefit from any
 /// port-wildcard leniency.
+///
+/// @rfc 8252
+/// @section 7.3
+/// @requirement Non-loopback hosts must require exact redirect URI match (no port wildcard).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
 #[test]
 fn rfc8252_non_loopback_host_requires_exact_match() {
     let c = client_registered_for("http://example.com:3000/cb");
@@ -79,6 +109,12 @@ fn rfc8252_non_loopback_host_requires_exact_match() {
 }
 
 /// Path must still match; only the port is wildcarded under §7.3.
+///
+/// @rfc 8252
+/// @section 7.3
+/// @requirement Loopback exception must still require path equality; only the port is wildcarded.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
 #[test]
 fn rfc8252_loopback_exception_still_requires_path_match() {
     let c = client_registered_for("http://127.0.0.1:3000/cb");
@@ -88,6 +124,12 @@ fn rfc8252_loopback_exception_still_requires_path_match() {
 
 /// Scheme must match; only the port is wildcarded under §7.3. An HTTP
 /// registration does not authorize an HTTPS request to a loopback port.
+///
+/// @rfc 8252
+/// @section 7.3
+/// @requirement Loopback exception must still require scheme equality (http vs https are distinct).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
 #[test]
 fn rfc8252_loopback_exception_still_requires_scheme_match() {
     let c = client_registered_for("http://127.0.0.1:3000/cb");
@@ -97,6 +139,12 @@ fn rfc8252_loopback_exception_still_requires_scheme_match() {
 /// Exact-match fallback still honors custom URI schemes — RFC 8252 §7.1.
 /// No wildcarding is applied; claimed-scheme redirects must match byte
 /// for byte.
+///
+/// @rfc 8252
+/// @section 7.1
+/// @requirement Claimed/custom URI schemes must match registered redirect URI byte-for-byte.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8252#section-7.1
 #[test]
 fn rfc8252_custom_scheme_exact_match_only() {
     let c = client_registered_for("com.example.app://oauth/callback");

--- a/tests/rfc9700_code_replay.rs
+++ b/tests/rfc9700_code_replay.rs
@@ -43,6 +43,13 @@ fn session_cookie(
         .to_string()
 }
 
+/// RFC 9700 §2.1.1: Replaying an authorization code must revoke all tokens previously issued from it.
+///
+/// @rfc 9700
+/// @section 2.1.1
+/// @requirement Authorization-code replay must cascade-revoke every access/refresh token issued from the original exchange.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.1
 #[actix_web::test]
 async fn rfc9700_authorization_code_replay_revokes_issued_tokens() {
     const ISSUER: &str = "https://auth.example.com";

--- a/tests/rfc9700_compliance.rs
+++ b/tests/rfc9700_compliance.rs
@@ -148,6 +148,12 @@ async fn setup_rfc9700_context(
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §2.1.1: PKCE `plain` method MUST be rejected.
+///
+/// @rfc 9700
+/// @section 2.1.1
+/// @requirement PKCE `plain` method must be rejected; only S256 is acceptable.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.1
 #[actix_web::test]
 async fn test_vector_a_plain_pkce_rejected() {
     let client = Client::new(
@@ -213,6 +219,12 @@ async fn test_vector_a_plain_pkce_rejected() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §2.1.1: Public clients MUST supply PKCE.
+///
+/// @rfc 9700
+/// @section 2.1.1
+/// @requirement Public clients must supply PKCE on the authorization-code flow.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.1
 #[actix_web::test]
 async fn test_vector_b_public_client_missing_pkce() {
     let mut client = Client::new(
@@ -283,6 +295,12 @@ async fn test_vector_b_public_client_missing_pkce() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §2.1.5: replaying an authorization code MUST revoke the entire token family.
+///
+/// @rfc 9700
+/// @section 2.1.5
+/// @requirement Authorization-code replay must revoke the entire issued token family.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.5
 #[actix_web::test]
 #[ignore = "Awaits bead 6.1: token family revocation on code replay"]
 async fn test_vector_c_authorization_code_replay() {
@@ -295,6 +313,12 @@ async fn test_vector_c_authorization_code_replay() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §2.1.5: replaying a rotated refresh token MUST revoke the entire family.
+///
+/// @rfc 9700
+/// @section 2.1.5
+/// @requirement Replaying a rotated refresh token must revoke the entire token family.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.5
 #[actix_web::test]
 #[ignore = "Awaits bead 6.1: token family revocation on refresh replay"]
 async fn test_vector_d_refresh_token_replay() {
@@ -307,6 +331,12 @@ async fn test_vector_d_refresh_token_replay() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9207 + RFC 9700 §4.8: every authorization response (success and error) MUST include `iss`.
+///
+/// @rfc 9207
+/// @section 2
+/// @requirement Authorization response (success or error) must include the `iss` parameter.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9207#section-2
 #[actix_web::test]
 async fn test_vector_e_iss_in_authorization_response() {
     const ISSUER: &str = "https://auth.example.com";
@@ -405,6 +435,12 @@ async fn test_vector_e_iss_in_authorization_response() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §4.1: `redirect_uri` must match registered URI exactly (no normalization).
+///
+/// @rfc 9700
+/// @section 4.1
+/// @requirement redirect_uri must be matched byte-for-byte; trailing-slash differences must be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-4.1
 #[actix_web::test]
 async fn test_vector_f_redirect_uri_trailing_slash() {
     let client = Client::new(
@@ -478,6 +514,12 @@ async fn test_vector_f_redirect_uri_trailing_slash() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §4.1: `redirect_uri` with extra query parameters must be rejected.
+///
+/// @rfc 9700
+/// @section 4.1
+/// @requirement redirect_uri carrying additional query parameters must be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-4.1
 #[actix_web::test]
 async fn test_vector_g_redirect_uri_extra_query_param() {
     let client = Client::new(
@@ -551,6 +593,12 @@ async fn test_vector_g_redirect_uri_extra_query_param() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §4.11: login form POST should redirect with 303 See Other, not 302.
+///
+/// @rfc 9700
+/// @section 4.11
+/// @requirement Login form POST handler should redirect with 303 See Other (not 302).
+/// @level SHOULD
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-4.11
 #[actix_web::test]
 #[ignore = "Awaits bead 6.7: 302 → 303 See Other for login redirects"]
 async fn test_vector_h_login_redirect_303() {
@@ -563,6 +611,12 @@ async fn test_vector_h_login_redirect_303() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §2.3: token responses MUST include `Cache-Control: no-store`.
+///
+/// @rfc 9700
+/// @section 2.3
+/// @requirement Token endpoint responses must include `Cache-Control: no-store`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.3
 #[actix_web::test]
 async fn test_vector_i_token_cache_control_no_store() {
     let client = Client::new(
@@ -625,6 +679,12 @@ async fn test_vector_i_token_cache_control_no_store() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §4.12: `/authorize` and `/consent` MUST include X-Frame-Options: DENY or CSP frame-ancestors 'none'.
+///
+/// @rfc 9700
+/// @section 4.12
+/// @requirement /authorize and /consent must set X-Frame-Options: DENY or CSP frame-ancestors 'none'.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-4.12
 #[actix_web::test]
 async fn test_vector_j_authorize_security_headers() {
     let client = Client::new(
@@ -711,6 +771,12 @@ async fn test_vector_j_authorize_security_headers() {
 /// - `grant_types_supported` excludes `password`
 /// - `response_types_supported` excludes `token`
 /// - `authorization_response_iss_parameter_supported=true`
+///
+/// @rfc 9700
+/// @section 4
+/// @requirement Discovery doc must satisfy RFC 9700 BCP constraints (S256-only, no password, no implicit, iss param).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-4
 #[actix_web::test]
 async fn test_vector_k_discovery_json_constraints() {
     let (_, _, _, _, _, oidc_config) =
@@ -766,6 +832,12 @@ async fn test_vector_k_discovery_json_constraints() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §2.5: replaying a client assertion with the same `jti` within its exp window MUST be rejected.
+///
+/// @rfc 9700
+/// @section 2.5
+/// @requirement A replayed client assertion (same `jti` within exp window) must be rejected.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.5
 #[actix_web::test]
 #[ignore = "Awaits bead 6.5: JWT client-assertion jti replay store"]
 async fn test_vector_l_client_assertion_jti_replay() {
@@ -778,6 +850,12 @@ async fn test_vector_l_client_assertion_jti_replay() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9700 §2.3 + RFC 8707: token request with `resource` parameter MUST populate `aud` claim.
+///
+/// @rfc 8707
+/// @section 2
+/// @requirement Token request `resource` parameter must populate the issued token's `aud` claim.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8707#section-2
 #[actix_web::test]
 async fn test_vector_m_resource_to_aud_claim() {
     let client = Client::new(
@@ -856,6 +934,12 @@ async fn test_vector_m_resource_to_aud_claim() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9449 §4: DPoP proof with invalid typ header → 400 invalid_dpop_proof
+///
+/// @rfc 9449
+/// @section 4
+/// @requirement DPoP proof with invalid `typ` JOSE header must be rejected with `invalid_dpop_proof`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9449#section-4
 #[actix_web::test]
 async fn test_vector_n_dpop_invalid_typ() {
     use oauth2_actix::handlers::dpop::{validate_dpop_proof, DpopReplayStore};
@@ -878,6 +962,12 @@ async fn test_vector_n_dpop_invalid_typ() {
 }
 
 /// RFC 9449 §4: DPoP proof jti replay → 400 invalid_dpop_proof
+///
+/// @rfc 9449
+/// @section 4
+/// @requirement Replayed DPoP proof (same `jti`) must be rejected with `invalid_dpop_proof`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9449#section-4
 #[actix_web::test]
 async fn test_vector_o_dpop_jti_replay() {
     use oauth2_actix::handlers::dpop::DpopReplayStore;
@@ -903,6 +993,12 @@ async fn test_vector_o_dpop_jti_replay() {
 // ---------------------------------------------------------------------------
 
 /// RFC 8705 §2.1: tls_client_auth requires certificate Subject DN match
+///
+/// @rfc 8705
+/// @section 2.1
+/// @requirement `tls_client_auth` must validate the client certificate Subject DN against the registered value.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8705#section-2.1
 #[actix_web::test]
 async fn test_vector_p_mtls_subject_dn_validation() {
     use oauth2_actix::handlers::oauth;
@@ -984,6 +1080,12 @@ async fn test_vector_p_mtls_subject_dn_validation() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9101 §4: JAR implementation verified via oauth.rs lines 713-778
+///
+/// @rfc 9101
+/// @section 4
+/// @requirement Authorization endpoint must accept and process the JAR `request` parameter.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9101#section-4
 #[actix_web::test]
 async fn test_vector_q_jar_request_parameter_integration() {
     use jsonwebtoken::{encode, Algorithm, EncodingKey, Header as JwtHeader};
@@ -1150,6 +1252,12 @@ async fn test_vector_q_jar_request_parameter_integration() {
 }
 
 /// RFC 9101 §4: JAR with private_key_jwt requires JWKS resolution
+///
+/// @rfc 9101
+/// @section 4
+/// @requirement JAR signed via `private_key_jwt` must be verified using the client's resolved JWKS.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9101#section-4
 #[actix_web::test]
 async fn test_vector_r_jar_private_key_jwt_jwks_cache() {
     use base64::{engine::general_purpose, Engine as _};

--- a/tests/rfc9700_https_enforcement.rs
+++ b/tests/rfc9700_https_enforcement.rs
@@ -9,6 +9,12 @@ async fn probe() -> HttpResponse {
 
 /// When `enforce = false` the middleware is a no-op and plain-HTTP requests
 /// reach the inner handler. This is the dev default and must stay that way.
+///
+/// @rfc 9700
+/// @section 2.6
+/// @requirement HTTPS-enforcement middleware must be a no-op when explicitly disabled.
+/// @level MAY
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.6
 #[actix_web::test]
 async fn disabled_by_default_passes_plain_http_through() {
     let app = test::init_service(
@@ -29,6 +35,12 @@ async fn disabled_by_default_passes_plain_http_through() {
 
 /// With enforcement on, a plain-HTTP request is rewritten to the matching
 /// `https://` URL and returned as HTTP 308 Permanent Redirect.
+///
+/// @rfc 9700
+/// @section 2.6
+/// @requirement Plain-HTTP requests must be redirected (308) to the corresponding HTTPS URL when enforcement is on.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.6
 #[actix_web::test]
 async fn enforced_plain_http_is_redirected_308_to_https() {
     let app = test::init_service(
@@ -74,6 +86,12 @@ async fn enforced_plain_http_is_redirected_308_to_https() {
 /// With `trust_proxy_headers = true`, the middleware honors
 /// `X-Forwarded-Proto: https` set by a TLS-terminating reverse proxy and
 /// lets the request through even though the local scheme is plain.
+///
+/// @rfc 9700
+/// @section 2.6
+/// @requirement HTTPS-enforcement must accept TLS-terminated upstream traffic via trusted X-Forwarded-Proto.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.6
 #[actix_web::test]
 async fn trusted_forwarded_proto_https_passes_through() {
     let app = test::init_service(
@@ -103,6 +121,12 @@ async fn trusted_forwarded_proto_https_passes_through() {
 /// When `trust_proxy_headers = false`, even `X-Forwarded-Proto: https` is
 /// ignored — prevents a spoofed header from bypassing the redirect when the
 /// server is not actually behind a trusted proxy.
+///
+/// @rfc 9700
+/// @section 2.6
+/// @requirement Untrusted X-Forwarded-Proto must not bypass HTTPS enforcement (anti-spoof).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.6
 #[actix_web::test]
 async fn untrusted_forwarded_proto_header_is_ignored() {
     let app = test::init_service(

--- a/tests/rfc9700_introspection_pii.rs
+++ b/tests/rfc9700_introspection_pii.rs
@@ -18,6 +18,12 @@ use oauth2_observability::Metrics;
 
 /// Anonymous caller (public_introspection=true) gets lifecycle claims but
 /// NOT the token subject's identity fields.
+///
+/// @rfc 7662
+/// @section 5
+/// @requirement Anonymous introspection must strip subject identity fields (username, sub) while keeping lifecycle claims.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7662#section-5
 #[actix_web::test]
 async fn rfc9700_anonymous_introspection_strips_username_and_sub() {
     const ISSUER: &str = "https://auth.example.com";
@@ -153,6 +159,12 @@ async fn rfc9700_anonymous_introspection_strips_username_and_sub() {
 /// response including PII. Token_client_credentials grant has no user, so
 /// we exercise this via authorization_code elsewhere; here we assert the
 /// owner simply gets `username` populated when it exists on the token.
+///
+/// @rfc 7662
+/// @section 5
+/// @requirement Authenticated owner introspection must still return identity claims (sub, client_id) for the token's owner.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7662#section-5
 #[actix_web::test]
 async fn rfc9700_owner_introspection_still_returns_pii() {
     const ISSUER: &str = "https://auth.example.com";

--- a/tests/rfc9700_jti_replay.rs
+++ b/tests/rfc9700_jti_replay.rs
@@ -16,6 +16,13 @@ use oauth2_actix::handlers::wellknown::OidcConfig;
 use oauth2_core::{Client, TokenResponse};
 use oauth2_observability::Metrics;
 
+/// RFC 9700 §2.5 / RFC 7523 §3: replaying a client_secret_jwt assertion (same `jti`) must be rejected.
+///
+/// @rfc 9700
+/// @section 2.5
+/// @requirement Replayed JWT client-assertion (same client_id + jti within exp window) must be rejected with `invalid_client`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.5
 #[actix_web::test]
 async fn rfc9700_client_secret_jwt_replay_is_rejected() {
     const ISSUER: &str = "https://auth.example.com";
@@ -158,6 +165,12 @@ async fn rfc9700_client_secret_jwt_replay_is_rejected() {
 /// A fresh `jti` (even from the same client) must succeed — the guard
 /// only rejects exact `(client_id, jti)` replays, not all subsequent
 /// assertions from a client.
+///
+/// @rfc 9700
+/// @section 2.5
+/// @requirement A new (client_id, jti) pair from the same client must still be accepted.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.5
 #[actix_web::test]
 async fn rfc9700_fresh_jti_from_same_client_is_accepted() {
     const ISSUER: &str = "https://auth.example.com";

--- a/tests/rfc9700_rate_limit.rs
+++ b/tests/rfc9700_rate_limit.rs
@@ -66,6 +66,12 @@ fn bad_credentials_body() -> &'static str {
 }
 
 /// After exhausting the invalid_client bucket the token endpoint returns 429.
+///
+/// @rfc 9700
+/// @section 2.5
+/// @requirement Token endpoint must rate-limit repeated `invalid_client` failures and return 429 when the budget is exhausted.
+/// @level SHOULD
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.5
 #[actix_web::test]
 async fn invalid_client_rate_limit_returns_429_after_budget_exhausted() {
     let (token_pool, client_actor, auth_actor, jwt_secret, metrics, oidc_config) =
@@ -124,6 +130,12 @@ async fn invalid_client_rate_limit_returns_429_after_budget_exhausted() {
 
 /// Without an invalid_client limiter in app_data the handler still returns
 /// 401 invalid_client (Option is None → no rate limiting applied).
+///
+/// @rfc 9700
+/// @section 2.5
+/// @requirement Without a configured rate limiter, the token endpoint must still respond 401 `invalid_client` to bad credentials.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.5
 #[actix_web::test]
 async fn invalid_client_no_limiter_returns_401() {
     let (token_pool, client_actor, auth_actor, jwt_secret, metrics, oidc_config) =
@@ -158,6 +170,12 @@ async fn invalid_client_no_limiter_returns_401() {
 
 /// Different client_ids have independent buckets — exhausting one does not
 /// affect another. Verifies the key is client_id, not a shared IP.
+///
+/// @rfc 9700
+/// @section 2.5
+/// @requirement Rate-limit buckets must be keyed per client_id so one client's exhaustion does not affect others.
+/// @level SHOULD
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.5
 #[actix_web::test]
 async fn invalid_client_buckets_are_isolated_per_client_id() {
     let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
@@ -260,6 +278,12 @@ async fn invalid_client_buckets_are_isolated_per_client_id() {
 }
 
 /// Successful token requests do NOT consume the invalid_client bucket.
+///
+/// @rfc 9700
+/// @section 2.5
+/// @requirement Successful token issuance must not consume the `invalid_client` rate-limit bucket.
+/// @level SHOULD
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-2.5
 #[actix_web::test]
 async fn valid_requests_do_not_deplete_invalid_client_bucket() {
     let storage = oauth2_storage_factory::create_storage("sqlite::memory:")

--- a/tests/rfc9700_require_state.rs
+++ b/tests/rfc9700_require_state.rs
@@ -140,6 +140,13 @@ async fn run_authorize(require_state: bool, send_state: bool) -> u16 {
     resp.status().as_u16()
 }
 
+/// RFC 9700 §4.7: With `require_state=false`, authorize must accept requests without `state`.
+///
+/// @rfc 9700
+/// @section 4.7
+/// @requirement Default `require_state=false` must allow authorize requests without a `state` parameter.
+/// @level MAY
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-4.7
 #[actix_web::test]
 async fn require_state_off_accepts_missing_state() {
     let status = run_authorize(false, false).await;
@@ -149,6 +156,13 @@ async fn require_state_off_accepts_missing_state() {
     );
 }
 
+/// RFC 9700 §4.7: With `require_state=true`, authorize must reject requests missing `state`.
+///
+/// @rfc 9700
+/// @section 4.7
+/// @requirement `require_state=true` must reject authorize requests missing a `state` parameter.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-4.7
 #[actix_web::test]
 async fn require_state_on_rejects_missing_state() {
     let status = run_authorize(true, false).await;
@@ -158,6 +172,13 @@ async fn require_state_on_rejects_missing_state() {
     );
 }
 
+/// RFC 9700 §4.7: With `require_state=true`, authorize must accept requests where `state` is present.
+///
+/// @rfc 9700
+/// @section 4.7
+/// @requirement `require_state=true` must accept authorize requests when `state` is provided.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9700#section-4.7
 #[actix_web::test]
 async fn require_state_on_accepts_present_state() {
     let status = run_authorize(true, true).await;

--- a/tests/rfc_compliance.rs
+++ b/tests/rfc_compliance.rs
@@ -126,6 +126,12 @@ async fn setup_rfc_context(
 // ---------------------------------------------------------------------------
 
 /// RFC 9207 §2: the `iss` parameter MUST be included in the authorization response.
+///
+/// @rfc 9207
+/// @section 2
+/// @requirement Authorization response must include the `iss` parameter naming the AS.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9207#section-2
 #[actix_web::test]
 async fn rfc9207_iss_included_in_authorization_response() {
     const ISSUER: &str = "https://auth.example.com";
@@ -209,6 +215,12 @@ async fn rfc9207_iss_included_in_authorization_response() {
 // ---------------------------------------------------------------------------
 
 /// RFC 9068 §2.1: access tokens MUST carry `typ: "at+JWT"` in the JOSE header.
+///
+/// @rfc 9068
+/// @section 2.1
+/// @requirement JWT access tokens must use JOSE header `typ: "at+JWT"`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9068#section-2.1
 #[actix_web::test]
 async fn rfc9068_access_token_has_typ_at_jwt() {
     let client = Client::new(
@@ -270,6 +282,12 @@ async fn rfc9068_access_token_has_typ_at_jwt() {
 }
 
 /// RFC 9068 §2.2: `iss` claim in the JWT must equal the configured issuer URL.
+///
+/// @rfc 9068
+/// @section 2.2
+/// @requirement Access-token JWT `iss` claim must equal the configured AS issuer URL.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9068#section-2.2
 #[actix_web::test]
 async fn rfc9068_jwt_iss_matches_configured_issuer() {
     const ISSUER: &str = "https://my-auth-server.example";
@@ -343,6 +361,12 @@ async fn rfc9068_jwt_iss_matches_configured_issuer() {
 // ---------------------------------------------------------------------------
 
 /// RFC 7662 §2.2: active introspection MUST include `nbf`, `jti`, `aud`, `iss`.
+///
+/// @rfc 7662
+/// @section 2.2
+/// @requirement Active introspection response must include `nbf`, `jti`, `aud`, and `iss` claims.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
 #[actix_web::test]
 async fn rfc7662_introspection_includes_nbf_jti_aud_iss() {
     const ISSUER: &str = "https://auth.example.com";
@@ -445,6 +469,12 @@ async fn rfc7662_introspection_includes_nbf_jti_aud_iss() {
 }
 
 /// RFC 7662 §2.2: `nbf` must be <= `iat` for tokens valid from issuance.
+///
+/// @rfc 7662
+/// @section 2.2
+/// @requirement Introspection response must satisfy `nbf <= iat` for tokens valid from issuance.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
 #[actix_web::test]
 async fn rfc7662_introspection_nbf_le_iat() {
     let client = Client::new(
@@ -546,6 +576,12 @@ fn make_public_client(id: &str, redirect: &str) -> Client {
 }
 
 /// Public clients can exchange an authorization code using only PKCE (no secret).
+///
+/// @rfc 6749
+/// @section 4.1.3
+/// @requirement Public clients (`token_endpoint_auth_method=none`) must exchange auth codes via PKCE without a secret.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
 #[actix_web::test]
 async fn public_client_exchanges_code_without_secret() {
     let client = make_public_client("client_public", "https://native.example/cb");
@@ -641,6 +677,12 @@ async fn public_client_exchanges_code_without_secret() {
 }
 
 /// Presenting a client_secret for a public client must be rejected with `invalid_client`.
+///
+/// @rfc 6749
+/// @section 4.1.3
+/// @requirement Public clients presenting a client_secret must be rejected (`invalid_client`).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
 #[actix_web::test]
 async fn public_client_must_not_present_secret() {
     let client = make_public_client("client_pub_secret", "https://native.example/cb");
@@ -740,6 +782,12 @@ async fn public_client_must_not_present_secret() {
 // ---------------------------------------------------------------------------
 
 /// RFC 8414 §3: metadata MUST also be served at `/.well-known/oauth-authorization-server`.
+///
+/// @rfc 8414
+/// @section 3
+/// @requirement AS metadata must be served at `/.well-known/oauth-authorization-server`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-3
 #[actix_web::test]
 async fn rfc8414_oauth_authorization_server_well_known_returns_metadata() {
     let (token_actor, client_actor, auth_actor, jwt_secret, metrics, oidc_config) =
@@ -799,6 +847,12 @@ async fn rfc8414_oauth_authorization_server_well_known_returns_metadata() {
 }
 
 /// Both well-known paths must return identical responses (RFC 8414 §3).
+///
+/// @rfc 8414
+/// @section 3
+/// @requirement Both `/.well-known/oauth-authorization-server` and `/.well-known/openid-configuration` must serve identical metadata.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc8414#section-3
 #[actix_web::test]
 async fn rfc8414_both_well_known_paths_return_same_response() {
     let (token_actor, client_actor, auth_actor, jwt_secret, metrics, oidc_config) =
@@ -862,6 +916,12 @@ async fn rfc8414_both_well_known_paths_return_same_response() {
 // ---------------------------------------------------------------------------
 
 /// Registering a public client with `token_endpoint_auth_method=none` must succeed.
+///
+/// @rfc 7591
+/// @section 2
+/// @requirement Dynamic registration must accept `token_endpoint_auth_method=none` for public clients.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7591#section-2
 #[actix_web::test]
 async fn public_client_registration_with_none_auth_method_succeeds() {
     let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
@@ -902,6 +962,12 @@ async fn public_client_registration_with_none_auth_method_succeeds() {
 }
 
 /// Registering a public client with `client_credentials` grant must be rejected.
+///
+/// @rfc 7591
+/// @section 2
+/// @requirement Dynamic registration must reject public clients requesting the `client_credentials` grant.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7591#section-2
 #[actix_web::test]
 async fn public_client_registration_with_client_credentials_is_rejected() {
     let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
@@ -946,6 +1012,12 @@ async fn public_client_registration_with_client_credentials_is_rejected() {
 // ---------------------------------------------------------------------------
 
 /// OIDC Core §5.4: UserInfo MUST return email claim when `email` scope is present.
+///
+/// @rfc oidc-core-1.0
+/// @section 5.4
+/// @requirement UserInfo must return the `email` claim when the access token has the `email` scope.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
 #[actix_web::test]
 async fn userinfo_returns_real_email_when_email_scope_requested() {
     let client = Client::new(
@@ -1064,6 +1136,12 @@ async fn userinfo_returns_real_email_when_email_scope_requested() {
 }
 
 /// OIDC Core §5.4: UserInfo with `profile` scope returns preferred_username.
+///
+/// @rfc oidc-core-1.0
+/// @section 5.4
+/// @requirement UserInfo must return profile claims (e.g. preferred_username) when `profile` scope is granted.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
 #[actix_web::test]
 async fn userinfo_returns_real_claims_for_auth_code_flow() {
     let client = Client::new(
@@ -1236,6 +1314,12 @@ async fn userinfo_returns_real_claims_for_auth_code_flow() {
 // ---------------------------------------------------------------------------
 
 /// OIDC Core §3.1.2.1: `prompt=none` without session → login_required error redirect.
+///
+/// @rfc oidc-core-1.0
+/// @section 3.1.2.1
+/// @requirement `prompt=none` without an active session must return a `login_required` error redirect.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 #[actix_web::test]
 async fn prompt_none_without_session_returns_login_required() {
     let client = Client::new(
@@ -1313,6 +1397,12 @@ async fn prompt_none_without_session_returns_login_required() {
 }
 
 /// OIDC Core §3.1.2.1: `prompt=login` forces re-authentication even with active session.
+///
+/// @rfc oidc-core-1.0
+/// @section 3.1.2.1
+/// @requirement `prompt=login` must force re-authentication even when an active session exists.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 #[actix_web::test]
 async fn prompt_login_forces_reauthentication() {
     let client = Client::new(
@@ -1390,6 +1480,12 @@ async fn prompt_login_forces_reauthentication() {
 }
 
 /// OIDC Core §3.1.2.1: `max_age=0` forces re-authentication (auth_time missing).
+///
+/// @rfc oidc-core-1.0
+/// @section 3.1.2.1
+/// @requirement `max_age=0` must force re-authentication when auth_time is unavailable or stale.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 #[actix_web::test]
 async fn max_age_zero_forces_reauthentication() {
     let client = Client::new(
@@ -1472,6 +1568,12 @@ async fn max_age_zero_forces_reauthentication() {
 // ---------------------------------------------------------------------------
 
 /// OIDC RP-Initiated Logout: id_token_hint with invalid aud returns error.
+///
+/// @rfc oidc-rpinit-1.0
+/// @section 3
+/// @requirement Logout endpoint must reject `id_token_hint` whose `aud` does not match a registered client.
+/// @level MUST
+/// @url https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
 #[actix_web::test]
 async fn logout_with_invalid_aud_id_token_hint_returns_error() {
     let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
@@ -1537,6 +1639,12 @@ async fn logout_with_invalid_aud_id_token_hint_returns_error() {
 }
 
 /// Token revocation cascades to the entire token family (RFC 7009 + Security BCP).
+///
+/// @rfc 7009
+/// @section 2
+/// @requirement Revoking a token must cascade-revoke the entire token family (security BCP).
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc7009#section-2
 #[actix_web::test]
 async fn revoke_cascades_to_entire_token_family() {
     let client = Client::new(
@@ -1696,6 +1804,12 @@ async fn revoke_cascades_to_entire_token_family() {
 // ---------------------------------------------------------------------------
 
 /// Discovery doc MUST include `authorization_response_iss_parameter_supported: true` (RFC 9207).
+///
+/// @rfc 9207
+/// @section 3
+/// @requirement Discovery must advertise `authorization_response_iss_parameter_supported: true`.
+/// @level MUST
+/// @url https://datatracker.ietf.org/doc/html/rfc9207#section-3
 #[actix_web::test]
 async fn discovery_includes_iss_parameter_supported() {
     let (token_actor, client_actor, auth_actor, jwt_secret, metrics, oidc_config) =


### PR DESCRIPTION
## Summary

Builds on the prior RFC 6749 proof-of-concept by extending structured
`@rfc / @section / @requirement / @level / @url` doc-comment metadata to
**every** compliance test file in `tests/`, then ships a generator binary
that emits the matrix as Markdown, JSON, and JUnit XML — wired into CI so
the generated docs flow through the MkDocs build.

## What's covered

- **189 tests across 21 files** annotated with structured metadata.
- Specs: RFC 6749, 6750, 7591, 7636, 7662, 7009, 8252, 8414, 8628, 8705,
  8707, 9068, 9101, 9126, 9207, 9449, 9700, 9701, OIDC Core / Discovery /
  Registration / Session / Front-Channel / Back-Channel / RP-Init Logout /
  MRT, plus IETF Token Status List draft.

## Generator (`src/bin/compliance_report.rs`)

- Pure stdlib + `serde` + `serde_json`. No `syn`, no regex, no proc-macros.
- Discovers `compliance_*.rs`, `rfc*.rs`, `phase*_rfc_*.rs`.
- Parses libtest pretty output **or** JSONL via `--results`; otherwise marks
  tests `unknown` / `ignored` from `#[ignore]`.
- Numeric-aware RFC ordering (RFC 6749 < 6750 < … < 9700 < OIDC < drafts).
- MkDocs-`strict: true`-safe Markdown (no relative source-file links).

## Make targets

| Target | Purpose |
|---|---|
| `make compliance-report` | Run generator, no test results (status = unknown). |
| `make compliance-report-with-results` | Run compliance test binaries, capture output, then generate. |

## CI integration

- `checks` job runs the test binaries with output capture, generates the
  three reports, and uploads them as the `rfc-compliance-report` artifact.
- `docs` job downloads that artifact (best-effort) and overlays the fresh
  Markdown into `docs/compliance/RFC_COMPLIANCE.md` before the MkDocs
  build, falling back to the committed file if the artifact is missing.

## Local verification

```
total=189 passed=185 failed=0 ignored=4 unknown=0
compliance_score = 97% (4 ignored = rfc9700 vectors c/d/h/l awaiting bead 6.x)
```

`cargo fmt --check` ✅, `cargo clippy --all-targets --all-features -- -D warnings` ✅.

## Companion fix

4× `#[allow(clippy::clone_on_copy)]` in `crates/oauth2-server/src/lib.rs`.
The `cache_redis_manager.clone()` calls are correct when `redis-cache` is
on (real `Option<TracedRedis>` clone) but trip the lint when off because
the type alias degenerates to `Option<()>` (`Copy`). Surgical 4-line
addition, no behaviour change.

## Notes for reviewers

- Some RFC mappings were judgement calls (flagged in commit body):
  - `compliance_wave5.rs::wave2_c1_…_alg_none` → RFC 7515 §6 (JWS-level)
    rather than RFC 9101.
  - `compliance_wave5.rs::wave5_response_mode_*` → \`oidc-mrt-1.0\`.
  - `compliance_wave4.rs::wave4_token_status_list_*` → \`draft-ietf-oauth-status-list\`.
- The regenerated `docs/compliance/RFC_COMPLIANCE.md` is committed so the
  docs site has a sensible fallback when the CI artifact isn't available.