### PR TITLE
chore: add .devbox.yaml for openclaw devbox build/test

### DIFF
--- a/.devbox.yaml
+++ b/.devbox.yaml
@@ -1,0 +1,23 @@
+# .devbox.yaml — toolchain config for openclaw's ephemeral devbox build/test Jobs.
+#
+# openclaw (the autonomous PR maintainer) reads this from the DEFAULT branch only
+# and runs the named commands in a throwaway Kubernetes Job to judge a PR before
+# merge. It is an advisory oracle — GitHub CI + branch protection remain the real
+# merge gate. The image must be on openclaw's allowlist (official toolchain images
+# or the cluster ACR); arbitrary images are rejected.
+image: rust:1.83-bookworm
+
+# The official rust image ships cargo/rustc but is built with `--profile minimal`,
+# so the clippy & rustfmt components must be added (~1s). The apt packages are
+# required to compile `rdkafka` (bundled librdkafka) under `--all-features`.
+setup: >-
+  export DEBIAN_FRONTEND=noninteractive &&
+  apt-get update -qq &&
+  apt-get install -y -qq cmake libsasl2-dev libssl-dev zlib1g-dev pkg-config &&
+  rustup component add clippy rustfmt
+
+commands:
+  fmt: cargo fmt --all -- --check
+  clippy: cargo clippy --all-targets --all-features --locked -- -D warnings
+  test: cargo test --all-features --locked
+  build: cargo build --release --locked


### PR DESCRIPTION
Adds a `.devbox.yaml` so openclaw's autonomous PR maintainer runs builds/tests for this repo in a **prebuilt `rust:1.83-bookworm` image** instead of installing the Rust toolchain from scratch on bare `ubuntu:24.04` every job.

### Why
The from-scratch approach was slow and caused a runaway clippy retry loop (the official/minimal toolchain lacked the clippy component). This pins the image and adds the components once (~1s).

### Contents
- **image:** `rust:1.83-bookworm`
- **setup:** `rustup component add clippy rustfmt` + `cmake libsasl2-dev libssl-dev zlib1g-dev pkg-config` (needed for `rdkafka`'s bundled librdkafka under `--all-features`)
- **commands:** `fmt` / `clippy` / `test` / `build` — mirror `.github/workflows/ci.yml`

### Safety
This file is **advisory only** — it configures openclaw's local oracle. CI + branch protection remain the merge gate. openclaw reads it from the **default branch only**, and the devbox helper enforces an image allowlist (official toolchain images / cluster ACR), so a PR cannot point the devbox at an arbitrary image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)