### PR TITLE
ci: flatten PR job graph, native arm64 builds, nextest

### DIFF
--- a/.claude/commands/ci.md
+++ b/.claude/commands/ci.md
@@ -1,10 +1,27 @@
-Run the CI gate checks locally before committing code.
+Run the CI gate checks locally.
 
-This includes:
+## Quick loop (while iterating)
+
+Use this between edits — it catches type/lint/test failures fast without
+paying for the full all-features build:
+
+1. `cargo fmt --all`
+2. `cargo check --all-targets`
+3. Targeted tests for what you touched, e.g. `cargo nextest run --test <file>`
+   or `cargo nextest run -p <crate>` (fallback: `cargo test --test <file>`)
+
+## Full gate (must pass before any commit/PR)
+
 1. Format check: `cargo fmt --all -- --check`
 2. Lint check: `cargo clippy --all-targets --all-features -- -D warnings`
-3. Tests: `cargo test --verbose --all-features --locked`
+3. Tests: `cargo nextest run --all-features --locked -E 'not binary(bdd)'`
+4. BDD suite: `cargo test --test bdd --all-features --locked`
+5. Doctests: `cargo test --doc --all-features --locked`
 
 If formatting fails, auto-fix with: `cargo fmt --all`
 
-All three checks must pass before any code change is considered complete.
+If `cargo-nextest` is missing (`cargo nextest --version` fails), install it
+with `cargo install cargo-nextest --locked`, or fall back to
+`cargo test --all-features --locked` (slower, same coverage).
+
+All full-gate checks must pass before any code change is considered complete.

--- a/.claude/commands/ci.md
+++ b/.claude/commands/ci.md
@@ -16,7 +16,9 @@ paying for the full all-features build:
 2. Lint check: `cargo clippy --all-targets --all-features -- -D warnings`
 3. Tests: `cargo nextest run --all-features --locked -E 'not binary(bdd)'`
 4. BDD suite: `cargo test --test bdd --all-features --locked`
