### PR TITLE
fix(security): expire stale return_to before post-login replay

### DIFF
--- a/crates/oauth2-actix/src/handlers/login.rs
+++ b/crates/oauth2-actix/src/handlers/login.rs
@@ -17,6 +17,10 @@ use oauth2_observability::Metrics;
 use oauth2_ports::DynStorage;
 use oauth2_ratelimit::RateLimiter;
 
+/// How long a pending `return_to` saved by the authorize endpoint stays valid.
+/// After this window a login no longer replays the stored authorize URL.
+const RETURN_TO_MAX_AGE_SECS: i64 = 600;
+
 fn extract_client_ip(req: &HttpRequest, trust_proxy_headers: bool) -> String {
     // Only trust proxy-provided client IP headers when explicitly configured.
     // Otherwise, an attacker can spoof X-Forwarded-For and evade per-IP
@@ -255,10 +259,19 @@ pub async fn login_submit(
     // Redirect to the OAuth authorize URL that was saved before the login redirect,
     // or fall back to the success page.
     let return_to: Option<String> = session.get("return_to")?;
+    let return_to_ts: Option<i64> = session.get("return_to_ts").unwrap_or(None);
     session.remove("return_to");
+    session.remove("return_to_ts");
+
+    // Only honor return_to when it was stamped by a recent authorize redirect.
+    // A stale (or unstamped) value from an abandoned authorization request must
+    // not be replayed on a later unrelated login (login-CSRF hardening).
+    let fresh = return_to_ts
+        .is_some_and(|ts| chrono::Utc::now().timestamp() - ts <= RETURN_TO_MAX_AGE_SECS);
 
     // Only allow safe relative redirects; anything else falls back to /profile.
     let redirect_url = return_to
+        .filter(|_| fresh)
         .filter(|u| is_safe_redirect(u))
         .unwrap_or_else(|| "/profile".to_string());
 

--- a/crates/oauth2-actix/src/handlers/oauth.rs
+++ b/crates/oauth2-actix/src/handlers/oauth.rs
@@ -954,6 +954,12 @@ pub async fn authorize(
             session
                 .insert("return_to", &return_to)
                 .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))?;
+            // Timestamp the pending redirect so login_submit can reject a stale
+            // return_to left over from an abandoned (possibly attacker-initiated)
+            // authorization request instead of silently replaying it.
+            session
+                .insert("return_to_ts", chrono::Utc::now().timestamp())
+                .map_err(|e| OAuth2Error::new("server_error", Some(&e.to_string())))?;
 
             // OIDC Core §3.1.2.1: forward login_hint to the login form
             // so the username field can be pre-filled for the user.

--- a/tests/security_http.rs
+++ b/tests/security_http.rs
@@ -3247,11 +3247,15 @@ async fn login_redirect_after_seeding(seed_query: &str) -> String {
         .expect("create storage");
     storage.init().await.expect("init storage");
 
+    // Random per-run password: the tests only need hash(password) to verify,
+    // and this avoids a hard-coded credential in the source.
+    let password = uuid::Uuid::new_v4().to_string();
+
     let now = chrono::Utc::now();
     let user = User {
         id: "user_login".to_string(),
         username: "user_login".to_string(),
-        password_hash: oauth2_actix::handlers::login::hash_password("correct horse battery")
+        password_hash: oauth2_actix::handlers::login::hash_password(&password)
             .expect("hash password"),
         email: "user_login@example.test".to_string(),
         enabled: true,
@@ -3287,10 +3291,7 @@ async fn login_redirect_after_seeding(seed_query: &str) -> String {
     let login_req = test::TestRequest::post()
         .uri("/auth/login")
         .insert_header(("Cookie", session_cookie.as_str()))
-        .set_form([
-            ("username", "user_login"),
-            ("password", "correct horse battery"),
-        ])
+        .set_form([("username", "user_login"), ("password", password.as_str())])
         .to_request();
     let login_resp = test::call_service(&app, login_req).await;
     assert_eq!(login_resp.status(), 303, "login must redirect with 303");

--- a/tests/security_http.rs
+++ b/tests/security_http.rs
@@ -3204,3 +3204,130 @@ async fn refresh_token_replay_revokes_entire_token_family() {
         "RT2 must return error=invalid_grant after family was revoked"
     );
 }
+
+// ── return_to staleness hardening (login-CSRF) ─────────────────────────────
+//
+// The authorize endpoint stores `return_to` (+ `return_to_ts`) in the session
+// before redirecting to /auth/login. A stale return_to from an abandoned
+// (possibly attacker-initiated) authorization request must NOT be replayed on
+// a later unrelated login — only a fresh, timestamped return_to is honored.
+
+#[derive(serde::Deserialize)]
+struct SeedReturnToQuery {
+    /// Seconds added to "now" for the stored return_to_ts (negative = in the past).
+    offset: i64,
+    /// Whether to store a return_to_ts at all.
+    with_ts: bool,
+}
+
+/// Test-only route seeding a pending return_to as the authorize handler would.
+async fn seed_return_to(session: Session, q: web::Query<SeedReturnToQuery>) -> HttpResponse {
+    session
+        .insert(
+            "return_to",
+            "/oauth/authorize?response_type=code&client_id=client_pending",
+        )
+        .unwrap();
+    if q.with_ts {
+        session
+            .insert("return_to_ts", chrono::Utc::now().timestamp() + q.offset)
+            .unwrap();
+    }
+    HttpResponse::Ok().finish()
+}
+
+/// Drive the real login_submit handler: seed the session via /test/seed with the
+/// given query, then POST valid credentials and return the redirect Location.
+async fn login_redirect_after_seeding(seed_query: &str) -> String {
+    use actix_session::{storage::CookieSessionStore, SessionMiddleware};
+    use actix_web::cookie::Key;
+
+    let storage = oauth2_storage_factory::create_storage("sqlite::memory:")
+        .await
+        .expect("create storage");
+    storage.init().await.expect("init storage");
+
+    let now = chrono::Utc::now();
+    let user = User {
+        id: "user_login".to_string(),
+        username: "user_login".to_string(),
+        password_hash: oauth2_actix::handlers::login::hash_password("correct horse battery")
+            .expect("hash password"),
+        email: "user_login@example.test".to_string(),
+        enabled: true,
+        role: "user".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+    storage.save_user(&user).await.expect("save user");
+
+    let metrics = Metrics::new().expect("metrics");
+    let app = test::init_service(
+        App::new()
+            .wrap(SessionMiddleware::new(
+                CookieSessionStore::default(),
+                Key::generate(),
+            ))
+            .route("/test/seed", web::get().to(seed_return_to))
+            .app_data(web::Data::new(storage))
+            .app_data(web::Data::new(metrics))
+            .route(
+                "/auth/login",
+                web::post().to(oauth2_actix::handlers::login::login_submit),
+            ),
+    )
+    .await;
+
+    let seed_req = test::TestRequest::get()
+        .uri(&format!("/test/seed?{seed_query}"))
+        .to_request();
+    let seed_resp = test::call_service(&app, seed_req).await;
+    let session_cookie = extract_session_cookie(&seed_resp);
+
+    let login_req = test::TestRequest::post()
+        .uri("/auth/login")
+        .insert_header(("Cookie", session_cookie.as_str()))
+        .set_form([
+            ("username", "user_login"),
+            ("password", "correct horse battery"),
+        ])
+        .to_request();
+    let login_resp = test::call_service(&app, login_req).await;
+    assert_eq!(login_resp.status(), 303, "login must redirect with 303");
+    login_resp
+        .headers()
+        .get(actix_web::http::header::LOCATION)
+        .and_then(|h| h.to_str().ok())
+        .expect("Location header")
+        .to_string()
+}
+
+#[actix_web::test]
+async fn fresh_return_to_is_replayed_after_login() {
+    let location = login_redirect_after_seeding("offset=0&with_ts=true").await;
+    assert_eq!(
+        location, "/oauth/authorize?response_type=code&client_id=client_pending",
+        "a fresh return_to must be replayed after login"
+    );
+}
+
+#[actix_web::test]
+async fn stale_return_to_is_not_replayed_after_login() {
+    // Stamped one hour in the past — well beyond the freshness window.
+    let location = login_redirect_after_seeding("offset=-3600&with_ts=true").await;
+    assert_eq!(
+        location, "/profile",
+        "a stale return_to from an abandoned authorization request must not be replayed"
+    );
+}
+
+#[actix_web::test]
+async fn unstamped_return_to_is_not_replayed_after_login() {
+    // return_to present without return_to_ts (e.g. left over from a pre-upgrade
+    // session): must be treated as stale, not silently replayed.
+    let location = login_redirect_after_seeding("offset=0&with_ts=false").await;
+    assert_eq!(
+        location, "/profile",
+        "an unstamped return_to must not be replayed"
+    );
+}


### PR DESCRIPTION
## Summary

The authorize endpoint stores the pending authorize URL as `return_to` in the session before redirecting to `/auth/login`, and `login_submit` replayed it unconditionally. A stale `return_to` left over from an abandoned (possibly attacker-initiated) authorization request was silently replayed on a later unrelated login — a narrow login-CSRF-style risk.

## Changes

- `oauth::authorize` now stamps `return_to_ts` alongside `return_to` when parking the pending redirect
- `login_submit` consumes both keys one-time and only honors `return_to` when the stamp is present and within `RETURN_TO_MAX_AGE_SECS` (10 minutes); otherwise it falls back to `/profile`
- Unstamped values (e.g. sessions created before this change) are treated as stale — fail closed; worst case is one extra click for a user upgrading mid-flow
- The existing `is_safe_redirect` gate is unchanged and still applies after the freshness check

TTL + one-time consumption was chosen over a nonce because the login POST has no channel to carry a nonce back without touching the login page template, and the session cookie already scopes `return_to` to the same browser.

## Tests

Three new regression tests in `tests/security_http.rs` drive the real `login_submit` handler with a genuine Argon2-hashed user:
- fresh `return_to` is replayed after login
- a one-hour-old `return_to` falls back to `/profile`
- an unstamped `return_to` falls back to `/profile`

Verified locally: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `security_http` 44/44, `rfc_compliance` 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)