-5. Doctests: `cargo test --doc --all-features --locked`
+5. Doctests: `cargo test --doc --workspace --all-features --locked` (`--workspace`
+   is required — the root `rust_oauth2_server` package is binary-only and
+   `cargo test --doc` without it errors instead of skipping that package)
 
 If formatting fails, auto-fix with: `cargo fmt --all`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      build_matrix: ${{ steps.build_matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v7.0.0 # v6
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -66,6 +67,33 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
 
+      # Decide which server binaries this run needs. PRs/develop build a single
+      # debug amd64 binary (only consumer: the single-arch e2e-kind image).
+      # Pushes to the default branch and tags build all release variants
+      # natively — arm64 on GitHub's free arm runners, no cross/QEMU.
+      - name: Compute binary build matrix
+        id: build_matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]] && \
+             { [[ "${GITHUB_REF}" == "refs/heads/${{ github.event.repository.default_branch }}" ]] || \
+               [[ "${GITHUB_REF}" == refs/tags/* ]]; }; then
+            matrix='[
+              {"name":"base-amd64","runner":"ubuntu-latest","arch":"amd64","profile":"release","cargo_args":"","binary_suffix":"","artifact":"rust_oauth2_server-linux-amd64"},
+              {"name":"base-arm64","runner":"ubuntu-24.04-arm","arch":"arm64","profile":"release","cargo_args":"","binary_suffix":"","artifact":"rust_oauth2_server-linux-arm64"},
+              {"name":"mongo-amd64","runner":"ubuntu-latest","arch":"amd64","profile":"release","cargo_args":"--features mongo","binary_suffix":"-mongo","artifact":"rust_oauth2_server-mongo-linux-amd64"},
+              {"name":"mongo-arm64","runner":"ubuntu-24.04-arm","arch":"arm64","profile":"release","cargo_args":"--features mongo","binary_suffix":"-mongo","artifact":"rust_oauth2_server-mongo-linux-arm64"},
+              {"name":"mongo-only-amd64","runner":"ubuntu-latest","arch":"amd64","profile":"release","cargo_args":"--no-default-features --features mongo,otel","binary_suffix":"-mongo-only","artifact":"rust_oauth2_server-mongo-only-linux-amd64"},
+              {"name":"mongo-only-arm64","runner":"ubuntu-24.04-arm","arch":"arm64","profile":"release","cargo_args":"--no-default-features --features mongo,otel","binary_suffix":"-mongo-only","artifact":"rust_oauth2_server-mongo-only-linux-arm64"}
+            ]'
+          else
+            matrix='[
+              {"name":"debug-amd64","runner":"ubuntu-latest","arch":"amd64","profile":"debug","cargo_args":"","binary_suffix":"","artifact":"rust_oauth2_server-linux-amd64"}
+            ]'
+          fi
+          echo "matrix=$(echo "${matrix}" | jq -c .)" >> "$GITHUB_OUTPUT"
+
   checks:
     name: Checks (fmt, clippy, test)
     runs-on: ubuntu-latest
@@ -80,10 +108,14 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-          # Shared debug-profile cache: integration/mongo (db-tests) restore the
-          # artifacts compiled here instead of rebuilding the workspace.
           cache-key: debug
           install-system-deps: "true"
+
+      - name: Install cargo-nextest
+        if: needs.changes.outputs.code == 'true'
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        with:
+          tool: cargo-nextest
 
       - name: Check formatting
         if: needs.changes.outputs.code == 'true'
@@ -93,9 +125,22 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Run tests
+      # The cucumber `bdd` target is harness = false and does not speak the
+      # libtest protocol nextest requires, so it is excluded here and run via
+      # `cargo test` below (same compiled artifacts, no rebuild).
+      - name: Run tests (nextest)
         if: needs.changes.outputs.code == 'true'
-        run: cargo test --verbose --all-features --locked
+        run: cargo nextest run --all-features --locked -E 'not binary(bdd)'
+
+      - name: Run BDD suite (cucumber)
+        if: needs.changes.outputs.code == 'true'
+        run: cargo test --test bdd --all-features --locked
+
+      # nextest does not run doctests; keep them gated separately (cheap — the
+      # compilation above is reused).
+      - name: Run doctests
+        if: needs.changes.outputs.code == 'true'
+        run: cargo test --doc --all-features --locked
 
       # Compliance matrix is only published by the (main-only) docs job, so the
       # re-run + report + upload only need to happen on push events.
@@ -132,12 +177,22 @@ jobs:
             target/compliance-tests.txt
           if-no-files-found: error
 
+  # Builds each server binary in its own job, in parallel with `checks` — the
+  # PR critical path used to be checks → build → e2e; flattening it shaves
+  # ~4-5 min off PR wall clock. arm64 variants build natively on GitHub's free
+  # arm runners (no cross/QEMU). Publishing is still gated: the `docker` job
+  # needs checks/security/db-tests/e2e-kind, so a red PR or push never ships
+  # an image — a failed run just wastes a few runner-minutes of build.
   build-binaries:
-    name: Build release binaries
-    runs-on: ubuntu-latest
-    needs: [changes, checks]
+    name: Build binaries (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    needs: [changes]
     if: needs.changes.outputs.code == 'true'
-    timeout-minutes: 45
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.changes.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7.0.0 # v6
 
@@ -145,81 +200,29 @@ jobs:
         uses: ./.github/actions/rust-setup
         with:
           toolchain: stable
-          cache-key: build-binaries
+          cache-key: build-${{ matrix.name }}
           install-system-deps: "true"
 
-      # cross (arm64) is only needed for the multi-arch images published on
-      # main/tags. PRs build a single debug amd64 binary for the e2e image.
-      - name: Install cross (for arm64 builds)
-        if: github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
-        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
-        with:
-          tool: cross
-
-      - name: Build server binary/binaries
+      - name: Build server binary
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" == "push" ]] && \
-             ([[ "${GITHUB_REF}" == "refs/heads/${{ github.event.repository.default_branch }}" ]] || \
-              [[ "${GITHUB_REF}" == refs/tags/* ]]); then
-            # Release path: multi-arch (amd64 + cross arm64) + mongo variants for
-            # the published images.
-            bash .github/scripts/build_release_binaries.sh --include-mongo-variants
+          if [[ "${{ matrix.profile }}" == "release" ]]; then
+            cargo build --release --locked ${{ matrix.cargo_args }}
           else
             # PR/develop path: the only consumer is e2e-kind, which loads a
-            # single-arch amd64 image. A debug build is much faster than release
-            # and skips the slow cross arm64 compile entirely.
-            cargo build --locked
-            mkdir -p target/release
-            cp target/debug/rust_oauth2_server target/release/rust_oauth2_server-amd64
+            # single-arch amd64 image. A debug build is much faster than release.
+            cargo build --locked ${{ matrix.cargo_args }}
           fi
+          mkdir -p target/release
+          cp "target/${{ matrix.profile }}/rust_oauth2_server" \
+            "target/release/rust_oauth2_server${{ matrix.binary_suffix }}-${{ matrix.arch }}"
 
-      - name: Upload release binary artifact (linux/amd64)
+      - name: Upload server binary artifact
         uses: actions/upload-artifact@v7.0.1 # v7
         with:
-          name: rust_oauth2_server-linux-amd64
-          path: target/release/rust_oauth2_server-amd64
-          if-no-files-found: error
-
-      - name: Upload release binary artifact (linux/arm64)
-        if: github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
-        uses: actions/upload-artifact@v7.0.1 # v7
-        with:
-          name: rust_oauth2_server-linux-arm64
-          path: target/release/rust_oauth2_server-arm64
-          if-no-files-found: error
-
-      - name: Upload release binary artifact (linux/amd64, mongo feature)
-        if: github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
-        uses: actions/upload-artifact@v7.0.1 # v7
-        with:
-          name: rust_oauth2_server-mongo-linux-amd64
-          path: target/release/rust_oauth2_server-mongo-amd64
-          if-no-files-found: error
-
-      - name: Upload release binary artifact (linux/arm64, mongo feature)
-        if: github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
-        uses: actions/upload-artifact@v7.0.1 # v7
-        with:
-          name: rust_oauth2_server-mongo-linux-arm64
-          path: target/release/rust_oauth2_server-mongo-arm64
-          if-no-files-found: error
-
-      - name: Upload release binary artifact (linux/amd64, mongo-only; no SQLx)
-        if: github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
-        uses: actions/upload-artifact@v7.0.1 # v7
-        with:
-          name: rust_oauth2_server-mongo-only-linux-amd64
-          path: target/release/rust_oauth2_server-mongo-only-amd64
-          if-no-files-found: error
-
-      - name: Upload release binary artifact (linux/arm64, mongo-only; no SQLx)
-        if: github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
-        uses: actions/upload-artifact@v7.0.1 # v7
-        with:
-          name: rust_oauth2_server-mongo-only-linux-arm64
-          path: target/release/rust_oauth2_server-mongo-only-arm64
+          name: ${{ matrix.artifact }}
+          path: target/release/rust_oauth2_server${{ matrix.binary_suffix }}-${{ matrix.arch }}
           if-no-files-found: error
 
   security:
@@ -262,12 +265,13 @@ jobs:
         run: cargo vet --locked
 
   # Integration (Postgres) + Mongo storage tests in one job: both are
-  # Docker-backed debug-profile suites, and sharing the `debug` cache lets them
-  # restore the artifacts already compiled by `checks`.
+  # Docker-backed debug-profile suites. Runs in parallel with `checks` (it
+  # builds with different feature sets, so there is no compiled-artifact
+  # sharing to wait for); the `gate` and `docker` jobs still require both.
   db-tests:
     name: Database Tests (postgres, mongo)
     runs-on: ubuntu-latest
-    needs: [changes, checks]
+    needs: [changes]
     if: needs.changes.outputs.code == 'true'
     timeout-minutes: 25
     services:
@@ -291,7 +295,7 @@ jobs:
         uses: ./.github/actions/rust-setup
         with:
           toolchain: stable
-          cache-key: debug
+          cache-key: db-tests
           install-system-deps: "true"
 
       - name: Run Flyway Migrations
@@ -332,7 +336,10 @@ jobs:
   docker:
     name: Docker (${{ matrix.variant_name }})
     runs-on: ubuntu-latest
-    needs: [build-binaries, security, db-tests, e2e-kind]
+    # `checks` must be an explicit dependency: build-binaries/db-tests no
+    # longer run after it, so nothing else keeps a red fmt/clippy/test run
+    # from publishing images.
+    needs: [checks, build-binaries, security, db-tests, e2e-kind]
     if: github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,13 @@ jobs:
         run: cargo test --test bdd --all-features --locked
 
       # nextest does not run doctests; keep them gated separately (cheap — the
-      # compilation above is reused).
+      # compilation above is reused). --workspace is required: the root
+      # `rust_oauth2_server` package is binary-only (no lib target), and
+      # `cargo test --doc` without --workspace errors on that instead of
+      # skipping it.
       - name: Run doctests
         if: needs.changes.outputs.code == 'true'
-        run: cargo test --doc --all-features --locked
+        run: cargo test --doc --workspace --all-features --locked
 
       # Compliance matrix is only published by the (main-only) docs job, so the
       # re-run + report + upload only need to happen on push events.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ existing clients (migration `V12__add_token_endpoint_auth_method.sql`).
 
 ```bash
 # All integration tests
-cargo test --verbose --all-features --locked
+cargo test --all-features --locked
 
 # Only RFC compliance tests
 cargo test --test rfc_compliance
@@ -276,8 +276,15 @@ See `docs/oauth2-spec-audit.md` §6 for the full checklist.
 ```bash
 cargo fmt --all -- --check     # auto-fix: cargo fmt --all
 cargo clippy --all-targets --all-features -- -D warnings
-cargo test --verbose --all-features --locked
+cargo nextest run --all-features --locked -E 'not binary(bdd)'
+cargo test --test bdd --all-features --locked      # cucumber (not nextest-compatible)
+cargo test --doc --all-features --locked           # nextest skips doctests
 ```
+
+While iterating, use the quick loop instead (`cargo check --all-targets` +
+targeted `cargo nextest run`) and run the full gate once before committing.
+If cargo-nextest is unavailable, `cargo test --all-features --locked` covers
+steps 3–5 in one (slower) command.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ cargo fmt --all -- --check     # auto-fix: cargo fmt --all
 cargo clippy --all-targets --all-features -- -D warnings
 cargo nextest run --all-features --locked -E 'not binary(bdd)'
 cargo test --test bdd --all-features --locked      # cucumber (not nextest-compatible)
-cargo test --doc --all-features --locked           # nextest skips doctests
+cargo test --doc --workspace --all-features --locked  # nextest skips doctests; --workspace required (root crate has no lib target)
 ```
 
 While iterating, use the quick loop instead (`cargo check --all-targets` +

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -5679,9 +5679,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -530,6 +530,10 @@ criteria = "safe-to-deploy"
 version = "0.8.6"
 criteria = "safe-to-run"
 
+[[exemptions.crossbeam-epoch]]
+version = "0.9.20"
+criteria = "safe-to-deploy"
+
 [[exemptions.crossbeam-queue]]
 version = "0.3.12"
 criteria = "safe-to-deploy"
@@ -2052,6 +2056,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.spin]]
 version = "0.9.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.spin]]
+version = "0.9.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.spki]]


### PR DESCRIPTION
## Summary

Reduces CI cycle time for agentic development while preserving all existing gating. Grounded in measured timings: PRs were ~10 min to full green with a serial `checks → build-binaries → e2e-kind` critical path; main pushes were ~36 min, of which 24 min was one job cross-compiling six binaries serially.

**Expected outcome: PRs ~10 → ~6 min, main pushes ~36 → ~12 min.**

### Changes

**Flatten the PR job graph**
- `build-binaries` and `db-tests` now run in parallel with `checks` instead of after it. The old edge only existed for cache sharing, but `checks` builds `--all-features` while these jobs use different feature sets — the shared cache was mostly illusory. `db-tests` gets its own cache key.
- `e2e-kind` starts as soon as the (~2.5 min) PR debug build finishes instead of waiting out `checks` first.
- **Gating preserved:** `docker` now depends on `checks` explicitly (previously transitive via build-binaries/db-tests), so a red fmt/clippy/test run still never publishes an image. The Quality Gate still requires checks, security, build, db-tests, and e2e. Cost of a red PR is a few wasted runner-minutes — the right trade when wall clock is the bottleneck.

**Native arm64 release builds (main/tags)**
- `build-binaries` is now a matrix driven by a `changes`-job output: PRs/develop get one debug amd64 leg; main/tags get six parallel legs (base/mongo/mongo-only × amd64/arm64), with arm64 built natively on GitHub's free `ubuntu-24.04-arm` runners. `cross`/QEMU removed from ci.yml. Artifact names are unchanged, so `docker` and `reusable-kind-e2e` consume them as before.
- `release.yml` still uses `build_release_binaries.sh` + cross — left untouched deliberately; converting it the same way is an easy follow-up.

**Faster test execution**
- `checks` runs the suite via **cargo-nextest**. The cucumber `bdd` target is `harness = false` and doesn't speak the libtest protocol, so it's excluded from nextest and run via `cargo test --test bdd` (same compiled artifacts). Doctests run via `cargo test --doc` since nextest skips them. Coverage is identical to the old `cargo test --all-features` invocation.

**Tiered local gate for agent loops**
- `/ci` command and CLAUDE.md now document a quick inner loop (`cargo check --all-targets` + targeted nextest) for iteration, with the full gate required once before commit/PR.

### Notes

- Required status checks (`Checks (fmt, clippy, test)`, `Security (audit, deny, vet)`) keep their job names — ruleset 11393718 is unaffected.
- First run on this PR pays cold caches for the renamed cache keys (`db-tests`, `build-debug-amd64`); subsequent runs are warm.
- Follow-up (post-merge, optional): add `Quality Gate` as a required status check — with the flattened graph it converges at ~6 min, so full gating pre-merge no longer costs cycle time:
  `gh api -X PUT repos/ianlintner/rust-oauth2-server/rulesets/11393718 ...` (happy to do this once the PR is merged and a run confirms timings).
- Matrix generation logic was tested locally for all four event paths (PR / main push / tag push / develop push); workflow validated with actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)